### PR TITLE
Export 操作を内部モデル基準の保存フローへ統一し、XML 再生成ボタンを廃止

### DIFF
--- a/mikuproject-src.html
+++ b/mikuproject-src.html
@@ -209,7 +209,6 @@
         </div>
 
         <div class="md-panel-actions">
-          <button id="exportXmlBtn" type="button" class="md-button md-button--surface">XML を再生成</button>
           <button id="downloadXmlBtn" type="button" class="md-button md-button--surface">XML Export</button>
           <button id="downloadMermaidSvgBtn" type="button" class="md-button md-button--surface" disabled>SVG保存</button>
           <button id="exportCsvBtn" type="button" class="md-button md-button--surface">CSV を生成</button>

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -1863,7 +1863,6 @@ lht-index-card-link {
         </div>
 
         <div class="md-panel-actions">
-          <button id="exportXmlBtn" type="button" class="md-button md-button--surface">XML を再生成</button>
           <button id="downloadXmlBtn" type="button" class="md-button md-button--surface">XML Export</button>
           <button id="downloadMermaidSvgBtn" type="button" class="md-button md-button--surface" disabled>SVG保存</button>
           <button id="exportCsvBtn" type="button" class="md-button md-button--surface">CSV を生成</button>
@@ -12678,7 +12677,7 @@ globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default;
         getElement("mermaidSvgPreview").innerHTML = markup;
     }
     function updateMermaidSvgButton() {
-        getElement("downloadMermaidSvgBtn").disabled = !currentMermaidSvg;
+        getElement("downloadMermaidSvgBtn").disabled = !currentModel;
     }
     function normalizeSvgForXml(svgText) {
         if (!svgText) {
@@ -12769,6 +12768,12 @@ globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default;
     }
     function refreshXmlSaveState() {
         updateXmlSaveState(getTextArea("xmlInput").value !== lastSavedXmlText);
+    }
+    function syncXmlTextFromModel(model) {
+        const xmlText = mikuprojectXml.exportMsProjectXml(model);
+        getTextArea("xmlInput").value = xmlText;
+        refreshXmlSaveState();
+        return xmlText;
     }
     function renderPreviewList(containerId, items) {
         const container = getElement(containerId);
@@ -13025,6 +13030,7 @@ globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default;
             .replace(/'/g, "&#39;");
     }
     function updateSummary(model) {
+        updateMermaidSvgButton();
         syncWbsHolidayDatesInput(model);
         getElement("summaryProjectName").textContent = (model === null || model === void 0 ? void 0 : model.project.name) || "-";
         getElement("summaryTaskCount").textContent = String((model === null || model === void 0 ? void 0 : model.tasks.length) || 0);
@@ -13146,19 +13152,6 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         showToast("XML を解析しました");
         setActiveTab("transform");
     }
-    function exportCurrentModel() {
-        if (!currentModel) {
-            setStatus("内部モデルがありません");
-            return;
-        }
-        getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
-        markXmlDirty();
-        renderValidationIssues([]);
-        renderXlsxImportSummary([]);
-        setStatus("内部モデルから XML を再生成しました");
-        showToast("XML を再生成しました");
-        setActiveTab("output");
-    }
     async function exportCurrentMermaid() {
         if (!currentModel) {
             setStatus("内部モデルがありません");
@@ -13172,17 +13165,16 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         setActiveTab("transform");
     }
     function exportCurrentCsv() {
-        if (!currentModel) {
-            setStatus("内部モデルがありません");
-            return;
-        }
-        getTextArea("csvOutput").value = mikuprojectXml.exportCsvParentId(currentModel);
+        const model = ensureCurrentModel();
+        syncXmlTextFromModel(model);
+        getTextArea("csvOutput").value = mikuprojectXml.exportCsvParentId(model);
         setStatus("内部モデルから CSV + ParentID を生成しました");
         showToast("CSV を生成しました");
         setActiveTab("output");
     }
     function exportCurrentXlsx() {
         const model = ensureCurrentModel();
+        syncXmlTextFromModel(model);
         const workbook = mikuprojectProjectXlsx.exportProjectWorkbook(model);
         const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
         const bytes = codec.exportWorkbook(workbook);
@@ -13201,6 +13193,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     }
     function exportCurrentWbsXlsx() {
         const model = ensureCurrentModel();
+        syncXmlTextFromModel(model);
         const defaultHolidayDates = parseWbsDefaultHolidayDates();
         const additionalHolidayDates = parseWbsAdditionalHolidayDates();
         const displayDaysBeforeBaseDate = parseWbsDisplayDaysBeforeBaseDate();
@@ -13278,11 +13271,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         setActiveTab("transform");
     }
     function downloadCurrentXml() {
-        const xmlText = getTextArea("xmlInput").value.trim();
-        if (!xmlText) {
-            setStatus("出力する XML がありません");
-            return;
-        }
+        const model = ensureCurrentModel();
+        const xmlText = syncXmlTextFromModel(model);
         const blob = new Blob([`${xmlText}\n`], { type: "application/xml;charset=utf-8" });
         const objectUrl = URL.createObjectURL(blob);
         const link = document.createElement("a");
@@ -13305,7 +13295,12 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         showToast("XML を保存しました");
         setActiveTab("output");
     }
-    function downloadCurrentMermaidSvg() {
+    async function downloadCurrentMermaidSvg() {
+        const model = ensureCurrentModel();
+        syncXmlTextFromModel(model);
+        const mermaidText = mikuprojectXml.exportMermaidGantt(model);
+        getTextArea("mermaidOutput").value = mermaidText;
+        await renderMermaidPreview(mermaidText);
         if (!currentMermaidSvg) {
             setStatus("出力する SVG がありません");
             return;
@@ -13351,26 +13346,15 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
                 setStatus(error instanceof Error ? error.message : "XML 解析に失敗しました");
             }
         });
-        getElement("exportXmlBtn").addEventListener("click", () => {
-            try {
-                exportCurrentModel();
-            }
-            catch (error) {
-                setStatus(error instanceof Error ? error.message : "XML 再生成に失敗しました");
-            }
-        });
         getElement("exportMermaidBtn").addEventListener("click", () => {
             void exportCurrentMermaid().catch((error) => {
                 setStatus(error instanceof Error ? error.message : "Mermaid 生成に失敗しました");
             });
         });
         getElement("downloadMermaidSvgBtn").addEventListener("click", () => {
-            try {
-                downloadCurrentMermaidSvg();
-            }
-            catch (error) {
+            void downloadCurrentMermaidSvg().catch((error) => {
                 setStatus(error instanceof Error ? error.message : "SVG 保存に失敗しました");
-            }
+            });
         });
         getElement("exportCsvBtn").addEventListener("click", () => {
             try {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -212,7 +212,7 @@
         getElement("mermaidSvgPreview").innerHTML = markup;
     }
     function updateMermaidSvgButton() {
-        getElement("downloadMermaidSvgBtn").disabled = !currentMermaidSvg;
+        getElement("downloadMermaidSvgBtn").disabled = !currentModel;
     }
     function normalizeSvgForXml(svgText) {
         if (!svgText) {
@@ -303,6 +303,12 @@
     }
     function refreshXmlSaveState() {
         updateXmlSaveState(getTextArea("xmlInput").value !== lastSavedXmlText);
+    }
+    function syncXmlTextFromModel(model) {
+        const xmlText = mikuprojectXml.exportMsProjectXml(model);
+        getTextArea("xmlInput").value = xmlText;
+        refreshXmlSaveState();
+        return xmlText;
     }
     function renderPreviewList(containerId, items) {
         const container = getElement(containerId);
@@ -559,6 +565,7 @@
             .replace(/'/g, "&#39;");
     }
     function updateSummary(model) {
+        updateMermaidSvgButton();
         syncWbsHolidayDatesInput(model);
         getElement("summaryProjectName").textContent = (model === null || model === void 0 ? void 0 : model.project.name) || "-";
         getElement("summaryTaskCount").textContent = String((model === null || model === void 0 ? void 0 : model.tasks.length) || 0);
@@ -680,19 +687,6 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         showToast("XML を解析しました");
         setActiveTab("transform");
     }
-    function exportCurrentModel() {
-        if (!currentModel) {
-            setStatus("内部モデルがありません");
-            return;
-        }
-        getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
-        markXmlDirty();
-        renderValidationIssues([]);
-        renderXlsxImportSummary([]);
-        setStatus("内部モデルから XML を再生成しました");
-        showToast("XML を再生成しました");
-        setActiveTab("output");
-    }
     async function exportCurrentMermaid() {
         if (!currentModel) {
             setStatus("内部モデルがありません");
@@ -706,17 +700,16 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         setActiveTab("transform");
     }
     function exportCurrentCsv() {
-        if (!currentModel) {
-            setStatus("内部モデルがありません");
-            return;
-        }
-        getTextArea("csvOutput").value = mikuprojectXml.exportCsvParentId(currentModel);
+        const model = ensureCurrentModel();
+        syncXmlTextFromModel(model);
+        getTextArea("csvOutput").value = mikuprojectXml.exportCsvParentId(model);
         setStatus("内部モデルから CSV + ParentID を生成しました");
         showToast("CSV を生成しました");
         setActiveTab("output");
     }
     function exportCurrentXlsx() {
         const model = ensureCurrentModel();
+        syncXmlTextFromModel(model);
         const workbook = mikuprojectProjectXlsx.exportProjectWorkbook(model);
         const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
         const bytes = codec.exportWorkbook(workbook);
@@ -735,6 +728,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     }
     function exportCurrentWbsXlsx() {
         const model = ensureCurrentModel();
+        syncXmlTextFromModel(model);
         const defaultHolidayDates = parseWbsDefaultHolidayDates();
         const additionalHolidayDates = parseWbsAdditionalHolidayDates();
         const displayDaysBeforeBaseDate = parseWbsDisplayDaysBeforeBaseDate();
@@ -812,11 +806,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         setActiveTab("transform");
     }
     function downloadCurrentXml() {
-        const xmlText = getTextArea("xmlInput").value.trim();
-        if (!xmlText) {
-            setStatus("出力する XML がありません");
-            return;
-        }
+        const model = ensureCurrentModel();
+        const xmlText = syncXmlTextFromModel(model);
         const blob = new Blob([`${xmlText}\n`], { type: "application/xml;charset=utf-8" });
         const objectUrl = URL.createObjectURL(blob);
         const link = document.createElement("a");
@@ -839,7 +830,12 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         showToast("XML を保存しました");
         setActiveTab("output");
     }
-    function downloadCurrentMermaidSvg() {
+    async function downloadCurrentMermaidSvg() {
+        const model = ensureCurrentModel();
+        syncXmlTextFromModel(model);
+        const mermaidText = mikuprojectXml.exportMermaidGantt(model);
+        getTextArea("mermaidOutput").value = mermaidText;
+        await renderMermaidPreview(mermaidText);
         if (!currentMermaidSvg) {
             setStatus("出力する SVG がありません");
             return;
@@ -885,26 +881,15 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
                 setStatus(error instanceof Error ? error.message : "XML 解析に失敗しました");
             }
         });
-        getElement("exportXmlBtn").addEventListener("click", () => {
-            try {
-                exportCurrentModel();
-            }
-            catch (error) {
-                setStatus(error instanceof Error ? error.message : "XML 再生成に失敗しました");
-            }
-        });
         getElement("exportMermaidBtn").addEventListener("click", () => {
             void exportCurrentMermaid().catch((error) => {
                 setStatus(error instanceof Error ? error.message : "Mermaid 生成に失敗しました");
             });
         });
         getElement("downloadMermaidSvgBtn").addEventListener("click", () => {
-            try {
-                downloadCurrentMermaidSvg();
-            }
-            catch (error) {
+            void downloadCurrentMermaidSvg().catch((error) => {
                 setStatus(error instanceof Error ? error.message : "SVG 保存に失敗しました");
-            }
+            });
         });
         getElement("exportCsvBtn").addEventListener("click", () => {
             try {

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -298,7 +298,7 @@
   }
 
   function updateMermaidSvgButton(): void {
-    getElement<HTMLButtonElement>("downloadMermaidSvgBtn").disabled = !currentMermaidSvg;
+    getElement<HTMLButtonElement>("downloadMermaidSvgBtn").disabled = !currentModel;
   }
 
   function normalizeSvgForXml(svgText: string): string {
@@ -400,6 +400,13 @@
 
   function refreshXmlSaveState(): void {
     updateXmlSaveState(getTextArea("xmlInput").value !== lastSavedXmlText);
+  }
+
+  function syncXmlTextFromModel(model: ProjectModel): string {
+    const xmlText = mikuprojectXml.exportMsProjectXml(model);
+    getTextArea("xmlInput").value = xmlText;
+    refreshXmlSaveState();
+    return xmlText;
   }
 
   function renderPreviewList(containerId: string, items: string[]): void {
@@ -697,6 +704,7 @@
   }
 
   function updateSummary(model: ProjectModel | null): void {
+    updateMermaidSvgButton();
     syncWbsHolidayDatesInput(model);
     getElement<HTMLElement>("summaryProjectName").textContent = model?.project.name || "-";
     getElement<HTMLElement>("summaryTaskCount").textContent = String(model?.tasks.length || 0);
@@ -823,20 +831,6 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     setActiveTab("transform");
   }
 
-  function exportCurrentModel(): void {
-    if (!currentModel) {
-      setStatus("内部モデルがありません");
-      return;
-    }
-    getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
-    markXmlDirty();
-    renderValidationIssues([]);
-    renderXlsxImportSummary([]);
-    setStatus("内部モデルから XML を再生成しました");
-    showToast("XML を再生成しました");
-    setActiveTab("output");
-  }
-
   async function exportCurrentMermaid(): Promise<void> {
     if (!currentModel) {
       setStatus("内部モデルがありません");
@@ -851,11 +845,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
   }
 
   function exportCurrentCsv(): void {
-    if (!currentModel) {
-      setStatus("内部モデルがありません");
-      return;
-    }
-    getTextArea("csvOutput").value = mikuprojectXml.exportCsvParentId(currentModel);
+    const model = ensureCurrentModel();
+    syncXmlTextFromModel(model);
+    getTextArea("csvOutput").value = mikuprojectXml.exportCsvParentId(model);
     setStatus("内部モデルから CSV + ParentID を生成しました");
     showToast("CSV を生成しました");
     setActiveTab("output");
@@ -863,6 +855,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
 
   function exportCurrentXlsx(): void {
     const model = ensureCurrentModel();
+    syncXmlTextFromModel(model);
     const workbook = mikuprojectProjectXlsx.exportProjectWorkbook(model);
     const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
     const bytes = codec.exportWorkbook(workbook);
@@ -885,6 +878,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
 
   function exportCurrentWbsXlsx(): void {
     const model = ensureCurrentModel();
+    syncXmlTextFromModel(model);
     const defaultHolidayDates = parseWbsDefaultHolidayDates();
     const additionalHolidayDates = parseWbsAdditionalHolidayDates();
     const displayDaysBeforeBaseDate = parseWbsDisplayDaysBeforeBaseDate();
@@ -968,11 +962,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
   }
 
   function downloadCurrentXml(): void {
-    const xmlText = getTextArea("xmlInput").value.trim();
-    if (!xmlText) {
-      setStatus("出力する XML がありません");
-      return;
-    }
+    const model = ensureCurrentModel();
+    const xmlText = syncXmlTextFromModel(model);
     const blob = new Blob([`${xmlText}\n`], { type: "application/xml;charset=utf-8" });
     const objectUrl = URL.createObjectURL(blob);
     const link = document.createElement("a");
@@ -996,7 +987,12 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     setActiveTab("output");
   }
 
-  function downloadCurrentMermaidSvg(): void {
+  async function downloadCurrentMermaidSvg(): Promise<void> {
+    const model = ensureCurrentModel();
+    syncXmlTextFromModel(model);
+    const mermaidText = mikuprojectXml.exportMermaidGantt(model);
+    getTextArea("mermaidOutput").value = mermaidText;
+    await renderMermaidPreview(mermaidText);
     if (!currentMermaidSvg) {
       setStatus("出力する SVG がありません");
       return;
@@ -1043,24 +1039,15 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         setStatus(error instanceof Error ? error.message : "XML 解析に失敗しました");
       }
     });
-    getElement<HTMLButtonElement>("exportXmlBtn").addEventListener("click", () => {
-      try {
-        exportCurrentModel();
-      } catch (error) {
-        setStatus(error instanceof Error ? error.message : "XML 再生成に失敗しました");
-      }
-    });
     getElement<HTMLButtonElement>("exportMermaidBtn").addEventListener("click", () => {
       void exportCurrentMermaid().catch((error) => {
         setStatus(error instanceof Error ? error.message : "Mermaid 生成に失敗しました");
       });
     });
     getElement<HTMLButtonElement>("downloadMermaidSvgBtn").addEventListener("click", () => {
-      try {
-        downloadCurrentMermaidSvg();
-      } catch (error) {
+      void downloadCurrentMermaidSvg().catch((error) => {
         setStatus(error instanceof Error ? error.message : "SVG 保存に失敗しました");
-      }
+      });
     });
     getElement<HTMLButtonElement>("exportCsvBtn").addEventListener("click", () => {
       try {

--- a/tests/mikuproject-main.test.js
+++ b/tests/mikuproject-main.test.js
@@ -53,7 +53,6 @@ function mountDom() {
     <button id="parseCsvBtn" type="button">CSV を解析</button>
     <button id="loadSampleBtn" type="button">サンプル読込</button>
     <button id="parseXmlBtn" type="button">XML を解析</button>
-    <button id="exportXmlBtn" type="button">XML を再生成</button>
     <button id="exportMermaidBtn" type="button">Mermaid を生成</button>
     <button id="downloadMermaidSvgBtn" type="button" disabled>SVG保存</button>
     <button id="exportCsvBtn" type="button">CSV を生成</button>
@@ -455,7 +454,7 @@ describe("mikuproject main", () => {
     bootPage();
 
     document.getElementById("parseXmlBtn").click();
-    document.getElementById("exportXmlBtn").click();
+    document.getElementById("downloadXmlBtn").click();
 
     const xmlText = document.getElementById("xmlInput").value;
     expect(xmlText).toContain("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
@@ -705,6 +704,10 @@ describe("mikuproject main", () => {
     bootPage();
 
     document.getElementById("parseXmlBtn").click();
+    document.getElementById("downloadXmlBtn").click();
+    const xmlInput = document.getElementById("xmlInput");
+    xmlInput.value = `${xmlInput.value}\n<!-- edited -->`;
+    xmlInput.dispatchEvent(new Event("input"));
     document.getElementById("exportCsvBtn").click();
 
     const csvText = document.getElementById("csvOutput").value;
@@ -712,6 +715,8 @@ describe("mikuproject main", () => {
     expect(csvText).toContain("1,,1,Project Summary,2026-03-16T09:00:00,2026-03-20T18:00:00,,,50,50,0,1,0,1,500,PT40H0M0S,1,,,,");
     expect(csvText).toContain("2,1,1.1,Design,2026-03-16T09:00:00,2026-03-17T18:00:00,,Miku,100,100,0,0,0,1,500,PT16H0M0S,1,,,,Design completed");
     expect(csvText).toContain("3,1,1.2,Implementation,2026-03-18T09:00:00,2026-03-20T18:00:00,2,Miku,0,0,0,0,1,1,700,PT24H0M0S,1,4,2026-03-18T09:00:00,2026-03-21T18:00:00,Implementation starts after design");
+    expect(document.getElementById("xmlInput").value).not.toContain("<!-- edited -->");
+    expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 保存済み (2026-03-16 23:12)");
     expect(document.getElementById("statusMessage").textContent).toContain("CSV + ParentID を生成しました");
   });
 
@@ -778,12 +783,18 @@ describe("mikuproject main", () => {
     bootPage();
 
     document.getElementById("parseXmlBtn").click();
+    document.getElementById("downloadXmlBtn").click();
+    const xmlInput = document.getElementById("xmlInput");
+    xmlInput.value = `${xmlInput.value}\n<!-- edited -->`;
+    xmlInput.dispatchEvent(new Event("input"));
     document.getElementById("exportXlsxBtn").click();
 
     expect(URL.createObjectURL).toHaveBeenCalled();
     expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
     const clickedAnchor = HTMLAnchorElement.prototype.click.mock.instances.at(-1);
     expect(clickedAnchor.download).toBe("mikuproject-export-202603162312.xlsx");
+    expect(document.getElementById("xmlInput").value).not.toContain("<!-- edited -->");
+    expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 保存済み (2026-03-16 23:12)");
     expect(document.getElementById("statusMessage").textContent).toContain("XLSX ファイルをエクスポートしました");
   });
 
@@ -792,6 +803,10 @@ describe("mikuproject main", () => {
     const exportSpy = vi.spyOn(globalThis.__mikuprojectWbsXlsx, "exportWbsWorkbook");
 
     document.getElementById("parseXmlBtn").click();
+    document.getElementById("downloadXmlBtn").click();
+    const xmlInput = document.getElementById("xmlInput");
+    xmlInput.value = `${xmlInput.value}\n<!-- edited -->`;
+    xmlInput.dispatchEvent(new Event("input"));
     document.getElementById("exportWbsXlsxBtn").click();
     const defaultHolidayDates = getDefaultSampleHolidayDates();
 
@@ -808,6 +823,8 @@ describe("mikuproject main", () => {
       useBusinessDaysForDisplayRange: false,
       useBusinessDaysForProgressBand: false
     });
+    expect(document.getElementById("xmlInput").value).not.toContain("<!-- edited -->");
+    expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 保存済み (2026-03-16 23:12)");
     expect(document.getElementById("statusMessage").textContent).toContain("WBS XLSX ファイルをエクスポートしました");
     expect(document.getElementById("statusMessage").textContent).toContain(`祝日 ${SAMPLE_HOLIDAY_COUNT} 件`);
   });
@@ -1233,19 +1250,68 @@ describe("mikuproject main", () => {
     expect(document.getElementById("xmlSaveState").classList.contains("md-save-state--dirty")).toBe(true);
   });
 
+  it("exports regenerated xml instead of manual textarea edits when a model exists", async () => {
+    bootPage();
+
+    document.getElementById("parseXmlBtn").click();
+    const xmlInput = document.getElementById("xmlInput");
+    xmlInput.value = `${xmlInput.value}\n<!-- edited -->`;
+    xmlInput.dispatchEvent(new Event("input"));
+    await flushAsyncWork();
+
+    const OriginalBlob = Blob;
+    class InspectableBlob extends OriginalBlob {
+      __parts;
+
+      constructor(parts, options) {
+        super(parts, options);
+        this.__parts = parts;
+      }
+
+      text() {
+        return Promise.resolve(this.__parts.join(""));
+      }
+    }
+    globalThis.Blob = InspectableBlob;
+    URL.createObjectURL.mockClear();
+    HTMLAnchorElement.prototype.click.mockClear();
+
+    try {
+      document.getElementById("downloadXmlBtn").click();
+
+      expect(URL.createObjectURL).toHaveBeenCalled();
+      const exportedBlob = URL.createObjectURL.mock.calls.at(-1)?.[0];
+      expect(exportedBlob).toBeInstanceOf(InspectableBlob);
+      await expect(exportedBlob.text()).resolves.not.toContain("<!-- edited -->");
+      expect(document.getElementById("xmlInput").value).not.toContain("<!-- edited -->");
+      expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 保存済み (2026-03-16 23:12)");
+    } finally {
+      globalThis.Blob = OriginalBlob;
+    }
+  });
+
 
   it("downloads rendered mermaid svg", async () => {
     bootPage();
 
     document.getElementById("parseXmlBtn").click();
-    document.getElementById("exportMermaidBtn").click();
-    await flushAsyncWork();
+    document.getElementById("downloadXmlBtn").click();
+    const xmlInput = document.getElementById("xmlInput");
+    xmlInput.value = `${xmlInput.value}\n<!-- edited -->`;
+    xmlInput.dispatchEvent(new Event("input"));
+    URL.createObjectURL.mockClear();
+    HTMLAnchorElement.prototype.click.mockClear();
     document.getElementById("downloadMermaidSvgBtn").click();
+    await flushAsyncWork();
+    await flushAsyncWork();
 
     expect(URL.createObjectURL).toHaveBeenCalled();
     expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
     const clickedAnchor = HTMLAnchorElement.prototype.click.mock.instances.at(-1);
     expect(clickedAnchor.download).toBe("mikuproject-mermaid.svg");
+    expect(document.getElementById("xmlInput").value).not.toContain("<!-- edited -->");
+    expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 保存済み (2026-03-16 23:12)");
+    expect(document.getElementById("mermaidOutput").value).toContain("gantt");
     expect(document.getElementById("statusMessage").textContent).toContain("Mermaid SVG を保存しました");
   });
 


### PR DESCRIPTION
## 概要

- `XML Export` を含む export 系操作の前に、現在の内部モデルから XML テキストを同期するよう変更します。
- `XML を再生成` ボタンを削除し、保存前の暗黙再生成へ挙動を整理します。
- `SVG保存` も内部モデルからの再生成を前提に、単独で保存できるよう調整します。

## 変更内容

### Export フローの整理

- `XML Export` 実行時に、`xmlInput` の現在値ではなく、内部モデルから再生成した XML を保存対象に変更
- `CSV を生成` 実行前に、内部モデルから XML テキストを同期
- `XLSX Export` 実行前に、内部モデルから XML テキストを同期
- `WBS XLSX Export` 実行前に、内部モデルから XML テキストを同期
- `SVG保存` 実行前に、内部モデルから XML テキストを同期し、`Mermaid gantt` と SVG を再生成してから保存するよう変更

### UI の整理

- `Export` タブから `XML を再生成` ボタンを削除

### 実装整理

- `syncXmlTextFromModel` を追加し、内部モデルから `xmlInput` を同期する処理を共通化
- `downloadMermaidSvgBtn` の有効化条件を `currentMermaidSvg` 依存から `currentModel` 依存へ変更
- `SVG保存` の click ハンドラを非同期処理前提に変更

## テスト

- `tests/mikuproject-main.test.js` を更新
- `XML Export` が手編集テキストではなく再生成 XML を保存することを確認するテストを追加
- `CSV を生成`、`XLSX Export`、`WBS XLSX Export`、`SVG保存` の各操作で、手編集した XML コメントが保存・生成処理へ残らないことを確認するテストを追加
- 既存の `exports xml from the current model` テストは、`XML を再生成` ボタンではなく `XML Export` を通す形へ更新

## 補足

- `mikuproject.html` は生成物更新を含みます