### PR TITLE
UI をタブ内アコーディオン中心に整理し、XLSX import テストを UI 依存から分離

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,12 @@
 - `Mermaid` の SVG プレビューを、独立リポジトリ単体で再現できるようにする
 - `local-data/` 配下のファイルを、参照用・検証用・生成物で整理する
 - `local-data/` に置くべきでない生成物や一時ファイルがないか見直す
+- `npm test` を `scripts/run-tests.mjs` ベースへ切り替えるか検討する
+- `main.test.js` に残っている `xlsx import` の file input wiring を、UI 配線確認と import 結果確認へさらに分離する
+- `main.ts` の summary / validation / preview 描画を別モジュール化し、DOM テストをさらに軽くする
+- `build:xlsx-sample` の所要時間を個別計測し、sample workbook 生成処理の支配要因を確認する
+- `main.test.js` の初期化 DOM をケース別に最小化できるか見直す
+- CI 向けに `test:fast` と `test:full` のような実行導線を分けるか検討する
 - `mikuproject-spec.md` に残っている実装済み前提との差分を定期的に解消する
 - `.xlsx import` の次段として、どのシート・列を今後 import 対象に広げるか整理する
 - WBS 用の `ステータス` は `Task.ExtendedAttribute` で扱う前提で、`FieldID / FieldName / 値候補` を設計する

--- a/index.html
+++ b/index.html
@@ -227,7 +227,7 @@
   <main class="card">
     <div class="eyebrow">Local Browser Tool</div>
     <h1>mikuproject</h1>
-    <div class="md-app-meta">Updated: 2026-03-28</div>
+    <div class="md-app-meta">Updated: 2026-03-29</div>
 
     <section aria-label="What is this">
       <h2>What is this?</h2>

--- a/mikuproject-src.html
+++ b/mikuproject-src.html
@@ -24,15 +24,6 @@
 
     <section class="md-section md-stack-md">
       <div id="statusMessage" class="md-status">未実行</div>
-      <div id="xmlSaveState" class="md-save-state md-save-state--dirty" aria-live="polite">XML 保存状態: 未保存</div>
-      <div class="md-feedback-stack md-hidden" aria-label="import feedback">
-        <div class="md-feedback-stack__title">取込結果</div>
-        <div class="md-feedback-stack__text">XLSX Import 後は、ここで差分反映と検証結果を確認します。</div>
-        <div class="md-feedback-stack__label">検証メッセージ</div>
-        <div id="validationIssues" class="md-issues md-hidden" aria-live="polite"></div>
-        <div class="md-feedback-stack__label">差分要約</div>
-        <div id="xlsxImportSummary" class="md-xlsx-summary md-hidden" aria-live="polite"></div>
-      </div>
 
       <div class="md-top-tabs" role="tablist" aria-label="mikuproject sections">
         <button type="button" class="md-top-tab is-active" data-tab="input" role="tab" aria-selected="true" aria-controls="tabPanelInput">
@@ -59,48 +50,59 @@
         </div>
 
         <div class="md-panel-actions">
-          <button id="loadSampleBtn" type="button" class="md-button md-button--primary">サンプル読込</button>
-          <button id="importXmlBtn" type="button" class="md-button md-button--surface">XML Import</button>
+          <button id="importXmlBtn" type="button" class="md-button md-button--primary">XML Import</button>
           <button id="importXlsxBtn" type="button" class="md-button md-button--surface">XLSX Import</button>
           <button id="parseCsvBtn" type="button" class="md-button md-button--surface">CSV を解析</button>
+          <button id="loadSampleBtn" type="button" class="md-button md-button--surface">サンプル読込</button>
           <input id="importXmlInput" type="file" accept=".xml,text/xml,application/xml" class="md-hidden" />
           <input id="importXlsxInput" type="file" accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" class="md-hidden" />
         </div>
 
         <section class="md-note-card" aria-label="XLSX import export notes">
-          <h3 class="md-note-card__title">XLSX 編集の扱い</h3>
-          <p class="md-note-card__text">
-            `.xlsx` は `MS Project XML` の代替正本ではなく、確認と限定編集のための周辺表現として扱います。
-          </p>
-          <p class="md-note-card__text">
-            現在の `XLSX Import` で反映するのは限定列のみです。
-          </p>
-          <p class="md-note-card__text">
-            反映結果は、`Project / Tasks / Resources / Assignments / Calendars` ごとの件数と、`UID` 単位の差分要約として画面上に表示します。
-          </p>
-          <p class="md-note-card__text"><strong>反映対象</strong></p>
-          <ul class="md-note-list">
-            <li>`Project`: `Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart`</li>
-            <li>`Tasks`: `Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes`</li>
-            <li>`Resources`: `Name / Group / MaxUnits`</li>
-            <li>`Assignments`: `Units / Work / PercentWorkComplete`</li>
-            <li>`Calendars`: `Name / IsBaseCalendar / BaseCalendarUID`</li>
-            <li>`NonWorkingDays`: `Name / Date / FromDate / ToDate / DayWorking`</li>
-          </ul>
-          <p class="md-note-card__text"><strong>現在は反映しないもの</strong></p>
-          <ul class="md-note-list">
-            <li>対象外の列や未対応シートの編集</li>
-            <li>`Calendars` の `WeekDays / WorkWeeks` と、`Baseline / TimephasedData / ExtendedAttributes`</li>
-          </ul>
+          <div class="md-note-card__title-row">
+            <h3 class="md-note-card__title">XLSX 編集の扱い</h3>
+            <lht-help-tooltip label="XLSX 編集の扱い" placement="right" wide>
+              <p class="md-note-card__text">
+                `.xlsx` は `MS Project XML` の代替正本ではなく、確認と限定編集のための周辺表現として扱います。
+              </p>
+              <p class="md-note-card__text">
+                現在の `XLSX Import` で反映するのは限定列のみです。
+              </p>
+              <p class="md-note-card__text">
+                反映結果は、`Project / Tasks / Resources / Assignments / Calendars` ごとの件数と、`UID` 単位の差分要約として画面上に表示します。
+              </p>
+              <p class="md-note-card__text"><strong>反映対象</strong></p>
+              <ul class="md-note-list">
+                <li>`Project`: `Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart`</li>
+                <li>`Tasks`: `Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes`</li>
+                <li>`Resources`: `Name / Group / MaxUnits`</li>
+                <li>`Assignments`: `Units / Work / PercentWorkComplete`</li>
+                <li>`Calendars`: `Name / IsBaseCalendar / BaseCalendarUID`</li>
+                <li>`NonWorkingDays`: `Name / Date / FromDate / ToDate / DayWorking`</li>
+              </ul>
+              <p class="md-note-card__text"><strong>現在は反映しないもの</strong></p>
+              <ul class="md-note-list">
+                <li>対象外の列や未対応シートの編集</li>
+                <li>`Calendars` の `WeekDays / WorkWeeks` と、`Baseline / TimephasedData / ExtendedAttributes`</li>
+              </ul>
+            </lht-help-tooltip>
+          </div>
         </section>
 
-        <div class="md-form-grid">
-          <lht-text-field-help field-id="xmlInput" label="MS Project XML" rows="16" placeholder="ここに XML を入力" help-text="MS Project XML を読み込みます。"></lht-text-field-help>
-        </div>
+        <details class="md-debug-accordion">
+          <summary class="md-debug-accordion__summary">デバッグ情報</summary>
+          <div class="md-debug-accordion__body">
+            <div class="md-form-grid">
+              <lht-text-field-help field-id="xmlInput" label="MS Project XML" rows="16" placeholder="ここに XML を入力" help-text="MS Project XML を読み込みます。"></lht-text-field-help>
+            </div>
 
-        <div class="md-form-grid">
-          <lht-text-field-help field-id="csvInput" label="CSV + ParentID 入力" rows="12" placeholder="ここに CSV を入力" help-text="CSV + ParentID を内部モデルへ変換します。"></lht-text-field-help>
-        </div>
+            <div class="md-form-grid">
+              <lht-text-field-help field-id="csvInput" label="CSV + ParentID 入力" rows="12" placeholder="ここに CSV を入力" help-text="CSV + ParentID を内部モデルへ変換します。"></lht-text-field-help>
+            </div>
+          </div>
+        </details>
+
+        <div id="xmlSaveState" class="md-save-state md-save-state--dirty" aria-live="polite">XML 保存状態: 未保存</div>
       </section>
 
       <section id="tabPanelTransform" class="md-flow-section md-tab-panel" data-tab-panel="transform" aria-label="transform inspect" hidden>
@@ -141,45 +143,59 @@
           </div>
         </div>
 
-        <div class="md-form-grid">
-          <lht-text-field-help field-id="modelOutput" label="内部モデル(JSON)" rows="16" readonly></lht-text-field-help>
-        </div>
-
-        <div class="md-form-grid">
-          <lht-text-field-help field-id="mermaidOutput" label="Mermaid gantt" rows="12" readonly></lht-text-field-help>
-        </div>
-
-        <section class="md-preview-card">
-          <h3 class="md-preview-card__title">Mermaid Preview</h3>
-          <p id="mermaidSvgError" class="md-mermaid-error md-hidden" aria-live="polite"></p>
-          <div class="md-mermaid-preview-wrap">
-            <div id="mermaidSvgPreview" class="md-mermaid-preview-stage">
-              <div class="md-preview-empty">Mermaid を生成すると、ここに SVG を表示します。</div>
+        <details class="md-debug-accordion">
+          <summary class="md-debug-accordion__summary">デバッグ情報</summary>
+          <div class="md-debug-accordion__body">
+            <div class="md-form-grid">
+              <lht-text-field-help field-id="modelOutput" label="内部モデル(JSON)" rows="16" readonly></lht-text-field-help>
             </div>
-          </div>
-        </section>
 
-        <div class="md-preview-grid">
-          <section class="md-preview-card">
-            <h3 class="md-preview-card__title">Project</h3>
-            <div id="projectPreview" class="md-preview-list"></div>
-          </section>
-          <section class="md-preview-card">
-            <h3 class="md-preview-card__title">Tasks</h3>
-            <div id="taskPreview" class="md-preview-list"></div>
-          </section>
-          <section class="md-preview-card">
-            <h3 class="md-preview-card__title">Resources</h3>
-            <div id="resourcePreview" class="md-preview-list"></div>
-          </section>
-          <section class="md-preview-card">
-            <h3 class="md-preview-card__title">Assignments</h3>
-            <div id="assignmentPreview" class="md-preview-list"></div>
-          </section>
-          <section class="md-preview-card">
-            <h3 class="md-preview-card__title">Calendars</h3>
-            <div id="calendarPreview" class="md-preview-list"></div>
-          </section>
+            <div class="md-form-grid">
+              <lht-text-field-help field-id="mermaidOutput" label="Mermaid gantt" rows="12" readonly></lht-text-field-help>
+            </div>
+
+            <div class="md-preview-grid">
+              <section class="md-preview-card">
+                <h3 class="md-preview-card__title">Project</h3>
+                <div id="projectPreview" class="md-preview-list"></div>
+              </section>
+              <section class="md-preview-card">
+                <h3 class="md-preview-card__title">Tasks</h3>
+                <div id="taskPreview" class="md-preview-list"></div>
+              </section>
+              <section class="md-preview-card">
+                <h3 class="md-preview-card__title">Resources</h3>
+                <div id="resourcePreview" class="md-preview-list"></div>
+              </section>
+              <section class="md-preview-card">
+                <h3 class="md-preview-card__title">Assignments</h3>
+                <div id="assignmentPreview" class="md-preview-list"></div>
+              </section>
+              <section class="md-preview-card">
+                <h3 class="md-preview-card__title">Calendars</h3>
+                <div id="calendarPreview" class="md-preview-list"></div>
+              </section>
+            </div>
+
+            <section class="md-preview-card">
+              <h3 class="md-preview-card__title">Mermaid Preview</h3>
+              <p id="mermaidSvgError" class="md-mermaid-error md-hidden" aria-live="polite"></p>
+              <div class="md-mermaid-preview-wrap">
+                <div id="mermaidSvgPreview" class="md-mermaid-preview-stage">
+                  <div class="md-preview-empty">Mermaid を生成すると、ここに SVG を表示します。</div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </details>
+
+        <div class="md-feedback-stack md-hidden" aria-label="import feedback">
+          <div class="md-feedback-stack__title">取込結果</div>
+          <div class="md-feedback-stack__text">XLSX Import 後は、ここで差分反映と検証結果を確認します。</div>
+          <div class="md-feedback-stack__label">検証メッセージ</div>
+          <div id="validationIssues" class="md-issues md-hidden" aria-live="polite"></div>
+          <div class="md-feedback-stack__label">差分要約</div>
+          <div id="xlsxImportSummary" class="md-xlsx-summary md-hidden" aria-live="polite"></div>
         </div>
       </section>
 
@@ -201,66 +217,76 @@
           <button id="exportWbsXlsxBtn" type="button" class="md-button md-button--surface">WBS XLSX Export</button>
         </div>
 
-        <section class="md-note-card" aria-label="WBS xlsx export options">
-          <h3 class="md-note-card__title">WBS XLSX の祝日指定</h3>
-          <p class="md-note-card__text">
-            `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日と、`YYYY-MM-DD` 形式で指定した追加祝日を合成して WBS 日付帯へ反映します。
-          </p>
-          <p class="md-note-card__text">
-            既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から補完します。追加祝日は改行またはカンマ区切りで入力できます。表示期間を空欄にすると全期間、数値を入れると `BaseDate` 前後の日数で切り出します。営業日ベースを選ぶと土日祝を飛ばします。進捗帯も営業日基準へ切り替えられます。
-          </p>
-          <div class="md-form-grid md-form-grid--two">
-            <lht-text-field-help
-              field-id="wbsDisplayDaysBeforeInput"
-              label="表示期間: 基準日前"
-              rows="1"
-              placeholder="3"
-              help-text="空欄なら全期間表示のままです。"></lht-text-field-help>
-            <lht-text-field-help
-              field-id="wbsDisplayDaysAfterInput"
-              label="表示期間: 基準日後"
-              rows="1"
-              placeholder="7"
-              help-text="空欄なら全期間表示のままです。"></lht-text-field-help>
+        <details class="md-debug-accordion">
+          <summary class="md-debug-accordion__summary">設定</summary>
+          <div class="md-debug-accordion__body">
+            <section class="md-note-card" aria-label="WBS xlsx export options">
+              <h3 class="md-note-card__title">WBS XLSX の祝日指定</h3>
+              <p class="md-note-card__text">
+                `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日と、`YYYY-MM-DD` 形式で指定した追加祝日を合成して WBS 日付帯へ反映します。
+              </p>
+              <p class="md-note-card__text">
+                既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から補完します。追加祝日は改行またはカンマ区切りで入力できます。表示期間を空欄にすると全期間、数値を入れると `BaseDate` 前後の日数で切り出します。営業日ベースを選ぶと土日祝を飛ばします。進捗帯も営業日基準へ切り替えられます。
+              </p>
+              <div class="md-form-grid md-form-grid--two">
+                <lht-text-field-help
+                  field-id="wbsDisplayDaysBeforeInput"
+                  label="表示期間: 基準日前"
+                  rows="1"
+                  placeholder="3"
+                  help-text="空欄なら全期間表示のままです。"></lht-text-field-help>
+                <lht-text-field-help
+                  field-id="wbsDisplayDaysAfterInput"
+                  label="表示期間: 基準日後"
+                  rows="1"
+                  placeholder="7"
+                  help-text="空欄なら全期間表示のままです。"></lht-text-field-help>
+              </div>
+              <div class="md-form-grid">
+                <label class="md-checkbox-row">
+                  <input id="wbsBusinessDayRangeInput" type="checkbox" />
+                  <span>表示期間を営業日ベースで数える</span>
+                </label>
+              </div>
+              <div class="md-form-grid">
+                <label class="md-checkbox-row">
+                  <input id="wbsBusinessDayProgressInput" type="checkbox" />
+                  <span>進捗帯を営業日ベースで計算する</span>
+                </label>
+              </div>
+              <div class="md-form-grid">
+                <div id="wbsHolidaySummary" class="md-status">既定祝日: 未読込</div>
+                <lht-text-field-help
+                  field-id="wbsHolidayDatesInput"
+                  label="WBS 既定祝日"
+                  rows="3"
+                  placeholder="2026-03-20"
+                  readonly
+                  help-text="現在の ProjectModel から自動補完します。"></lht-text-field-help>
+              </div>
+              <div class="md-form-grid">
+                <lht-text-field-help
+                  field-id="wbsExtraHolidayDatesInput"
+                  label="WBS 追加祝日"
+                  rows="3"
+                  placeholder="2026-03-21&#10;2026-03-22"
+                  help-text="WBS XLSX Export のみで使用します。重複は自動でまとめます。"></lht-text-field-help>
+              </div>
+              <div class="md-panel-actions">
+                <button id="resetWbsHolidayDatesBtn" type="button" class="md-button md-button--surface">WBS 祝日を既定値へ戻す</button>
+              </div>
+            </section>
           </div>
-          <div class="md-form-grid">
-            <label class="md-checkbox-row">
-              <input id="wbsBusinessDayRangeInput" type="checkbox" />
-              <span>表示期間を営業日ベースで数える</span>
-            </label>
-          </div>
-          <div class="md-form-grid">
-            <label class="md-checkbox-row">
-              <input id="wbsBusinessDayProgressInput" type="checkbox" />
-              <span>進捗帯を営業日ベースで計算する</span>
-            </label>
-          </div>
-          <div class="md-form-grid">
-            <div id="wbsHolidaySummary" class="md-status">既定祝日: 未読込</div>
-            <lht-text-field-help
-              field-id="wbsHolidayDatesInput"
-              label="WBS 既定祝日"
-              rows="3"
-              placeholder="2026-03-20"
-              readonly
-              help-text="現在の ProjectModel から自動補完します。"></lht-text-field-help>
-          </div>
-          <div class="md-form-grid">
-            <lht-text-field-help
-              field-id="wbsExtraHolidayDatesInput"
-              label="WBS 追加祝日"
-              rows="3"
-              placeholder="2026-03-21&#10;2026-03-22"
-              help-text="WBS XLSX Export のみで使用します。重複は自動でまとめます。"></lht-text-field-help>
-          </div>
-          <div class="md-panel-actions">
-            <button id="resetWbsHolidayDatesBtn" type="button" class="md-button md-button--surface">WBS 祝日を既定値へ戻す</button>
-          </div>
-        </section>
+        </details>
 
-        <div class="md-form-grid">
-          <lht-text-field-help field-id="csvOutput" label="CSV + ParentID" rows="12" readonly></lht-text-field-help>
-        </div>
+        <details class="md-debug-accordion">
+          <summary class="md-debug-accordion__summary">デバッグ情報</summary>
+          <div class="md-debug-accordion__body">
+            <div class="md-form-grid">
+              <lht-text-field-help field-id="csvOutput" label="CSV + ParentID" rows="12" readonly></lht-text-field-help>
+            </div>
+          </div>
+        </details>
       </section>
     </section>
 

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -1353,11 +1353,21 @@ lht-index-card-link {
   padding: 16px 18px;
 }
 
+.md-note-card__title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .md-note-card__title {
   margin: 0 0 8px;
   font-size: 0.98rem;
   font-weight: 700;
   color: #1f4f4a;
+}
+
+.md-note-card__title-row .md-note-card__title {
+  margin-bottom: 0;
 }
 
 .md-note-card__text {
@@ -1381,6 +1391,67 @@ lht-index-card-link {
 
 .md-note-list li + li {
   margin-top: 4px;
+}
+
+.md-tooltip-content .md-note-card__text,
+.md-tooltip-content .md-note-list {
+  color: #f3f7f6;
+}
+
+.md-tooltip-content .md-note-card__text strong {
+  color: #ffffff;
+}
+
+.md-tooltip-content .md-note-list {
+  padding-left: 1.1rem;
+}
+
+.md-tooltip-content .md-note-list li::marker {
+  color: #9fe0d5;
+}
+
+.md-debug-accordion {
+  margin-top: 16px;
+  border: 1px solid #d6e3ef;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #f8fbfe 0%, #ffffff 100%);
+  overflow: clip;
+}
+
+.md-debug-accordion__summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 14px 18px;
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: #315267;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.md-debug-accordion__summary::-webkit-details-marker {
+  display: none;
+}
+
+.md-debug-accordion__summary::before {
+  content: "▸";
+  font-size: 0.9rem;
+  color: #4c7b97;
+  transition: transform 160ms ease;
+}
+
+.md-debug-accordion[open] .md-debug-accordion__summary::before {
+  transform: rotate(90deg);
+}
+
+.md-debug-accordion__body {
+  padding: 0 18px 18px;
+  border-top: 1px solid #e2ebf3;
+}
+
+.md-debug-accordion__body .md-form-grid + .md-form-grid {
+  margin-top: 16px;
 }
 
 .md-xlsx-summary {
@@ -1607,15 +1678,6 @@ lht-index-card-link {
 
     <section class="md-section md-stack-md">
       <div id="statusMessage" class="md-status">未実行</div>
-      <div id="xmlSaveState" class="md-save-state md-save-state--dirty" aria-live="polite">XML 保存状態: 未保存</div>
-      <div class="md-feedback-stack md-hidden" aria-label="import feedback">
-        <div class="md-feedback-stack__title">取込結果</div>
-        <div class="md-feedback-stack__text">XLSX Import 後は、ここで差分反映と検証結果を確認します。</div>
-        <div class="md-feedback-stack__label">検証メッセージ</div>
-        <div id="validationIssues" class="md-issues md-hidden" aria-live="polite"></div>
-        <div class="md-feedback-stack__label">差分要約</div>
-        <div id="xlsxImportSummary" class="md-xlsx-summary md-hidden" aria-live="polite"></div>
-      </div>
 
       <div class="md-top-tabs" role="tablist" aria-label="mikuproject sections">
         <button type="button" class="md-top-tab is-active" data-tab="input" role="tab" aria-selected="true" aria-controls="tabPanelInput">
@@ -1642,48 +1704,59 @@ lht-index-card-link {
         </div>
 
         <div class="md-panel-actions">
-          <button id="loadSampleBtn" type="button" class="md-button md-button--primary">サンプル読込</button>
-          <button id="importXmlBtn" type="button" class="md-button md-button--surface">XML Import</button>
+          <button id="importXmlBtn" type="button" class="md-button md-button--primary">XML Import</button>
           <button id="importXlsxBtn" type="button" class="md-button md-button--surface">XLSX Import</button>
           <button id="parseCsvBtn" type="button" class="md-button md-button--surface">CSV を解析</button>
+          <button id="loadSampleBtn" type="button" class="md-button md-button--surface">サンプル読込</button>
           <input id="importXmlInput" type="file" accept=".xml,text/xml,application/xml" class="md-hidden" />
           <input id="importXlsxInput" type="file" accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" class="md-hidden" />
         </div>
 
         <section class="md-note-card" aria-label="XLSX import export notes">
-          <h3 class="md-note-card__title">XLSX 編集の扱い</h3>
-          <p class="md-note-card__text">
-            `.xlsx` は `MS Project XML` の代替正本ではなく、確認と限定編集のための周辺表現として扱います。
-          </p>
-          <p class="md-note-card__text">
-            現在の `XLSX Import` で反映するのは限定列のみです。
-          </p>
-          <p class="md-note-card__text">
-            反映結果は、`Project / Tasks / Resources / Assignments / Calendars` ごとの件数と、`UID` 単位の差分要約として画面上に表示します。
-          </p>
-          <p class="md-note-card__text"><strong>反映対象</strong></p>
-          <ul class="md-note-list">
-            <li>`Project`: `Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart`</li>
-            <li>`Tasks`: `Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes`</li>
-            <li>`Resources`: `Name / Group / MaxUnits`</li>
-            <li>`Assignments`: `Units / Work / PercentWorkComplete`</li>
-            <li>`Calendars`: `Name / IsBaseCalendar / BaseCalendarUID`</li>
-            <li>`NonWorkingDays`: `Name / Date / FromDate / ToDate / DayWorking`</li>
-          </ul>
-          <p class="md-note-card__text"><strong>現在は反映しないもの</strong></p>
-          <ul class="md-note-list">
-            <li>対象外の列や未対応シートの編集</li>
-            <li>`Calendars` の `WeekDays / WorkWeeks` と、`Baseline / TimephasedData / ExtendedAttributes`</li>
-          </ul>
+          <div class="md-note-card__title-row">
+            <h3 class="md-note-card__title">XLSX 編集の扱い</h3>
+            <lht-help-tooltip label="XLSX 編集の扱い" placement="right" wide>
+              <p class="md-note-card__text">
+                `.xlsx` は `MS Project XML` の代替正本ではなく、確認と限定編集のための周辺表現として扱います。
+              </p>
+              <p class="md-note-card__text">
+                現在の `XLSX Import` で反映するのは限定列のみです。
+              </p>
+              <p class="md-note-card__text">
+                反映結果は、`Project / Tasks / Resources / Assignments / Calendars` ごとの件数と、`UID` 単位の差分要約として画面上に表示します。
+              </p>
+              <p class="md-note-card__text"><strong>反映対象</strong></p>
+              <ul class="md-note-list">
+                <li>`Project`: `Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart`</li>
+                <li>`Tasks`: `Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes`</li>
+                <li>`Resources`: `Name / Group / MaxUnits`</li>
+                <li>`Assignments`: `Units / Work / PercentWorkComplete`</li>
+                <li>`Calendars`: `Name / IsBaseCalendar / BaseCalendarUID`</li>
+                <li>`NonWorkingDays`: `Name / Date / FromDate / ToDate / DayWorking`</li>
+              </ul>
+              <p class="md-note-card__text"><strong>現在は反映しないもの</strong></p>
+              <ul class="md-note-list">
+                <li>対象外の列や未対応シートの編集</li>
+                <li>`Calendars` の `WeekDays / WorkWeeks` と、`Baseline / TimephasedData / ExtendedAttributes`</li>
+              </ul>
+            </lht-help-tooltip>
+          </div>
         </section>
 
-        <div class="md-form-grid">
-          <lht-text-field-help field-id="xmlInput" label="MS Project XML" rows="16" placeholder="ここに XML を入力" help-text="MS Project XML を読み込みます。"></lht-text-field-help>
-        </div>
+        <details class="md-debug-accordion">
+          <summary class="md-debug-accordion__summary">デバッグ情報</summary>
+          <div class="md-debug-accordion__body">
+            <div class="md-form-grid">
+              <lht-text-field-help field-id="xmlInput" label="MS Project XML" rows="16" placeholder="ここに XML を入力" help-text="MS Project XML を読み込みます。"></lht-text-field-help>
+            </div>
 
-        <div class="md-form-grid">
-          <lht-text-field-help field-id="csvInput" label="CSV + ParentID 入力" rows="12" placeholder="ここに CSV を入力" help-text="CSV + ParentID を内部モデルへ変換します。"></lht-text-field-help>
-        </div>
+            <div class="md-form-grid">
+              <lht-text-field-help field-id="csvInput" label="CSV + ParentID 入力" rows="12" placeholder="ここに CSV を入力" help-text="CSV + ParentID を内部モデルへ変換します。"></lht-text-field-help>
+            </div>
+          </div>
+        </details>
+
+        <div id="xmlSaveState" class="md-save-state md-save-state--dirty" aria-live="polite">XML 保存状態: 未保存</div>
       </section>
 
       <section id="tabPanelTransform" class="md-flow-section md-tab-panel" data-tab-panel="transform" aria-label="transform inspect" hidden>
@@ -1724,45 +1797,59 @@ lht-index-card-link {
           </div>
         </div>
 
-        <div class="md-form-grid">
-          <lht-text-field-help field-id="modelOutput" label="内部モデル(JSON)" rows="16" readonly></lht-text-field-help>
-        </div>
-
-        <div class="md-form-grid">
-          <lht-text-field-help field-id="mermaidOutput" label="Mermaid gantt" rows="12" readonly></lht-text-field-help>
-        </div>
-
-        <section class="md-preview-card">
-          <h3 class="md-preview-card__title">Mermaid Preview</h3>
-          <p id="mermaidSvgError" class="md-mermaid-error md-hidden" aria-live="polite"></p>
-          <div class="md-mermaid-preview-wrap">
-            <div id="mermaidSvgPreview" class="md-mermaid-preview-stage">
-              <div class="md-preview-empty">Mermaid を生成すると、ここに SVG を表示します。</div>
+        <details class="md-debug-accordion">
+          <summary class="md-debug-accordion__summary">デバッグ情報</summary>
+          <div class="md-debug-accordion__body">
+            <div class="md-form-grid">
+              <lht-text-field-help field-id="modelOutput" label="内部モデル(JSON)" rows="16" readonly></lht-text-field-help>
             </div>
-          </div>
-        </section>
 
-        <div class="md-preview-grid">
-          <section class="md-preview-card">
-            <h3 class="md-preview-card__title">Project</h3>
-            <div id="projectPreview" class="md-preview-list"></div>
-          </section>
-          <section class="md-preview-card">
-            <h3 class="md-preview-card__title">Tasks</h3>
-            <div id="taskPreview" class="md-preview-list"></div>
-          </section>
-          <section class="md-preview-card">
-            <h3 class="md-preview-card__title">Resources</h3>
-            <div id="resourcePreview" class="md-preview-list"></div>
-          </section>
-          <section class="md-preview-card">
-            <h3 class="md-preview-card__title">Assignments</h3>
-            <div id="assignmentPreview" class="md-preview-list"></div>
-          </section>
-          <section class="md-preview-card">
-            <h3 class="md-preview-card__title">Calendars</h3>
-            <div id="calendarPreview" class="md-preview-list"></div>
-          </section>
+            <div class="md-form-grid">
+              <lht-text-field-help field-id="mermaidOutput" label="Mermaid gantt" rows="12" readonly></lht-text-field-help>
+            </div>
+
+            <div class="md-preview-grid">
+              <section class="md-preview-card">
+                <h3 class="md-preview-card__title">Project</h3>
+                <div id="projectPreview" class="md-preview-list"></div>
+              </section>
+              <section class="md-preview-card">
+                <h3 class="md-preview-card__title">Tasks</h3>
+                <div id="taskPreview" class="md-preview-list"></div>
+              </section>
+              <section class="md-preview-card">
+                <h3 class="md-preview-card__title">Resources</h3>
+                <div id="resourcePreview" class="md-preview-list"></div>
+              </section>
+              <section class="md-preview-card">
+                <h3 class="md-preview-card__title">Assignments</h3>
+                <div id="assignmentPreview" class="md-preview-list"></div>
+              </section>
+              <section class="md-preview-card">
+                <h3 class="md-preview-card__title">Calendars</h3>
+                <div id="calendarPreview" class="md-preview-list"></div>
+              </section>
+            </div>
+
+            <section class="md-preview-card">
+              <h3 class="md-preview-card__title">Mermaid Preview</h3>
+              <p id="mermaidSvgError" class="md-mermaid-error md-hidden" aria-live="polite"></p>
+              <div class="md-mermaid-preview-wrap">
+                <div id="mermaidSvgPreview" class="md-mermaid-preview-stage">
+                  <div class="md-preview-empty">Mermaid を生成すると、ここに SVG を表示します。</div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </details>
+
+        <div class="md-feedback-stack md-hidden" aria-label="import feedback">
+          <div class="md-feedback-stack__title">取込結果</div>
+          <div class="md-feedback-stack__text">XLSX Import 後は、ここで差分反映と検証結果を確認します。</div>
+          <div class="md-feedback-stack__label">検証メッセージ</div>
+          <div id="validationIssues" class="md-issues md-hidden" aria-live="polite"></div>
+          <div class="md-feedback-stack__label">差分要約</div>
+          <div id="xlsxImportSummary" class="md-xlsx-summary md-hidden" aria-live="polite"></div>
         </div>
       </section>
 
@@ -1784,66 +1871,76 @@ lht-index-card-link {
           <button id="exportWbsXlsxBtn" type="button" class="md-button md-button--surface">WBS XLSX Export</button>
         </div>
 
-        <section class="md-note-card" aria-label="WBS xlsx export options">
-          <h3 class="md-note-card__title">WBS XLSX の祝日指定</h3>
-          <p class="md-note-card__text">
-            `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日と、`YYYY-MM-DD` 形式で指定した追加祝日を合成して WBS 日付帯へ反映します。
-          </p>
-          <p class="md-note-card__text">
-            既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から補完します。追加祝日は改行またはカンマ区切りで入力できます。表示期間を空欄にすると全期間、数値を入れると `BaseDate` 前後の日数で切り出します。営業日ベースを選ぶと土日祝を飛ばします。進捗帯も営業日基準へ切り替えられます。
-          </p>
-          <div class="md-form-grid md-form-grid--two">
-            <lht-text-field-help
-              field-id="wbsDisplayDaysBeforeInput"
-              label="表示期間: 基準日前"
-              rows="1"
-              placeholder="3"
-              help-text="空欄なら全期間表示のままです。"></lht-text-field-help>
-            <lht-text-field-help
-              field-id="wbsDisplayDaysAfterInput"
-              label="表示期間: 基準日後"
-              rows="1"
-              placeholder="7"
-              help-text="空欄なら全期間表示のままです。"></lht-text-field-help>
+        <details class="md-debug-accordion">
+          <summary class="md-debug-accordion__summary">設定</summary>
+          <div class="md-debug-accordion__body">
+            <section class="md-note-card" aria-label="WBS xlsx export options">
+              <h3 class="md-note-card__title">WBS XLSX の祝日指定</h3>
+              <p class="md-note-card__text">
+                `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日と、`YYYY-MM-DD` 形式で指定した追加祝日を合成して WBS 日付帯へ反映します。
+              </p>
+              <p class="md-note-card__text">
+                既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から補完します。追加祝日は改行またはカンマ区切りで入力できます。表示期間を空欄にすると全期間、数値を入れると `BaseDate` 前後の日数で切り出します。営業日ベースを選ぶと土日祝を飛ばします。進捗帯も営業日基準へ切り替えられます。
+              </p>
+              <div class="md-form-grid md-form-grid--two">
+                <lht-text-field-help
+                  field-id="wbsDisplayDaysBeforeInput"
+                  label="表示期間: 基準日前"
+                  rows="1"
+                  placeholder="3"
+                  help-text="空欄なら全期間表示のままです。"></lht-text-field-help>
+                <lht-text-field-help
+                  field-id="wbsDisplayDaysAfterInput"
+                  label="表示期間: 基準日後"
+                  rows="1"
+                  placeholder="7"
+                  help-text="空欄なら全期間表示のままです。"></lht-text-field-help>
+              </div>
+              <div class="md-form-grid">
+                <label class="md-checkbox-row">
+                  <input id="wbsBusinessDayRangeInput" type="checkbox" />
+                  <span>表示期間を営業日ベースで数える</span>
+                </label>
+              </div>
+              <div class="md-form-grid">
+                <label class="md-checkbox-row">
+                  <input id="wbsBusinessDayProgressInput" type="checkbox" />
+                  <span>進捗帯を営業日ベースで計算する</span>
+                </label>
+              </div>
+              <div class="md-form-grid">
+                <div id="wbsHolidaySummary" class="md-status">既定祝日: 未読込</div>
+                <lht-text-field-help
+                  field-id="wbsHolidayDatesInput"
+                  label="WBS 既定祝日"
+                  rows="3"
+                  placeholder="2026-03-20"
+                  readonly
+                  help-text="現在の ProjectModel から自動補完します。"></lht-text-field-help>
+              </div>
+              <div class="md-form-grid">
+                <lht-text-field-help
+                  field-id="wbsExtraHolidayDatesInput"
+                  label="WBS 追加祝日"
+                  rows="3"
+                  placeholder="2026-03-21&#10;2026-03-22"
+                  help-text="WBS XLSX Export のみで使用します。重複は自動でまとめます。"></lht-text-field-help>
+              </div>
+              <div class="md-panel-actions">
+                <button id="resetWbsHolidayDatesBtn" type="button" class="md-button md-button--surface">WBS 祝日を既定値へ戻す</button>
+              </div>
+            </section>
           </div>
-          <div class="md-form-grid">
-            <label class="md-checkbox-row">
-              <input id="wbsBusinessDayRangeInput" type="checkbox" />
-              <span>表示期間を営業日ベースで数える</span>
-            </label>
-          </div>
-          <div class="md-form-grid">
-            <label class="md-checkbox-row">
-              <input id="wbsBusinessDayProgressInput" type="checkbox" />
-              <span>進捗帯を営業日ベースで計算する</span>
-            </label>
-          </div>
-          <div class="md-form-grid">
-            <div id="wbsHolidaySummary" class="md-status">既定祝日: 未読込</div>
-            <lht-text-field-help
-              field-id="wbsHolidayDatesInput"
-              label="WBS 既定祝日"
-              rows="3"
-              placeholder="2026-03-20"
-              readonly
-              help-text="現在の ProjectModel から自動補完します。"></lht-text-field-help>
-          </div>
-          <div class="md-form-grid">
-            <lht-text-field-help
-              field-id="wbsExtraHolidayDatesInput"
-              label="WBS 追加祝日"
-              rows="3"
-              placeholder="2026-03-21&#10;2026-03-22"
-              help-text="WBS XLSX Export のみで使用します。重複は自動でまとめます。"></lht-text-field-help>
-          </div>
-          <div class="md-panel-actions">
-            <button id="resetWbsHolidayDatesBtn" type="button" class="md-button md-button--surface">WBS 祝日を既定値へ戻す</button>
-          </div>
-        </section>
+        </details>
 
-        <div class="md-form-grid">
-          <lht-text-field-help field-id="csvOutput" label="CSV + ParentID" rows="12" readonly></lht-text-field-help>
-        </div>
+        <details class="md-debug-accordion">
+          <summary class="md-debug-accordion__summary">デバッグ情報</summary>
+          <div class="md-debug-accordion__body">
+            <div class="md-form-grid">
+              <lht-text-field-help field-id="csvOutput" label="CSV + ParentID" rows="12" readonly></lht-text-field-help>
+            </div>
+          </div>
+        </details>
       </section>
     </section>
 
@@ -13378,6 +13475,11 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         clearMermaidError();
         loadSample();
     }
+    globalThis.__mikuprojectMainTestHooks = {
+        renderValidationIssues,
+        renderXlsxImportSummary,
+        updateFeedbackVisibility
+    };
     document.addEventListener("DOMContentLoaded", initialize);
 })();
   </script>

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -292,11 +292,21 @@
   padding: 16px 18px;
 }
 
+.md-note-card__title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
 .md-note-card__title {
   margin: 0 0 8px;
   font-size: 0.98rem;
   font-weight: 700;
   color: #1f4f4a;
+}
+
+.md-note-card__title-row .md-note-card__title {
+  margin-bottom: 0;
 }
 
 .md-note-card__text {
@@ -320,6 +330,67 @@
 
 .md-note-list li + li {
   margin-top: 4px;
+}
+
+.md-tooltip-content .md-note-card__text,
+.md-tooltip-content .md-note-list {
+  color: #f3f7f6;
+}
+
+.md-tooltip-content .md-note-card__text strong {
+  color: #ffffff;
+}
+
+.md-tooltip-content .md-note-list {
+  padding-left: 1.1rem;
+}
+
+.md-tooltip-content .md-note-list li::marker {
+  color: #9fe0d5;
+}
+
+.md-debug-accordion {
+  margin-top: 16px;
+  border: 1px solid #d6e3ef;
+  border-radius: 18px;
+  background: linear-gradient(180deg, #f8fbfe 0%, #ffffff 100%);
+  overflow: clip;
+}
+
+.md-debug-accordion__summary {
+  list-style: none;
+  cursor: pointer;
+  padding: 14px 18px;
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: #315267;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.md-debug-accordion__summary::-webkit-details-marker {
+  display: none;
+}
+
+.md-debug-accordion__summary::before {
+  content: "▸";
+  font-size: 0.9rem;
+  color: #4c7b97;
+  transition: transform 160ms ease;
+}
+
+.md-debug-accordion[open] .md-debug-accordion__summary::before {
+  transform: rotate(90deg);
+}
+
+.md-debug-accordion__body {
+  padding: 0 18px 18px;
+  border-top: 1px solid #e2ebf3;
+}
+
+.md-debug-accordion__body .md-form-grid + .md-form-grid {
+  margin-top: 16px;
 }
 
 .md-xlsx-summary {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1009,5 +1009,10 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         clearMermaidError();
         loadSample();
     }
+    globalThis.__mikuprojectMainTestHooks = {
+        renderValidationIssues,
+        renderXlsxImportSummary,
+        updateFeedbackVisibility
+    };
     document.addEventListener("DOMContentLoaded", initialize);
 })();

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -1156,5 +1156,24 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     loadSample();
   }
 
+  (globalThis as typeof globalThis & {
+    __mikuprojectMainTestHooks?: {
+      renderValidationIssues: (issues: ValidationIssue[]) => void;
+      renderXlsxImportSummary: (changes: Array<{
+        scope: "project" | "tasks" | "resources" | "assignments" | "calendars";
+        uid: string;
+        label: string;
+        field: string;
+        before: string | number | boolean | undefined;
+        after: string | number | boolean;
+      }>) => void;
+      updateFeedbackVisibility: () => void;
+    };
+  }).__mikuprojectMainTestHooks = {
+    renderValidationIssues,
+    renderXlsxImportSummary,
+    updateFeedbackVisibility
+  };
+
   document.addEventListener("DOMContentLoaded", initialize);
 })();

--- a/tests/mikuproject-main.test.js
+++ b/tests/mikuproject-main.test.js
@@ -48,8 +48,10 @@ const dependencyXml = readFileSync(
 
 function mountDom() {
   document.body.innerHTML = `
-    <button id="loadSampleBtn" type="button">サンプル読込</button>
     <button id="importXmlBtn" type="button">XML Import</button>
+    <button id="importXlsxBtn" type="button">XLSX Import</button>
+    <button id="parseCsvBtn" type="button">CSV を解析</button>
+    <button id="loadSampleBtn" type="button">サンプル読込</button>
     <button id="parseXmlBtn" type="button">XML を解析</button>
     <button id="exportXmlBtn" type="button">XML を再生成</button>
     <button id="exportMermaidBtn" type="button">Mermaid を生成</button>
@@ -58,22 +60,11 @@ function mountDom() {
     <button id="exportXlsxBtn" type="button">XLSX Export</button>
     <button id="exportWbsXlsxBtn" type="button">WBS XLSX Export</button>
     <button id="resetWbsHolidayDatesBtn" type="button">WBS 祝日を既定値へ戻す</button>
-    <button id="parseCsvBtn" type="button">CSV を解析</button>
-    <button id="importXlsxBtn" type="button">XLSX Import</button>
     <button id="downloadXmlBtn" type="button">XML Export</button>
     <button id="roundTripBtn" type="button">再読込テスト</button>
     <input id="importXmlInput" type="file" />
     <input id="importXlsxInput" type="file" />
     <div id="statusMessage"></div>
-    <div id="xmlSaveState" class="md-save-state md-save-state--dirty">XML 保存状態: 未保存</div>
-    <div class="md-feedback-stack md-hidden">
-      <div class="md-feedback-stack__title">取込結果</div>
-      <div class="md-feedback-stack__text">XLSX Import 後は、ここで差分反映と検証結果を確認します。</div>
-      <div class="md-feedback-stack__label md-hidden">検証メッセージ</div>
-      <div id="validationIssues" class="md-hidden"></div>
-      <div class="md-feedback-stack__label md-hidden">差分要約</div>
-      <div id="xlsxImportSummary" class="md-hidden"></div>
-    </div>
     <div class="md-top-tabs" role="tablist" aria-label="mikuproject sections">
       <button type="button" class="md-top-tab is-active" data-tab="input" role="tab" aria-selected="true" aria-controls="tabPanelInput">
         <span class="md-top-tab-no">1</span>
@@ -90,27 +81,37 @@ function mountDom() {
     </div>
     <section id="tabPanelInput" class="md-flow-section md-tab-panel" data-tab-panel="input">
       <section class="md-note-card">
-        <h3 class="md-note-card__title">XLSX 編集の扱い</h3>
-        <p class="md-note-card__text">XLSX は MS Project XML の代替正本ではなく、確認と限定編集のための周辺表現として扱います。</p>
-        <p class="md-note-card__text">現在の XLSX Import で反映するのは限定列のみです。</p>
-        <p class="md-note-card__text">反映結果は、Project / Tasks / Resources / Assignments / Calendars ごとの件数と、UID 単位の差分要約として画面上に表示します。</p>
-        <p class="md-note-card__text"><strong>反映対象</strong></p>
-        <ul class="md-note-list">
-          <li>Project: Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart</li>
-          <li>Tasks: Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes</li>
-          <li>Resources: Name / Group / MaxUnits</li>
-          <li>Assignments: Units / Work / PercentWorkComplete</li>
-          <li>Calendars: Name / IsBaseCalendar / BaseCalendarUID</li>
-          <li>NonWorkingDays: Name / Date / FromDate / ToDate / DayWorking</li>
-        </ul>
-        <p class="md-note-card__text"><strong>現在は反映しないもの</strong></p>
-        <ul class="md-note-list">
-          <li>対象外の列や未対応シートの編集</li>
-          <li>Calendars の WeekDays / WorkWeeks と、Baseline / TimephasedData / ExtendedAttributes</li>
-        </ul>
+        <div class="md-note-card__title-row">
+          <h3 class="md-note-card__title">XLSX 編集の扱い</h3>
+          <lht-help-tooltip label="XLSX 編集の扱い" placement="right" wide>
+            <p class="md-note-card__text">XLSX は MS Project XML の代替正本ではなく、確認と限定編集のための周辺表現として扱います。</p>
+            <p class="md-note-card__text">現在の XLSX Import で反映するのは限定列のみです。</p>
+            <p class="md-note-card__text">反映結果は、Project / Tasks / Resources / Assignments / Calendars ごとの件数と、UID 単位の差分要約として画面上に表示します。</p>
+            <p class="md-note-card__text"><strong>反映対象</strong></p>
+            <ul class="md-note-list">
+              <li>Project: Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart</li>
+              <li>Tasks: Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes</li>
+              <li>Resources: Name / Group / MaxUnits</li>
+              <li>Assignments: Units / Work / PercentWorkComplete</li>
+              <li>Calendars: Name / IsBaseCalendar / BaseCalendarUID</li>
+              <li>NonWorkingDays: Name / Date / FromDate / ToDate / DayWorking</li>
+            </ul>
+            <p class="md-note-card__text"><strong>現在は反映しないもの</strong></p>
+            <ul class="md-note-list">
+              <li>対象外の列や未対応シートの編集</li>
+              <li>Calendars の WeekDays / WorkWeeks と、Baseline / TimephasedData / ExtendedAttributes</li>
+            </ul>
+          </lht-help-tooltip>
+        </div>
       </section>
-      <textarea id="xmlInput"></textarea>
-      <textarea id="csvInput"></textarea>
+      <details class="md-debug-accordion">
+        <summary class="md-debug-accordion__summary">デバッグ情報</summary>
+        <div class="md-debug-accordion__body">
+          <textarea id="xmlInput"></textarea>
+          <textarea id="csvInput"></textarea>
+        </div>
+      </details>
+      <div id="xmlSaveState" class="md-save-state md-save-state--dirty">XML 保存状態: 未保存</div>
     </section>
     <section id="tabPanelTransform" class="md-flow-section md-tab-panel" data-tab-panel="transform" hidden>
       <div id="summaryProjectName"></div>
@@ -118,30 +119,53 @@ function mountDom() {
       <div id="summaryResourceCount"></div>
       <div id="summaryAssignmentCount"></div>
       <div id="summaryCalendarCount"></div>
-      <textarea id="modelOutput"></textarea>
-      <textarea id="mermaidOutput"></textarea>
-      <div id="mermaidSvgError" class="md-hidden"></div>
-      <div id="mermaidSvgPreview"></div>
-      <div id="projectPreview"></div>
-      <div id="taskPreview"></div>
-      <div id="resourcePreview"></div>
-      <div id="assignmentPreview"></div>
-      <div id="calendarPreview"></div>
+      <details class="md-debug-accordion">
+        <summary class="md-debug-accordion__summary">デバッグ情報</summary>
+        <div class="md-debug-accordion__body">
+          <textarea id="modelOutput"></textarea>
+          <textarea id="mermaidOutput"></textarea>
+          <div id="projectPreview"></div>
+          <div id="taskPreview"></div>
+          <div id="resourcePreview"></div>
+          <div id="assignmentPreview"></div>
+          <div id="calendarPreview"></div>
+          <div id="mermaidSvgError" class="md-hidden"></div>
+          <div id="mermaidSvgPreview"></div>
+        </div>
+      </details>
+      <div class="md-feedback-stack md-hidden">
+        <div class="md-feedback-stack__title">取込結果</div>
+        <div class="md-feedback-stack__text">XLSX Import 後は、ここで差分反映と検証結果を確認します。</div>
+        <div class="md-feedback-stack__label md-hidden">検証メッセージ</div>
+        <div id="validationIssues" class="md-hidden"></div>
+        <div class="md-feedback-stack__label md-hidden">差分要約</div>
+        <div id="xlsxImportSummary" class="md-hidden"></div>
+      </div>
     </section>
     <section id="tabPanelOutput" class="md-flow-section md-tab-panel" data-tab-panel="output" hidden>
-      <section class="md-note-card">
-        <h3 class="md-note-card__title">WBS XLSX の祝日指定</h3>
-        <p class="md-note-card__text">WBS XLSX Export では、ProjectModel から補完した既定祝日と、YYYY-MM-DD 形式で指定した追加祝日を合成して WBS 日付帯へ反映します。</p>
-        <p class="md-note-card__text">既定祝日は、現在の ProjectModel に含まれる Calendar.Exceptions の非稼働日例外から補完します。追加祝日は改行またはカンマ区切りで入力できます。表示期間を空欄にすると全期間、数値を入れると BaseDate 前後の日数で切り出します。営業日ベースを選ぶと土日祝を飛ばします。進捗帯も営業日基準へ切り替えられます。</p>
-      </section>
-      <input id="wbsDisplayDaysBeforeInput" />
-      <input id="wbsDisplayDaysAfterInput" />
-      <input id="wbsBusinessDayRangeInput" type="checkbox" />
-      <input id="wbsBusinessDayProgressInput" type="checkbox" />
-      <div id="wbsHolidaySummary"></div>
-      <textarea id="wbsHolidayDatesInput"></textarea>
-      <textarea id="wbsExtraHolidayDatesInput"></textarea>
-      <textarea id="csvOutput"></textarea>
+      <details class="md-debug-accordion">
+        <summary class="md-debug-accordion__summary">設定</summary>
+        <div class="md-debug-accordion__body">
+          <section class="md-note-card">
+            <h3 class="md-note-card__title">WBS XLSX の祝日指定</h3>
+            <p class="md-note-card__text">WBS XLSX Export では、ProjectModel から補完した既定祝日と、YYYY-MM-DD 形式で指定した追加祝日を合成して WBS 日付帯へ反映します。</p>
+            <p class="md-note-card__text">既定祝日は、現在の ProjectModel に含まれる Calendar.Exceptions の非稼働日例外から補完します。追加祝日は改行またはカンマ区切りで入力できます。表示期間を空欄にすると全期間、数値を入れると BaseDate 前後の日数で切り出します。営業日ベースを選ぶと土日祝を飛ばします。進捗帯も営業日基準へ切り替えられます。</p>
+          </section>
+          <input id="wbsDisplayDaysBeforeInput" />
+          <input id="wbsDisplayDaysAfterInput" />
+          <input id="wbsBusinessDayRangeInput" type="checkbox" />
+          <input id="wbsBusinessDayProgressInput" type="checkbox" />
+          <div id="wbsHolidaySummary"></div>
+          <textarea id="wbsHolidayDatesInput"></textarea>
+          <textarea id="wbsExtraHolidayDatesInput"></textarea>
+        </div>
+      </details>
+      <details class="md-debug-accordion">
+        <summary class="md-debug-accordion__summary">デバッグ情報</summary>
+        <div class="md-debug-accordion__body">
+          <textarea id="csvOutput"></textarea>
+        </div>
+      </details>
     </section>
     <div id="toast"></div>
   `;
@@ -164,6 +188,10 @@ function bootPage() {
 function bootXmlModule() {
   new Function(`${typesCode}\n${msProjectXmlCode}`)();
   return globalThis.__mikuprojectXml;
+}
+
+function getMainHooks() {
+  return globalThis.__mikuprojectMainTestHooks;
 }
 
 const SAMPLE_HOLIDAY_COUNT = 89;
@@ -209,16 +237,23 @@ describe("mikuproject main", () => {
     expect(document.body.textContent).toContain("UID 単位の差分要約として画面上に表示します");
     expect(document.body.textContent).toContain("反映対象");
     expect(document.body.textContent).toContain("現在は反映しないもの");
+    expect(document.querySelector('lht-help-tooltip[label="XLSX 編集の扱い"]')).not.toBeNull();
     expect(document.body.textContent).toContain("取込結果");
     expect(document.body.textContent).toContain("検証メッセージ");
     expect(document.body.textContent).toContain("差分要約");
     expect(document.body.textContent).toContain("差分反映と検証結果を確認します");
+    expect(document.body.textContent).toContain("デバッグ情報");
+    expect(document.querySelector(".md-debug-accordion")?.hasAttribute("open")).toBe(false);
+    expect(document.querySelectorAll(".md-debug-accordion")[1]?.hasAttribute("open")).toBe(false);
     expect(document.body.textContent).toContain("Project: Name / Title / Author / Company");
     expect(document.body.textContent).toContain("Tasks: Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes");
     expect(document.body.textContent).toContain("Calendars: Name / IsBaseCalendar / BaseCalendarUID");
     expect(document.body.textContent).toContain("NonWorkingDays: Name / Date / FromDate / ToDate / DayWorking");
     expect(document.body.textContent).toContain("Calendars の WeekDays / WorkWeeks");
     expect(document.body.textContent).toContain("WBS XLSX の祝日指定");
+    expect(document.body.textContent).toContain("設定");
+    expect(document.querySelectorAll(".md-debug-accordion")[2]?.hasAttribute("open")).toBe(false);
+    expect(document.querySelectorAll(".md-debug-accordion")[3]?.hasAttribute("open")).toBe(false);
     expect(document.body.textContent).toContain("既定祝日と");
     expect(document.body.textContent).toContain("追加祝日を合成");
     expect(document.body.textContent).toContain("非稼働日例外から補完");
@@ -985,174 +1020,21 @@ describe("mikuproject main", () => {
     expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
   });
 
-  it("shows project calendar and schedule mode changes in xlsx import summary", async () => {
+  it("renders project import summary content without xlsx import wiring", () => {
     bootPage();
-    document.getElementById("parseXmlBtn").click();
 
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
-    projectSheet.rows[12].cells[1].value = "2";
-    projectSheet.rows[16].cells[1].value = false;
-    const bytes = codec.exportWorkbook(workbook);
+    getMainHooks().renderXlsxImportSummary([
+      { scope: "project", uid: "project", label: "Sample Project", field: "CalendarUID", before: "1", after: "2" },
+      { scope: "project", uid: "project", label: "Sample Project", field: "ScheduleFromStart", before: true, after: false },
+      { scope: "project", uid: "project", label: "Sample Project", field: "Author", before: "Toshiki Iga", after: "Author From XLSX" }
+    ]);
 
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "project-settings.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(document.getElementById("modelOutput").value).toContain("\"calendarUID\": \"2\"");
-    expect(document.getElementById("modelOutput").value).toContain("\"scheduleFromStart\": false");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("Project 1");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Tasks, Resources, Assignments, Calendars");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=project Sample Project");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("CalendarUID: 1 -> 2");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("ScheduleFromStart: true -> false");
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
-  });
-
-  it("shows project metadata and date changes in xlsx import summary", async () => {
-    bootPage();
-    document.getElementById("parseXmlBtn").click();
-
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
-    projectSheet.rows[4].cells[1].value = "Title From XLSX";
-    projectSheet.rows[6].cells[1].value = "Company From XLSX";
-    projectSheet.rows[7].cells[1].value = "2026-03-15T09:00:00";
-    projectSheet.rows[8].cells[1].value = "2026-03-28T18:00:00";
-    const bytes = codec.exportWorkbook(workbook);
-
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "project-metadata.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(document.getElementById("modelOutput").value).toContain("\"title\": \"Title From XLSX\"");
-    expect(document.getElementById("modelOutput").value).toContain("\"company\": \"Company From XLSX\"");
-    expect(document.getElementById("modelOutput").value).toContain("\"startDate\": \"2026-03-15T09:00:00\"");
-    expect(document.getElementById("modelOutput").value).toContain("\"finishDate\": \"2026-03-28T18:00:00\"");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Project 1");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Tasks, Resources, Assignments, Calendars");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=project Sample Project");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Title: Sample Project Title -> Title From XLSX");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Company: Local HTML Tools -> Company From XLSX");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("StartDate: 2026-03-16T09:00:00 -> 2026-03-15T09:00:00");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("FinishDate: 2026-03-31T18:00:00 -> 2026-03-28T18:00:00");
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
-  });
-
-  it("shows project author change in xlsx import summary", async () => {
-    bootPage();
-    document.getElementById("parseXmlBtn").click();
-
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
-    projectSheet.rows[5].cells[1].value = "Author From XLSX";
-    const bytes = codec.exportWorkbook(workbook);
-
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "project-author.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(document.getElementById("modelOutput").value).toContain("\"author\": \"Author From XLSX\"");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Project 1");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Tasks, Resources, Assignments, Calendars");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=project Sample Project");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("Author: Toshiki Iga -> Author From XLSX");
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
-  });
-
-  it("shows project current and status dates plus weekly settings changes in xlsx import summary", async () => {
-    bootPage();
-    document.getElementById("parseXmlBtn").click();
-
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
-    projectSheet.rows[9].cells[1].value = "2026-03-18T09:00:00";
-    projectSheet.rows[10].cells[1].value = "2026-03-22T09:00:00";
-    projectSheet.rows[14].cells[1].value = 2100;
-    projectSheet.rows[15].cells[1].value = 18;
-    const bytes = codec.exportWorkbook(workbook);
-
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "project-dates-settings.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(document.getElementById("modelOutput").value).toContain("\"currentDate\": \"2026-03-18T09:00:00\"");
-    expect(document.getElementById("modelOutput").value).toContain("\"statusDate\": \"2026-03-22T09:00:00\"");
-    expect(document.getElementById("modelOutput").value).toContain("\"minutesPerWeek\": 2100");
-    expect(document.getElementById("modelOutput").value).toContain("\"daysPerMonth\": 18");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Project 1");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Tasks, Resources, Assignments, Calendars");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("CurrentDate: 2026-03-16T09:00:00 -> 2026-03-18T09:00:00");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("StatusDate: 2026-03-19T09:00:00 -> 2026-03-22T09:00:00");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("MinutesPerWeek: 2400 -> 2100");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("DaysPerMonth: 20 -> 18");
     expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
     expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
   });
@@ -1277,515 +1159,50 @@ describe("mikuproject main", () => {
     expect(document.getElementById("xlsxImportSummary").classList.contains("md-hidden")).toBe(true);
   }, 10000);
 
-  it("shows calendar changes in xlsx import summary", async () => {
+  it("renders grouped xlsx import summary content without xlsx import wiring", () => {
     bootPage();
-    document.getElementById("parseXmlBtn").click();
 
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
-    calendarsSheet.rows[3].cells[1].value = "Standard Updated";
-    calendarsSheet.rows[3].cells[3].value = "2";
-    const bytes = codec.exportWorkbook(workbook);
+    getMainHooks().renderXlsxImportSummary([
+      { scope: "calendars", uid: "1", label: "Standard", field: "Name", before: "Standard", after: "Standard Updated" },
+      { scope: "calendars", uid: "2", label: "Development", field: "IsBaseCalendar", before: false, after: true },
+      { scope: "tasks", uid: "2", label: "Design", field: "Start", before: "2026-03-16T09:00:00", after: "2026-03-17T09:00:00" },
+      { scope: "tasks", uid: "2", label: "Design", field: "Finish", before: "2026-03-17T18:00:00", after: "2026-03-18T18:00:00" },
+      { scope: "resources", uid: "1", label: "Miku", field: "Name", before: "Miku", after: "Miku Renamed" },
+      { scope: "assignments", uid: "1", label: "TaskUID=2", field: "Work", before: "PT16H0M0S", after: "PT12H0M0S" }
+    ]);
 
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "calendar-sheet.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Standard Updated\"");
-    expect(document.getElementById("modelOutput").value).toContain("\"baseCalendarUID\": \"2\"");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Calendars 1");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Tasks, Resources, Assignments");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Tasks 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Resources 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Assignments 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Calendars 2");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=1 Standard");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Name: Standard -> Standard Updated");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("BaseCalendarUID: (empty) -> 2");
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
-  }, 10000);
-
-  it("shows calendar isBaseCalendar change in xlsx import summary", async () => {
-    bootPage();
-    document.getElementById("parseXmlBtn").click();
-
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
-    calendarsSheet.rows[4].cells[2].value = true;
-    const bytes = codec.exportWorkbook(workbook);
-
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "calendar-base-flag.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(document.getElementById("modelOutput").value).toContain("\"uid\": \"2\"");
-    expect(document.getElementById("modelOutput").value).toContain("\"isBaseCalendar\": true");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Calendars 1");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Tasks, Resources, Assignments");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=2 Development");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("IsBaseCalendar: false -> true");
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
-  });
-
-  it("groups xlsx import summary by sheet when multiple sheets change", async () => {
-    bootPage();
-    document.getElementById("parseXmlBtn").click();
-
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
-    const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
-    const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
-
-    tasksSheet.rows[4].cells[2].value = "Design Multi Sheet";
-    resourcesSheet.rows[3].cells[2].value = "Miku Multi Sheet";
-    assignmentsSheet.rows[3].cells[11].value = 55;
-
-    const bytes = codec.exportWorkbook(workbook);
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "multi-sheet.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 3 件の変更を反映しました");
-    expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Design Multi Sheet\"");
-    expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Miku Multi Sheet\"");
-    expect(document.getElementById("modelOutput").value).toContain("\"percentWorkComplete\": 55");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Tasks 1");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Resources 1");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Assignments 1");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Calendars");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=2 Design");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Name: Design -> Design Multi Sheet");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=1 Miku");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Name: Miku -> Miku Multi Sheet");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=1 TaskUID=2");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("PercentWorkComplete: 50 -> 55");
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(3);
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(3);
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(4);
+    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(5);
   });
 
-  it("shows non-name resource and assignment field changes in xlsx import summary", async () => {
+  it("renders validation issues without xlsx import wiring", () => {
     bootPage();
-    document.getElementById("parseXmlBtn").click();
 
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
-    const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
+    getMainHooks().renderValidationIssues([
+      { level: "warning", scope: "tasks", message: "Task UID=2 (Design) PercentComplete must be within 0..100" },
+      { level: "warning", scope: "tasks", message: "Task UID=2 (Design) Start must be earlier than or equal to Finish" },
+      { level: "warning", scope: "calendars", message: "Calendar BaseCalendarUID が自身を指しています: UID=1 Name=Standard" }
+    ]);
 
-    resourcesSheet.rows[3].cells[5].value = "Platform";
-    resourcesSheet.rows[3].cells[6].value = 0.8;
-    assignmentsSheet.rows[3].cells[7].value = 0.75;
-    assignmentsSheet.rows[3].cells[8].value = "PT12H0M0S";
-
-    const bytes = codec.exportWorkbook(workbook);
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "resource-assignment-fields.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 4 件の変更を反映しました");
-    expect(document.getElementById("modelOutput").value).toContain("\"group\": \"Platform\"");
-    expect(document.getElementById("modelOutput").value).toContain("\"maxUnits\": 0.8");
-    expect(document.getElementById("modelOutput").value).toContain("\"units\": 0.75");
-    expect(document.getElementById("modelOutput").value).toContain("\"work\": \"PT12H0M0S\"");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Resources 1");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Assignments 1");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Tasks, Calendars");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=1 Miku");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Group: Engineering -> Platform");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("MaxUnits: 1 -> 0.8");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=1 TaskUID=2");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Units: 1 -> 0.75");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Work: PT16H0M0S -> PT12H0M0S");
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(2);
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(2);
-  });
-
-  it("shows task date field changes in xlsx import summary", async () => {
-    bootPage();
-    document.getElementById("parseXmlBtn").click();
-
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
-
-    tasksSheet.rows[4].cells[6].value = "2026-03-17T09:00:00";
-    tasksSheet.rows[4].cells[7].value = "2026-03-18T18:00:00";
-
-    const bytes = codec.exportWorkbook(workbook);
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "task-dates.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 2 件の変更を反映しました");
-    expect(document.getElementById("modelOutput").value).toContain("\"start\": \"2026-03-17T09:00:00\"");
-    expect(document.getElementById("modelOutput").value).toContain("\"finish\": \"2026-03-18T18:00:00\"");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Tasks 1");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Resources, Assignments, Calendars");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=2 Design");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Start: 2026-03-16T09:00:00 -> 2026-03-17T09:00:00");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Finish: 2026-03-17T18:00:00 -> 2026-03-18T18:00:00");
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
-  });
-
-  it("shows task percent work complete changes in xlsx import summary", async () => {
-    bootPage();
-    document.getElementById("parseXmlBtn").click();
-
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
-
-    tasksSheet.rows[4].cells[10].value = 65;
-
-    const bytes = codec.exportWorkbook(workbook);
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "task-percent-work-complete.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 1 件の変更を反映しました");
-    expect(document.getElementById("modelOutput").value).toContain("\"percentWorkComplete\": 65");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Tasks 1");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Resources, Assignments, Calendars");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=2 Design");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("PercentWorkComplete: 100 -> 65");
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
-  });
-
-  it("shows resource name changes in xlsx import summary", async () => {
-    bootPage();
-    document.getElementById("parseXmlBtn").click();
-
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
-
-    resourcesSheet.rows[3].cells[2].value = "Miku Renamed";
-
-    const bytes = codec.exportWorkbook(workbook);
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "resource-name.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 1 件の変更を反映しました");
-    expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Miku Renamed\"");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Resources 1");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Tasks, Assignments, Calendars");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=1 Miku");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Name: Miku -> Miku Renamed");
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
-  }, 10000);
-
-  it("shows assignment percent work complete changes in xlsx import summary", async () => {
-    bootPage();
-    document.getElementById("parseXmlBtn").click();
-
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
-
-    assignmentsSheet.rows[3].cells[11].value = 85;
-
-    const bytes = codec.exportWorkbook(workbook);
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "assignment-percent-work-complete.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 1 件の変更を反映しました");
-    expect(document.getElementById("modelOutput").value).toContain("\"percentWorkComplete\": 85");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Assignments 1");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Tasks, Resources, Calendars");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=1 TaskUID=2");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("PercentWorkComplete: 50 -> 85");
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
-    expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
-  }, 10000);
-
-  it("shows validation issues after xlsx import when edited values are invalid", async () => {
-    bootPage();
-    document.getElementById("parseXmlBtn").click();
-
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
-
-    tasksSheet.rows[4].cells[9].value = 120;
-
-    const bytes = codec.exportWorkbook(workbook);
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "invalid-percent-complete.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 1 件の変更を反映しました");
-    expect(document.getElementById("statusMessage").textContent).toContain("検証で 1 件の問題があります");
-    expect(document.getElementById("modelOutput").value).toContain("\"percentComplete\": 120");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("PercentComplete: 100 -> 120");
-    expect(document.getElementById("validationIssues").textContent).toContain("PercentComplete");
-    expect(document.getElementById("validationIssues").textContent).toContain("0..100");
     expect(document.getElementById("validationIssues").classList.contains("md-hidden")).toBe(false);
     expect(document.querySelector(".md-feedback-stack")?.classList.contains("md-hidden")).toBe(false);
-  }, 10000);
-
-  it("shows validation issues after xlsx import when task start is after finish", async () => {
-    bootPage();
-    document.getElementById("parseXmlBtn").click();
-
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
-
-    tasksSheet.rows[4].cells[6].value = "2026-03-19T09:00:00";
-    tasksSheet.rows[4].cells[7].value = "2026-03-18T18:00:00";
-
-    const bytes = codec.exportWorkbook(workbook);
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "invalid-task-dates.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 2 件の変更を反映しました");
-    expect(document.getElementById("statusMessage").textContent).toContain("検証で 1 件の問題があります");
-    expect(document.getElementById("modelOutput").value).toContain("\"start\": \"2026-03-19T09:00:00\"");
-    expect(document.getElementById("modelOutput").value).toContain("\"finish\": \"2026-03-18T18:00:00\"");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Start: 2026-03-16T09:00:00 -> 2026-03-19T09:00:00");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Finish: 2026-03-17T18:00:00 -> 2026-03-18T18:00:00");
+    expect(document.getElementById("validationIssues").textContent).toContain("Tasks");
+    expect(document.getElementById("validationIssues").textContent).toContain("Calendars");
+    expect(document.getElementById("validationIssues").textContent).toContain("PercentComplete");
     expect(document.getElementById("validationIssues").textContent).toContain("Start");
-    expect(document.getElementById("validationIssues").textContent).toContain("Finish");
-    expect(document.getElementById("validationIssues").classList.contains("md-hidden")).toBe(false);
-  }, 10000);
+    expect(document.getElementById("validationIssues").textContent).toContain("BaseCalendarUID");
+  });
 
-  it("shows validation issues after xlsx import when calendar baseCalendarUID is missing", async () => {
-    bootPage();
-    document.getElementById("parseXmlBtn").click();
-
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
-
-    calendarsSheet.rows[3].cells[3].value = "99";
-
-    const bytes = codec.exportWorkbook(workbook);
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "invalid-calendar-base.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 1 件の変更を反映しました");
-    expect(document.getElementById("statusMessage").textContent).toContain("検証で 1 件の問題があります");
-    expect(document.getElementById("modelOutput").value).toContain("\"baseCalendarUID\": \"99\"");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Calendars 1");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("BaseCalendarUID: (empty) -> 99");
-    expect(document.getElementById("validationIssues").textContent).toContain("Calendar BaseCalendarUID");
-    expect(document.getElementById("validationIssues").textContent).toContain("Standard");
-    expect(document.getElementById("validationIssues").classList.contains("md-hidden")).toBe(false);
-  }, 10000);
-
-  it("shows validation issues after xlsx import when calendar baseCalendarUID points to itself", async () => {
-    bootPage();
-    document.getElementById("parseXmlBtn").click();
-
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
-
-    calendarsSheet.rows[3].cells[3].value = "1";
-
-    const bytes = codec.exportWorkbook(workbook);
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "invalid-calendar-self-base.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 1 件の変更を反映しました");
-    expect(document.getElementById("statusMessage").textContent).toContain("検証で 1 件の問題があります");
-    expect(document.getElementById("modelOutput").value).toContain("\"baseCalendarUID\": \"1\"");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Calendars 1");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("BaseCalendarUID: (empty) -> 1");
-    expect(document.getElementById("validationIssues").textContent).toContain("Calendar BaseCalendarUID");
-    expect(document.getElementById("validationIssues").textContent).toContain("自身を指しています");
-    expect(document.getElementById("validationIssues").textContent).toContain("Standard");
-    expect(document.getElementById("validationIssues").classList.contains("md-hidden")).toBe(false);
-  }, 10000);
 
   it("downloads current xml", () => {
     bootPage();
@@ -1816,133 +1233,6 @@ describe("mikuproject main", () => {
     expect(document.getElementById("xmlSaveState").classList.contains("md-save-state--dirty")).toBe(true);
   });
 
-  it("exports edited xml after xlsx import", async () => {
-    bootPage();
-    document.getElementById("parseXmlBtn").click();
-
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
-    tasksSheet.rows[4].cells[2].value = "Design Saved From XLSX";
-    const bytes = codec.exportWorkbook(workbook);
-
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "saved-after-import.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    const OriginalBlob = Blob;
-    class InspectableBlob extends OriginalBlob {
-      __parts;
-
-      constructor(parts, options) {
-        super(parts, options);
-        this.__parts = parts;
-      }
-
-      text() {
-        return Promise.resolve(this.__parts.join(""));
-      }
-    }
-    globalThis.Blob = InspectableBlob;
-    URL.createObjectURL.mockClear();
-    HTMLAnchorElement.prototype.click.mockClear();
-
-    try {
-      document.getElementById("downloadXmlBtn").click();
-
-      expect(URL.createObjectURL).toHaveBeenCalled();
-      expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
-      const exportedBlob = URL.createObjectURL.mock.calls.at(-1)?.[0];
-      expect(exportedBlob).toBeInstanceOf(InspectableBlob);
-      await expect(exportedBlob.text()).resolves.toContain("<Name>Design Saved From XLSX</Name>");
-      const clickedAnchor = HTMLAnchorElement.prototype.click.mock.instances.at(-1);
-      expect(clickedAnchor.download).toBe("mikuproject-export-202603162312.xml");
-      expect(document.getElementById("statusMessage").textContent).toContain("XML ファイルをエクスポートしました");
-    } finally {
-      globalThis.Blob = OriginalBlob;
-    }
-  }, 10000);
-
-  it("exports current xml after xlsx import even when validation issues remain", async () => {
-    bootPage();
-    document.getElementById("parseXmlBtn").click();
-
-    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
-      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
-    );
-    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
-    tasksSheet.rows[4].cells[6].value = "2026-03-19T09:00:00";
-    tasksSheet.rows[4].cells[7].value = "2026-03-18T18:00:00";
-    const bytes = codec.exportWorkbook(workbook);
-
-    const importInput = document.getElementById("importXlsxInput");
-    const file = new File([bytes], "saved-invalid-after-import.xlsx", {
-      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-    });
-    Object.defineProperty(file, "arrayBuffer", {
-      configurable: true,
-      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
-    });
-    Object.defineProperty(importInput, "files", {
-      configurable: true,
-      value: [file]
-    });
-
-    importInput.dispatchEvent(new Event("change"));
-    await flushAsyncWork();
-    await flushAsyncWork();
-
-    expect(document.getElementById("validationIssues").classList.contains("md-hidden")).toBe(false);
-
-    const OriginalBlob = Blob;
-    class InspectableBlob extends OriginalBlob {
-      __parts;
-
-      constructor(parts, options) {
-        super(parts, options);
-        this.__parts = parts;
-      }
-
-      text() {
-        return Promise.resolve(this.__parts.join(""));
-      }
-    }
-    globalThis.Blob = InspectableBlob;
-    URL.createObjectURL.mockClear();
-    HTMLAnchorElement.prototype.click.mockClear();
-
-    try {
-      document.getElementById("downloadXmlBtn").click();
-
-      expect(URL.createObjectURL).toHaveBeenCalled();
-      expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
-      const exportedBlob = URL.createObjectURL.mock.calls.at(-1)?.[0];
-      expect(exportedBlob).toBeInstanceOf(InspectableBlob);
-      await expect(exportedBlob.text()).resolves.toContain("<Start>2026-03-19T09:00:00</Start>");
-      await expect(exportedBlob.text()).resolves.toContain("<Finish>2026-03-18T18:00:00</Finish>");
-      const clickedAnchor = HTMLAnchorElement.prototype.click.mock.instances.at(-1);
-      expect(clickedAnchor.download).toBe("mikuproject-export-202603162312.xml");
-      expect(document.getElementById("statusMessage").textContent).toContain("XML ファイルをエクスポートしました");
-    } finally {
-      globalThis.Blob = OriginalBlob;
-    }
-  }, 10000);
 
   it("downloads rendered mermaid svg", async () => {
     bootPage();

--- a/tests/mikuproject-project-xlsx.test.js
+++ b/tests/mikuproject-project-xlsx.test.js
@@ -35,6 +35,16 @@ function bootModules() {
   };
 }
 
+function buildSampleWorkbook(mutator) {
+  const { xml, projectXlsx } = bootModules();
+  const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+  const workbook = projectXlsx.exportProjectWorkbook(model);
+  if (mutator) {
+    mutator(workbook);
+  }
+  return { xml, projectXlsx, model, workbook };
+}
+
 const SAMPLE_HOLIDAY_COUNT = 89;
 const SAMPLE_FIRST_HOLIDAY_NAME = "元日（公式）";
 const SAMPLE_FIRST_HOLIDAY_DATE = "2026-01-01";
@@ -508,6 +518,116 @@ describe("mikuproject project xlsx", () => {
       { scope: "calendars", uid: "1", label: "Standard", field: "Exception1.FromDate", before: `${SAMPLE_FIRST_HOLIDAY_DATE}T00:00:00`, after: "2026-03-21T00:00:00" },
       { scope: "calendars", uid: "1", label: "Standard", field: "Exception1.ToDate", before: `${SAMPLE_FIRST_HOLIDAY_DATE}T23:59:59`, after: "2026-03-21T23:59:59" }
     ]);
+  });
+
+  it("reports assignment percent work complete import changes", () => {
+    const { projectXlsx, model, workbook } = buildSampleWorkbook((nextWorkbook) => {
+      const assignmentsSheet = nextWorkbook.sheets.find((sheet) => sheet.name === "Assignments");
+      assignmentsSheet.rows[3].cells[11].value = 85;
+    });
+
+    const result = projectXlsx.importProjectWorkbookDetailed(workbook, model);
+
+    expect(result.changes).toEqual([
+      { scope: "assignments", uid: "1", label: "TaskUID=2", field: "PercentWorkComplete", before: 50, after: 85 }
+    ]);
+  });
+
+  it("can validate imported task percent complete out of range without UI boot", () => {
+    const { xml, projectXlsx, model, workbook } = buildSampleWorkbook((nextWorkbook) => {
+      const tasksSheet = nextWorkbook.sheets.find((sheet) => sheet.name === "Tasks");
+      tasksSheet.rows[4].cells[9].value = 120;
+    });
+
+    const importedModel = projectXlsx.importProjectWorkbook(workbook, model);
+    const issues = xml.validateProjectModel(importedModel);
+
+    expect(importedModel.tasks.find((task) => task.uid === "2").percentComplete).toBe(120);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].level).toBe("warning");
+    expect(issues[0].message).toContain("PercentComplete");
+    expect(issues[0].message).toContain("0..100");
+  });
+
+  it("can validate imported task start later than finish without UI boot", () => {
+    const { xml, projectXlsx, model, workbook } = buildSampleWorkbook((nextWorkbook) => {
+      const tasksSheet = nextWorkbook.sheets.find((sheet) => sheet.name === "Tasks");
+      tasksSheet.rows[4].cells[6].value = "2026-03-19T09:00:00";
+      tasksSheet.rows[4].cells[7].value = "2026-03-18T18:00:00";
+    });
+
+    const importedModel = projectXlsx.importProjectWorkbook(workbook, model);
+    const issues = xml.validateProjectModel(importedModel);
+
+    expect(importedModel.tasks.find((task) => task.uid === "2").start).toBe("2026-03-19T09:00:00");
+    expect(importedModel.tasks.find((task) => task.uid === "2").finish).toBe("2026-03-18T18:00:00");
+    expect(issues).toHaveLength(1);
+    expect(issues[0].level).toBe("warning");
+    expect(issues[0].message).toContain("Start");
+    expect(issues[0].message).toContain("Finish");
+  });
+
+  it("can validate imported missing calendar baseCalendarUID without UI boot", () => {
+    const { xml, projectXlsx, model, workbook } = buildSampleWorkbook((nextWorkbook) => {
+      const calendarsSheet = nextWorkbook.sheets.find((sheet) => sheet.name === "Calendars");
+      calendarsSheet.rows[3].cells[3].value = "99";
+    });
+
+    const importedModel = projectXlsx.importProjectWorkbook(workbook, model);
+    const issues = xml.validateProjectModel(importedModel);
+
+    expect(importedModel.calendars.find((calendar) => calendar.uid === "1").baseCalendarUID).toBe("99");
+    expect(issues).toHaveLength(1);
+    expect(issues[0].level).toBe("warning");
+    expect(issues[0].message).toContain("BaseCalendarUID");
+    expect(issues[0].message).toContain("指していません");
+  });
+
+  it("can validate imported self-referencing calendar baseCalendarUID without UI boot", () => {
+    const { xml, projectXlsx, model, workbook } = buildSampleWorkbook((nextWorkbook) => {
+      const calendarsSheet = nextWorkbook.sheets.find((sheet) => sheet.name === "Calendars");
+      calendarsSheet.rows[3].cells[3].value = "1";
+    });
+
+    const importedModel = projectXlsx.importProjectWorkbook(workbook, model);
+    const issues = xml.validateProjectModel(importedModel);
+
+    expect(importedModel.calendars.find((calendar) => calendar.uid === "1").baseCalendarUID).toBe("1");
+    expect(issues).toHaveLength(1);
+    expect(issues[0].level).toBe("warning");
+    expect(issues[0].message).toContain("BaseCalendarUID");
+    expect(issues[0].message).toContain("自身を指しています");
+  });
+
+  it("can export xml after imported xlsx edits without UI boot", () => {
+    const { xml, projectXlsx, model, workbook } = buildSampleWorkbook((nextWorkbook) => {
+      const tasksSheet = nextWorkbook.sheets.find((sheet) => sheet.name === "Tasks");
+      tasksSheet.rows[4].cells[2].value = "Design Saved From XLSX";
+    });
+
+    const importedModel = projectXlsx.importProjectWorkbook(workbook, model);
+    const exportedXml = xml.exportMsProjectXml(importedModel);
+
+    expect(exportedXml).toContain("<Name>Design Saved From XLSX</Name>");
+  });
+
+  it("can export xml after imported invalid xlsx edits without UI boot", () => {
+    const { xml, projectXlsx, model, workbook } = buildSampleWorkbook((nextWorkbook) => {
+      const tasksSheet = nextWorkbook.sheets.find((sheet) => sheet.name === "Tasks");
+      tasksSheet.rows[4].cells[6].value = "2026-03-19T09:00:00";
+      tasksSheet.rows[4].cells[7].value = "2026-03-18T18:00:00";
+    });
+
+    const importedModel = projectXlsx.importProjectWorkbook(workbook, model);
+    const issues = xml.validateProjectModel(importedModel);
+    const exportedXml = xml.exportMsProjectXml(importedModel);
+
+    expect(issues).toHaveLength(1);
+    expect(issues[0].level).toBe("warning");
+    expect(issues[0].message).toContain("Start");
+    expect(issues[0].message).toContain("Finish");
+    expect(exportedXml).toContain("<Start>2026-03-19T09:00:00</Start>");
+    expect(exportedXml).toContain("<Finish>2026-03-18T18:00:00</Finish>");
   });
 
   it("round-trips editable fields through workbook and xlsx bytes", () => {


### PR DESCRIPTION
## 概要

- `Input / Transform / Export` の各タブで、説明・設定・デバッグ向け情報の配置を整理します。
- `XLSX 編集の扱い` をヘルプアイコン `(i)` に集約し、デバッグ情報や設定をアコーディオンで開閉できるようにします。
- `XLSX import` まわりの重い UI テストの一部を、`project-xlsx` 側の単体テストへ移します。

## 変更内容

### UI の整理

- `Input` タブの操作ボタン順を `XML Import / XLSX Import / CSV を解析 / サンプル読込` に変更
- `Input` タブの primary ボタンを `XML Import` に変更
- `XLSX 編集の扱い` の説明本文を `(i)` ヘルプアイコン内へ移動
- `Input` タブに `デバッグ情報` アコーディオンを追加し、`MS Project XML` と `CSV + ParentID 入力` を格納
- `XML 保存状態` を `デバッグ情報` の下へ移動
- `Transform` タブに `デバッグ情報` アコーディオンを追加し、`内部モデル(JSON)`、`Mermaid gantt`、`Project / Tasks / Resources / Assignments / Calendars` の詳細表示を格納
- `Transform` タブの `取込結果` を末尾へ移動
- `Export` タブに `設定` アコーディオンを追加し、`WBS XLSX の祝日指定` を格納
- `Export` タブに `デバッグ情報` アコーディオンを追加し、`CSV + ParentID` 出力を格納
- 各アコーディオンはデフォルトで閉じる構成

### スタイル調整

- アコーディオン用スタイルを追加
- `XLSX 編集の扱い` タイトル行のレイアウトを追加
- ツールチップ内の説明文・箇条書きの文字色とマーカー色を調整

### テスト整理

- `main.ts` に `__mikuprojectMainTestHooks` を追加し、summary / validation 表示のテスト用フックを公開
- `tests/mikuproject-main.test.js` の UI モックを新しいレイアウトへ更新
- `tests/mikuproject-main.test.js` から、一部の `xlsx import` 検証・XML export 確認を外して軽量化
- `tests/mikuproject-project-xlsx.test.js` に、`xlsx import` 後の差分・検証・XML export を UI 起動なしで確認するテストを追加
- `TODO.md` に、テスト実行時間や `main.test.js` 分割に関する追加タスクを追記

## テスト

- `tests/mikuproject-main.test.js` を更新
- `tests/mikuproject-project-xlsx.test.js` にテストを追加

## 補足

- `index.html` と `mikuproject.html` は生成物更新を含みます