### PR TITLE
トップページの追加とビルド時メタデータ埋め込み対応

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,62 +2,17 @@
 
 ## mikuproject
 
-- `MS Project XML` を意味の基軸として扱う
-- `ProjectModel` を内部の中立表現として扱う
-- `.xlsx` は確認・可視化・帳票化のための周辺表現として扱う
-- `.xlsx` 編集結果を `ProjectModel` へ戻し、必要に応じて `MS Project XML` へ再出力できる構成を目指す
-- `MS Project XML` を中心に据えたまま、`.xlsx` 入出力を追加する
-- `.xlsx` の正本化は避け、内部モデル `ProjectModel` を中心に扱う
-- まずは `.xlsx export` を優先し、`ProjectModel -> .xlsx` を成立させる
-- その後に `.xlsx import` を検討し、`.xlsx -> ProjectModel` を設計する
-- `.xlsx` は、構造忠実な汎用 workbook と、表示専用の WBS workbook を分けて扱う
-- 初期検討時のみ `local-data/WBS_Template_analysis.md` を参照し、その後は依存しない
-- `mikuproject-spec.md` に `.xlsx` 対応方針を追記する
-- `.xlsx` 入出力で保持する最小フィールド集合を定義する
-- `mikuproject-spec.md` では、現在の editable 列 coverage をシート別の一覧で追えるように保つ
-- round-trip の観点で、`xml -> model -> xlsx` と `xlsx -> model -> xml` の扱いを切り分ける
-- `.xlsx import` では編集可能な列を限定し、部分更新として `ProjectModel` へ反映する
-- まずは `Tasks` シートを起点に、限定列 import を成立させる
-- `Start / Finish / PercentComplete / PercentWorkComplete` など、戻しやすい項目から優先対応する
-- `Tasks` で import 実績を作った後に `Resources / Assignments` へ対象を広げる
-- `Resources` では `Name / Group / MaxUnits` などの戻しやすい項目から優先対応する
-- `Assignments` では `Units / Work / PercentWorkComplete` などの戻しやすい項目から優先対応する
-- `Project` シートでは `Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart` を限定 import 対象として扱う
-- `Calendars` シートでは、まず `Name / IsBaseCalendar / BaseCalendarUID` のみを限定 import 対象として扱う
-- 複雑な `Calendar / Baseline / TimephasedData / ExtendedAttributes` は後段で扱う
-- `.xlsx` 対応用のテストデータとテスト戦略を追加する
-- `ProjectModel -> workbook -> .xlsx -> workbook -> ProjectModel` の統合経路を継続的に確認する
-- `project-xlsx.ts` で `ProjectModel -> XlsxWorkbookModel` の変換方針を詰める
-- `project-xlsx.ts` で結合セルを使う箇所を設計する
-- `Project` シートに結合付きの見出し行やセクション見出しを追加する
-- `Tasks / Resources / Assignments / Calendars` シートのレイアウト方針を整理する
-- 上記シート粒度が `MS Project XML` / `ProjectModel` の構造に由来することを明記する
-- Excel 側の独自都合ではなく、まずは `MS Project XML` の構造に忠実な workbook 構成を優先する
-- WBS 帳票的な見せ方は、別ビュー・別 workbook として export を継続改善する
-- `WBS XLSX Export` は表示専用 workbook として、上部サマリ、凡例、Week/BaseDate ガイド、日付帯の視認性改善を継続する
-- `WBS XLSX Export` では、`ProjectModel` 由来の既定祝日と、UI から入力した追加祝日を分けて扱えるように保つ
-- WBS sample 生成では、`Calendar.Exceptions` のうち非稼働日例外を祝日候補として日付帯へ反映する
-- `build-project-xlsx-sample.mjs` を静的 workbook 直書きから `project-xlsx.ts` 利用へ切り替える
-- `MS Project XML -> ProjectModel -> XlsxWorkbookModel -> .xlsx` のサンプル生成経路へ寄せる
-- UI 上で `.xlsx import` の反映件数と差分要約を分かるようにする
-- 次は `.xlsx import` の差分要約を、行単位またはシート単位でさらに見やすく整理する
-- 次は `Resources / Assignments` の import 差分も UI 上で追いやすくする
-- `.xlsx import` の差分要約は、同一行の複数変更を1ブロックで見せる
-- 次はシート別の件数表示や、更新対象ごとの折りたたみなし一覧を検討する
-- `.xlsx import` の差分要約には、`Tasks / Resources / Assignments` の件数も先頭表示する
-- 次は変更が 0 件だったシートをどこまで表示するかを整理する
-- 変更があったシートを前面に出し、変更なしのシートは補助表示へ下げる
-- 次は `Resources / Assignments` にも変更があるケースの UI 表示確認を追加する
-- 画面上の `.xlsx import` 説明文は、実際の編集可能列と差分要約の見え方に合わせて保守する
-- 次は `Tasks.Start / Finish` のような日付変更が UI 差分要約で分かることを固定する
-- `.xlsx import` 後に、更新済み XML を `XML Export` で保存できる導線を画面上で分かるようにする
-- `.xlsx import` で変更が 0 件だった場合は、XML が未変更であることを明示する
-- 対象外列や未対応シートを編集しても反映しないことを、画面文言とテストで明確にする
-- `Calendars` の `WeekDays / Exceptions / WorkWeeks` は、当面は反映対象外として扱う
-- 現在の editable 列 coverage を保ちながら、次段でどのシート・列を import 対象に広げるかを整理する
-- 画面上の `.xlsx import` 説明は、`反映対象` と `現在は反映しないもの` を分けて読めるように保つ
-- 次は `Calendars` など未対応シートを本当に import 対象へ広げるか、引き続き無視対象に留めるかを整理する
-- `.xlsx import` 後に validation メッセージが必要なケースも UI テストで固定する
-- `Calendars.BaseCalendarUID` のような参照系 warning も、`.xlsx import` の差分要約と validation を並べて確認できるように保つ
-- `.xlsx import` による `Start > Finish` のような日付整合性エラーも UI テストで固定する
-- validation が残る状態でも `XML Export` でその時点の XML を保存できることをテストで固定する
+- `Mermaid` ランタイムをこのリポジトリ内でどう扱うか決める
+- `Mermaid` の SVG プレビューを、独立リポジトリ単体で再現できるようにする
+- `build:app` 生成物としての `src/js/` をどこまで Git 管理するか方針を固める
+- `src/ts/ -> src/js/ -> mikuproject.html` の生成責務を README と実装で一貫させる
+- `build:xlsx-sample` を実行する前提条件と出力物の位置づけを README に追記する
+- `local-data/` 配下のファイルを、参照用・検証用・生成物で整理する
+- `local-data/` に置くべきでない生成物や一時ファイルがないか見直す
+- `mikuproject-spec.md` と `README.md` と `TODO.md` の役割分担を整理する
+- `mikuproject-spec.md` に残っている実装済み前提との差分を定期的に解消する
+- `.xlsx import` の次段として、どのシート・列を今後 import 対象に広げるか整理する
+- `Calendars` の `WeekDays / Exceptions / WorkWeeks` を今後も非対応で維持するか再判断する
+- `Calendar / Baseline / TimephasedData / ExtendedAttributes` をどの順で扱うか優先順位を決める
+- WBS workbook の表示改善を継続する
+- WBS workbook の見た目改善と、構造忠実 workbook との責務分離を保つ

--- a/index-src.html
+++ b/index-src.html
@@ -1,0 +1,403 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
+  <title>mikuproject</title>
+  <style>
+    :root {
+      --bg: #f4f8fb;
+      --bg-accent: #eaf1f6;
+      --surface: #fbfdff;
+      --surface-2: #eef4f8;
+      --text: #16202a;
+      --heading: #17364d;
+      --muted: #4d5d6a;
+      --primary: #2f6ea5;
+      --primary-strong: #22577f;
+      --on-primary: #ffffff;
+      --secondary-bg: #e3edf5;
+      --secondary-text: #28465f;
+      --outline: #d6e1ea;
+      --outline-2: #c1d1dd;
+      --code-bg: #edf3f8;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "BIZ UDPGothic", "Noto Sans JP", "Hiragino Sans", "Segoe UI", sans-serif;
+      background:
+        radial-gradient(circle at top left, rgba(47, 110, 165, 0.16), transparent 28%),
+        linear-gradient(180deg, var(--bg-accent) 0%, var(--bg) 100%);
+      color: var(--text);
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 24px;
+    }
+    .card {
+      width: min(860px, 100%);
+      background: var(--surface);
+      border: 1px solid var(--outline);
+      border-radius: 24px;
+      padding: 30px;
+      box-shadow:
+        0 20px 44px rgba(20, 46, 68, 0.10),
+        inset 0 1px 0 rgba(255, 255, 255, 0.82);
+    }
+    h1 {
+      margin: 0 0 12px;
+      font-size: clamp(2rem, 5vw, 2.9rem);
+      line-height: 1.1;
+      letter-spacing: -0.02em;
+      color: var(--heading);
+    }
+    h2 {
+      margin: 0 0 10px;
+      font-size: 1.18rem;
+      line-height: 1.25;
+      color: var(--heading);
+    }
+    p {
+      margin: 0 0 14px;
+      color: var(--muted);
+      line-height: 1.75;
+    }
+    ul,
+    ol {
+      margin: 0 0 16px;
+      padding-left: 1.25rem;
+      color: var(--muted);
+      line-height: 1.68;
+    }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      background: var(--code-bg);
+      color: var(--secondary-text);
+      padding: 0.12rem 0.38rem;
+      border-radius: 8px;
+      font-size: 0.92em;
+    }
+    .eyebrow {
+      display: inline-block;
+      margin-bottom: 12px;
+      padding: 0.34rem 0.72rem;
+      border-radius: 999px;
+      background: rgba(47, 110, 165, 0.12);
+      color: var(--heading);
+      font-size: 0.82rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .lead {
+      font-size: 1.02rem;
+      color: #425767;
+    }
+    .md-app-meta {
+      margin: 0 0 20px;
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+    .link-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 10px;
+    }
+    .link-btn,
+    .link-btn-secondary {
+      display: inline-block;
+      text-decoration: none;
+      padding: 0.82rem 1.35rem;
+      border-radius: 999px;
+      font-weight: 700;
+      transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease, border-color 120ms ease;
+    }
+    .link-btn {
+      background: var(--primary);
+      color: var(--on-primary);
+      box-shadow: 0 10px 24px rgba(47, 110, 165, 0.24);
+    }
+    .link-btn-secondary {
+      background: var(--secondary-bg);
+      color: var(--secondary-text);
+      border: 1px solid var(--outline-2);
+    }
+    .link-btn:hover,
+    .link-btn-secondary:hover {
+      transform: translateY(-1px);
+    }
+    .link-btn:hover {
+      background: var(--primary-strong);
+      box-shadow: 0 12px 26px rgba(34, 87, 127, 0.26);
+    }
+    .link-btn-secondary:hover {
+      background: #d9e7f1;
+      border-color: #b2c6d5;
+    }
+    .divider {
+      border: 0;
+      border-top: 1px solid var(--outline);
+      margin: 24px 0;
+    }
+    .panel-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 16px;
+    }
+    @media (min-width: 760px) {
+      .panel-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+    .panel {
+      padding: 16px;
+      background: var(--surface-2);
+      border: 1px solid var(--outline);
+      border-radius: 18px;
+    }
+    .panel p:last-child,
+    .panel ul:last-child,
+    .panel ol:last-child {
+      margin-bottom: 0;
+    }
+    .sub {
+      margin-top: 14px;
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+    .gallery {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 16px;
+      margin-top: 18px;
+    }
+    @media (min-width: 720px) {
+      .gallery {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+    .shot-card {
+      margin: 0;
+      padding: 14px;
+      background: var(--surface-2);
+      border: 1px solid var(--outline);
+      border-radius: 20px;
+      box-shadow: 0 10px 28px rgba(20, 46, 68, 0.08);
+    }
+    .shot-frame {
+      display: grid;
+      place-items: center;
+      width: 100%;
+      min-height: 220px;
+      border-radius: 12px;
+      border: 1px dashed var(--outline-2);
+      background:
+        linear-gradient(135deg, rgba(47, 110, 165, 0.08), rgba(34, 87, 127, 0.03)),
+        repeating-linear-gradient(
+          -45deg,
+          rgba(255, 255, 255, 0.5),
+          rgba(255, 255, 255, 0.5) 10px,
+          rgba(47, 110, 165, 0.03) 10px,
+          rgba(47, 110, 165, 0.03) 20px
+        );
+      color: var(--secondary-text);
+      text-align: center;
+      padding: 20px;
+      line-height: 1.6;
+      font-weight: 700;
+    }
+    .shot-frame code {
+      display: inline-block;
+      margin-top: 6px;
+    }
+    .shot-card figcaption {
+      margin-top: 10px;
+      font-size: 0.92rem;
+      color: var(--muted);
+      line-height: 1.55;
+    }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <div class="eyebrow">Local Browser Tool</div>
+    <h1>mikuproject</h1>
+    <div class="md-app-meta">Updated: {{BUILD_DATE}}</div>
+
+    <section aria-label="What is this">
+      <h2>What is this?</h2>
+      <p class="lead">
+        <code>mikuproject</code> は、<code>MS Project XML</code> をローカルで読み込み、内部の <code>ProjectModel</code> に変換し、再度 <code>MS Project XML</code> や補助表現へ出力する Single-file Web App です。
+      </p>
+      <ul>
+        <li>ブラウザ内でローカルに動作し、サーバ通信を前提にしません。</li>
+        <li><code>MS Project XML</code> を意味の基軸として扱います。</li>
+        <li><code>.xlsx</code> は確認・可視化・限定編集のための周辺表現として扱います。</li>
+      </ul>
+    </section>
+
+    <hr class="divider" />
+
+    <section aria-label="Features">
+      <h2>Features</h2>
+      <div class="panel-grid">
+        <div class="panel">
+          <ul>
+            <li><code>MS Project XML</code> を読み込み、内部モデルへ変換します。</li>
+            <li>内部モデルを JSON とサマリとして確認できます。</li>
+            <li><code>MS Project XML</code> を再生成できます。</li>
+            <li>Mermaid gantt テキストを生成できます。</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <ul>
+            <li><code>Project / Tasks / Resources / Assignments / Calendars</code> workbook を <code>XLSX Export / Import</code> できます。</li>
+            <li>表示専用の <code>WBS XLSX Export</code> を持ちます。</li>
+            <li><code>CSV + ParentID</code> の生成と解析を行えます。</li>
+            <li><code>XLSX Import</code> 後の差分要約と validation を確認できます。</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <hr class="divider" />
+
+    <section aria-label="Use cases">
+      <h2>Use Cases</h2>
+      <ul>
+        <li><code>MS Project XML</code> の round-trip をローカルで確認したい。</li>
+        <li>XML の中身を内部モデルとして確認したい。</li>
+        <li><code>.xlsx</code> で限定的に編集し、XML へ戻したい。</li>
+        <li>WBS 形式の workbook を補助資料として出力したい。</li>
+        <li>依存関係やタスク構造を Mermaid や CSV に変換して確認したい。</li>
+      </ul>
+    </section>
+
+    <hr class="divider" />
+
+    <section aria-label="How to use">
+      <h2>How to use</h2>
+      <ol>
+        <li>Web ブラウザで <code>mikuproject.html</code> を開きます。</li>
+        <li><code>MS Project XML</code> を読み込むか、サンプル XML を使います。</li>
+        <li>内部モデル、プレビュー、Mermaid、CSV、XLSX を必要に応じて確認します。</li>
+        <li><code>XLSX Import</code> を使う場合は、差分要約と validation を確認した上で XML を再出力します。</li>
+      </ol>
+      <div class="link-row">
+        <a class="link-btn" href="./mikuproject.html?v=202603280000">Open mikuproject</a>
+        <a class="link-btn-secondary" href="./README.md">README</a>
+        <a class="link-btn-secondary" href="./mikuproject-spec.md">Spec</a>
+      </div>
+    </section>
+
+    <hr class="divider" />
+
+    <section aria-label="Project notes">
+      <h2>Project Notes</h2>
+      <div class="panel-grid">
+        <div class="panel">
+          <p>
+            正本は <code>MS Project XML</code> です。<code>.xlsx</code> は確認と限定編集のための補助表現であり、自由編集の正本としては扱いません。
+          </p>
+        </div>
+        <div class="panel">
+          <p>
+            現時点では、<code>Calendars</code> の <code>WeekDays / Exceptions / WorkWeeks</code> など一部の項目は <code>XLSX Import</code> の反映対象外です。
+          </p>
+        </div>
+      </div>
+      <p class="sub">
+        このページは紹介用の入口です。実際の操作 UI は <code>mikuproject.html</code> 側にあります。
+      </p>
+    </section>
+
+    <hr class="divider" />
+
+    <section aria-label="Screenshots">
+      <h2>Screenshots</h2>
+      <p>
+        スクリーンショットは後から差し込めるように枠だけ先に用意しています。画像を追加する場合は、たとえば <code>docs/screenshots/</code> 配下へ置く構成が扱いやすいです。
+      </p>
+      <div class="gallery">
+        <figure class="shot-card">
+          <div class="shot-frame">
+            Main Screen
+            <br />
+            <code>docs/screenshots/mikuproject-main.png</code>
+          </div>
+          <figcaption>
+            XML 読込、内部モデル確認、Mermaid、CSV、XLSX の各操作を行うメイン画面用の枠です。
+          </figcaption>
+        </figure>
+        <figure class="shot-card">
+          <div class="shot-frame">
+            XLSX Import Summary
+            <br />
+            <code>docs/screenshots/mikuproject-xlsx-import.png</code>
+          </div>
+          <figcaption>
+            差分要約と validation を確認できる `XLSX Import` 後の画面用の枠です。
+          </figcaption>
+        </figure>
+        <figure class="shot-card">
+          <div class="shot-frame">
+            WBS XLSX Export
+            <br />
+            <code>docs/screenshots/mikuproject-wbs.png</code>
+          </div>
+          <figcaption>
+            WBS workbook 出力の用途や見た目を説明するためのスクリーンショット枠です。
+          </figcaption>
+        </figure>
+        <figure class="shot-card">
+          <div class="shot-frame">
+            Mermaid Preview
+            <br />
+            <code>docs/screenshots/mikuproject-mermaid.png</code>
+          </div>
+          <figcaption>
+            Mermaid gantt テキスト生成と SVG プレビューの説明に使う枠です。
+          </figcaption>
+        </figure>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    (() => {
+      const selector = 'a[href^="./mikuproject.html"]';
+      const buildVersionStamp = () => {
+        const d = new Date();
+        return (
+          d.getFullYear().toString() +
+          String(d.getMonth() + 1).padStart(2, "0") +
+          String(d.getDate()).padStart(2, "0") +
+          String(d.getHours()).padStart(2, "0") +
+          String(d.getMinutes()).padStart(2, "0")
+        );
+      };
+      const stampAndGo = (anchor) => {
+        const u = new URL(anchor.getAttribute("href"), location.href);
+        u.searchParams.set("v", buildVersionStamp());
+        anchor.setAttribute("href", u.pathname + u.search);
+      };
+      document.addEventListener("click", (ev) => {
+        const a = ev.target.closest(selector);
+        if (!a) return;
+        stampAndGo(a);
+      }, true);
+      document.addEventListener("auxclick", (ev) => {
+        if (ev.button !== 1) return;
+        const a = ev.target.closest(selector);
+        if (!a) return;
+        stampAndGo(a);
+      }, true);
+    })();
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,403 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
+  <title>mikuproject</title>
+  <style>
+    :root {
+      --bg: #f4f8fb;
+      --bg-accent: #eaf1f6;
+      --surface: #fbfdff;
+      --surface-2: #eef4f8;
+      --text: #16202a;
+      --heading: #17364d;
+      --muted: #4d5d6a;
+      --primary: #2f6ea5;
+      --primary-strong: #22577f;
+      --on-primary: #ffffff;
+      --secondary-bg: #e3edf5;
+      --secondary-text: #28465f;
+      --outline: #d6e1ea;
+      --outline-2: #c1d1dd;
+      --code-bg: #edf3f8;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "BIZ UDPGothic", "Noto Sans JP", "Hiragino Sans", "Segoe UI", sans-serif;
+      background:
+        radial-gradient(circle at top left, rgba(47, 110, 165, 0.16), transparent 28%),
+        linear-gradient(180deg, var(--bg-accent) 0%, var(--bg) 100%);
+      color: var(--text);
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      padding: 24px;
+    }
+    .card {
+      width: min(860px, 100%);
+      background: var(--surface);
+      border: 1px solid var(--outline);
+      border-radius: 24px;
+      padding: 30px;
+      box-shadow:
+        0 20px 44px rgba(20, 46, 68, 0.10),
+        inset 0 1px 0 rgba(255, 255, 255, 0.82);
+    }
+    h1 {
+      margin: 0 0 12px;
+      font-size: clamp(2rem, 5vw, 2.9rem);
+      line-height: 1.1;
+      letter-spacing: -0.02em;
+      color: var(--heading);
+    }
+    h2 {
+      margin: 0 0 10px;
+      font-size: 1.18rem;
+      line-height: 1.25;
+      color: var(--heading);
+    }
+    p {
+      margin: 0 0 14px;
+      color: var(--muted);
+      line-height: 1.75;
+    }
+    ul,
+    ol {
+      margin: 0 0 16px;
+      padding-left: 1.25rem;
+      color: var(--muted);
+      line-height: 1.68;
+    }
+    code {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      background: var(--code-bg);
+      color: var(--secondary-text);
+      padding: 0.12rem 0.38rem;
+      border-radius: 8px;
+      font-size: 0.92em;
+    }
+    .eyebrow {
+      display: inline-block;
+      margin-bottom: 12px;
+      padding: 0.34rem 0.72rem;
+      border-radius: 999px;
+      background: rgba(47, 110, 165, 0.12);
+      color: var(--heading);
+      font-size: 0.82rem;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .lead {
+      font-size: 1.02rem;
+      color: #425767;
+    }
+    .md-app-meta {
+      margin: 0 0 20px;
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+    .link-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 10px;
+    }
+    .link-btn,
+    .link-btn-secondary {
+      display: inline-block;
+      text-decoration: none;
+      padding: 0.82rem 1.35rem;
+      border-radius: 999px;
+      font-weight: 700;
+      transition: transform 120ms ease, box-shadow 120ms ease, background 120ms ease, border-color 120ms ease;
+    }
+    .link-btn {
+      background: var(--primary);
+      color: var(--on-primary);
+      box-shadow: 0 10px 24px rgba(47, 110, 165, 0.24);
+    }
+    .link-btn-secondary {
+      background: var(--secondary-bg);
+      color: var(--secondary-text);
+      border: 1px solid var(--outline-2);
+    }
+    .link-btn:hover,
+    .link-btn-secondary:hover {
+      transform: translateY(-1px);
+    }
+    .link-btn:hover {
+      background: var(--primary-strong);
+      box-shadow: 0 12px 26px rgba(34, 87, 127, 0.26);
+    }
+    .link-btn-secondary:hover {
+      background: #d9e7f1;
+      border-color: #b2c6d5;
+    }
+    .divider {
+      border: 0;
+      border-top: 1px solid var(--outline);
+      margin: 24px 0;
+    }
+    .panel-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 16px;
+    }
+    @media (min-width: 760px) {
+      .panel-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+    .panel {
+      padding: 16px;
+      background: var(--surface-2);
+      border: 1px solid var(--outline);
+      border-radius: 18px;
+    }
+    .panel p:last-child,
+    .panel ul:last-child,
+    .panel ol:last-child {
+      margin-bottom: 0;
+    }
+    .sub {
+      margin-top: 14px;
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+    .gallery {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 16px;
+      margin-top: 18px;
+    }
+    @media (min-width: 720px) {
+      .gallery {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+    }
+    .shot-card {
+      margin: 0;
+      padding: 14px;
+      background: var(--surface-2);
+      border: 1px solid var(--outline);
+      border-radius: 20px;
+      box-shadow: 0 10px 28px rgba(20, 46, 68, 0.08);
+    }
+    .shot-frame {
+      display: grid;
+      place-items: center;
+      width: 100%;
+      min-height: 220px;
+      border-radius: 12px;
+      border: 1px dashed var(--outline-2);
+      background:
+        linear-gradient(135deg, rgba(47, 110, 165, 0.08), rgba(34, 87, 127, 0.03)),
+        repeating-linear-gradient(
+          -45deg,
+          rgba(255, 255, 255, 0.5),
+          rgba(255, 255, 255, 0.5) 10px,
+          rgba(47, 110, 165, 0.03) 10px,
+          rgba(47, 110, 165, 0.03) 20px
+        );
+      color: var(--secondary-text);
+      text-align: center;
+      padding: 20px;
+      line-height: 1.6;
+      font-weight: 700;
+    }
+    .shot-frame code {
+      display: inline-block;
+      margin-top: 6px;
+    }
+    .shot-card figcaption {
+      margin-top: 10px;
+      font-size: 0.92rem;
+      color: var(--muted);
+      line-height: 1.55;
+    }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <div class="eyebrow">Local Browser Tool</div>
+    <h1>mikuproject</h1>
+    <div class="md-app-meta">Updated: 2026-03-28</div>
+
+    <section aria-label="What is this">
+      <h2>What is this?</h2>
+      <p class="lead">
+        <code>mikuproject</code> は、<code>MS Project XML</code> をローカルで読み込み、内部の <code>ProjectModel</code> に変換し、再度 <code>MS Project XML</code> や補助表現へ出力する Single-file Web App です。
+      </p>
+      <ul>
+        <li>ブラウザ内でローカルに動作し、サーバ通信を前提にしません。</li>
+        <li><code>MS Project XML</code> を意味の基軸として扱います。</li>
+        <li><code>.xlsx</code> は確認・可視化・限定編集のための周辺表現として扱います。</li>
+      </ul>
+    </section>
+
+    <hr class="divider" />
+
+    <section aria-label="Features">
+      <h2>Features</h2>
+      <div class="panel-grid">
+        <div class="panel">
+          <ul>
+            <li><code>MS Project XML</code> を読み込み、内部モデルへ変換します。</li>
+            <li>内部モデルを JSON とサマリとして確認できます。</li>
+            <li><code>MS Project XML</code> を再生成できます。</li>
+            <li>Mermaid gantt テキストを生成できます。</li>
+          </ul>
+        </div>
+        <div class="panel">
+          <ul>
+            <li><code>Project / Tasks / Resources / Assignments / Calendars</code> workbook を <code>XLSX Export / Import</code> できます。</li>
+            <li>表示専用の <code>WBS XLSX Export</code> を持ちます。</li>
+            <li><code>CSV + ParentID</code> の生成と解析を行えます。</li>
+            <li><code>XLSX Import</code> 後の差分要約と validation を確認できます。</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <hr class="divider" />
+
+    <section aria-label="Use cases">
+      <h2>Use Cases</h2>
+      <ul>
+        <li><code>MS Project XML</code> の round-trip をローカルで確認したい。</li>
+        <li>XML の中身を内部モデルとして確認したい。</li>
+        <li><code>.xlsx</code> で限定的に編集し、XML へ戻したい。</li>
+        <li>WBS 形式の workbook を補助資料として出力したい。</li>
+        <li>依存関係やタスク構造を Mermaid や CSV に変換して確認したい。</li>
+      </ul>
+    </section>
+
+    <hr class="divider" />
+
+    <section aria-label="How to use">
+      <h2>How to use</h2>
+      <ol>
+        <li>Web ブラウザで <code>mikuproject.html</code> を開きます。</li>
+        <li><code>MS Project XML</code> を読み込むか、サンプル XML を使います。</li>
+        <li>内部モデル、プレビュー、Mermaid、CSV、XLSX を必要に応じて確認します。</li>
+        <li><code>XLSX Import</code> を使う場合は、差分要約と validation を確認した上で XML を再出力します。</li>
+      </ol>
+      <div class="link-row">
+        <a class="link-btn" href="./mikuproject.html?v=202603280000">Open mikuproject</a>
+        <a class="link-btn-secondary" href="./README.md">README</a>
+        <a class="link-btn-secondary" href="./mikuproject-spec.md">Spec</a>
+      </div>
+    </section>
+
+    <hr class="divider" />
+
+    <section aria-label="Project notes">
+      <h2>Project Notes</h2>
+      <div class="panel-grid">
+        <div class="panel">
+          <p>
+            正本は <code>MS Project XML</code> です。<code>.xlsx</code> は確認と限定編集のための補助表現であり、自由編集の正本としては扱いません。
+          </p>
+        </div>
+        <div class="panel">
+          <p>
+            現時点では、<code>Calendars</code> の <code>WeekDays / Exceptions / WorkWeeks</code> など一部の項目は <code>XLSX Import</code> の反映対象外です。
+          </p>
+        </div>
+      </div>
+      <p class="sub">
+        このページは紹介用の入口です。実際の操作 UI は <code>mikuproject.html</code> 側にあります。
+      </p>
+    </section>
+
+    <hr class="divider" />
+
+    <section aria-label="Screenshots">
+      <h2>Screenshots</h2>
+      <p>
+        スクリーンショットは後から差し込めるように枠だけ先に用意しています。画像を追加する場合は、たとえば <code>docs/screenshots/</code> 配下へ置く構成が扱いやすいです。
+      </p>
+      <div class="gallery">
+        <figure class="shot-card">
+          <div class="shot-frame">
+            Main Screen
+            <br />
+            <code>docs/screenshots/mikuproject-main.png</code>
+          </div>
+          <figcaption>
+            XML 読込、内部モデル確認、Mermaid、CSV、XLSX の各操作を行うメイン画面用の枠です。
+          </figcaption>
+        </figure>
+        <figure class="shot-card">
+          <div class="shot-frame">
+            XLSX Import Summary
+            <br />
+            <code>docs/screenshots/mikuproject-xlsx-import.png</code>
+          </div>
+          <figcaption>
+            差分要約と validation を確認できる `XLSX Import` 後の画面用の枠です。
+          </figcaption>
+        </figure>
+        <figure class="shot-card">
+          <div class="shot-frame">
+            WBS XLSX Export
+            <br />
+            <code>docs/screenshots/mikuproject-wbs.png</code>
+          </div>
+          <figcaption>
+            WBS workbook 出力の用途や見た目を説明するためのスクリーンショット枠です。
+          </figcaption>
+        </figure>
+        <figure class="shot-card">
+          <div class="shot-frame">
+            Mermaid Preview
+            <br />
+            <code>docs/screenshots/mikuproject-mermaid.png</code>
+          </div>
+          <figcaption>
+            Mermaid gantt テキスト生成と SVG プレビューの説明に使う枠です。
+          </figcaption>
+        </figure>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    (() => {
+      const selector = 'a[href^="./mikuproject.html"]';
+      const buildVersionStamp = () => {
+        const d = new Date();
+        return (
+          d.getFullYear().toString() +
+          String(d.getMonth() + 1).padStart(2, "0") +
+          String(d.getDate()).padStart(2, "0") +
+          String(d.getHours()).padStart(2, "0") +
+          String(d.getMinutes()).padStart(2, "0")
+        );
+      };
+      const stampAndGo = (anchor) => {
+        const u = new URL(anchor.getAttribute("href"), location.href);
+        u.searchParams.set("v", buildVersionStamp());
+        anchor.setAttribute("href", u.pathname + u.search);
+      };
+      document.addEventListener("click", (ev) => {
+        const a = ev.target.closest(selector);
+        if (!a) return;
+        stampAndGo(a);
+      }, true);
+      document.addEventListener("auxclick", (ev) => {
+        if (ev.button !== 1) return;
+        const a = ev.target.closest(selector);
+        if (!a) return;
+        stampAndGo(a);
+      }, true);
+    })();
+  </script>
+</body>
+</html>

--- a/scripts/build-project.mjs
+++ b/scripts/build-project.mjs
@@ -6,6 +6,11 @@ const ROOT = process.cwd();
 
 const TARGETS = [
   {
+    id: "index",
+    srcHtml: "index-src.html",
+    outHtml: "index.html"
+  },
+  {
     id: "mikuproject",
     srcHtml: "mikuproject-src.html",
     outHtml: "mikuproject.html",
@@ -27,7 +32,7 @@ for (const target of TARGETS) {
   const srcPath = path.resolve(ROOT, target.srcHtml);
   const outPath = path.resolve(ROOT, target.outHtml);
   const source = fs.readFileSync(srcPath, "utf8");
-  const output = buildSingleHtmlFromSource(source, srcPath, ROOT);
+  const output = buildSingleHtmlFromSource(applyTemplateValues(source), srcPath, ROOT);
   fs.mkdirSync(path.dirname(outPath), { recursive: true });
   fs.writeFileSync(outPath, output, "utf8");
   console.log(`[build:project] generated ${target.outHtml}`);
@@ -83,4 +88,15 @@ function transpileTypeScript(target, tsModule) {
     fs.mkdirSync(path.dirname(jsPath), { recursive: true });
     fs.writeFileSync(jsPath, outputText, "utf8");
   }
+}
+
+function applyTemplateValues(source) {
+  return source.replaceAll("{{BUILD_DATE}}", formatBuildDate(new Date()));
+}
+
+function formatBuildDate(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }


### PR DESCRIPTION
## 概要

この変更では、`mikuproject` の紹介用トップページを追加し、ビルド時に `index.html` を生成する導線を追加しました。あわせて、ビルド時に `{{BUILD_DATE}}` を日付文字列へ置換する処理を追加し、`TODO.md` を現状の課題に合わせて整理しています。

## 変更内容

- `index-src.html` を新規追加
  - `mikuproject` の概要、機能、利用例、使い方、補足事項をまとめた紹介ページを追加
  - `mikuproject.html`、`README.md`、`mikuproject-spec.md` への導線を追加
  - スクリーンショット用のプレースホルダ枠を追加
- `index.html` を生成物として追加
- `scripts/build-project.mjs` を更新
  - `index-src.html -> index.html` をビルド対象に追加
  - `{{BUILD_DATE}}` を `YYYY-MM-DD` 形式の日付へ置換する処理を追加
- `TODO.md` を整理
  - 既存の長い項目群を整理し、現時点の課題に絞った内容へ更新

## 影響範囲

- トップページとして `index.html` が追加されます
- 既存のビルド処理で `mikuproject.html` に加えて `index.html` も生成されます
- `TODO.md` の内容が大きく整理されます

## 確認ポイント

- `build-project.mjs` 実行時に `index.html` が生成されること
- `index.html` 内の `Updated:` 表示に `{{BUILD_DATE}}` ではなく日付が埋め込まれること
- `index-src.html` の導線が `mikuproject.html`、`README.md`、`mikuproject-spec.md` を指していること
- `TODO.md` が現状の課題一覧として読める内容になっていること

## 補足

- スクリーンショットは実画像ではなく、差し込み用のプレースホルダ枠です