### PR TITLE
Transform / Output 中心に UI を再整理し、Mermaid 生成と export フローを自動化

### DIFF
--- a/mikuproject-src.html
+++ b/mikuproject-src.html
@@ -36,7 +36,7 @@
         </button>
         <button type="button" class="md-top-tab" data-tab="output" role="tab" aria-selected="false" aria-controls="tabPanelOutput">
           <span class="md-top-tab-no">3</span>
-          <span class="md-top-tab-label">Export</span>
+          <span class="md-top-tab-label">Output</span>
         </button>
       </div>
 
@@ -50,10 +50,10 @@
         </div>
 
         <div class="md-panel-actions">
-          <button id="importXmlBtn" type="button" class="md-button md-button--primary">XML Import</button>
-          <button id="importXlsxBtn" type="button" class="md-button md-button--surface">XLSX Import</button>
-          <button id="parseCsvBtn" type="button" class="md-button md-button--surface">CSV を解析</button>
-          <button id="loadSampleBtn" type="button" class="md-button md-button--surface">サンプル読込</button>
+          <button id="importXmlBtn" type="button" class="md-button md-button--primary">MS Project XML</button>
+          <button id="importXlsxBtn" type="button" class="md-button md-button--surface">XLSX</button>
+          <button id="parseCsvBtn" type="button" class="md-button md-button--surface">CSV</button>
+          <button id="loadSampleBtn" type="button" class="md-button md-button--surface">サンプル</button>
           <input id="importXmlInput" type="file" accept=".xml,text/xml,application/xml" class="md-hidden" />
           <input id="importXlsxInput" type="file" accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" class="md-hidden" />
         </div>
@@ -114,11 +114,12 @@
           <p class="md-flow-section__text">内部モデル、要約、プレビューをここで確認します。</p>
         </div>
 
-        <div class="md-panel-actions">
-          <button id="parseXmlBtn" type="button" class="md-button md-button--surface">XML を解析</button>
-          <button id="exportMermaidBtn" type="button" class="md-button md-button--surface">Mermaid を生成</button>
-          <button id="roundTripBtn" type="button" class="md-button md-button--surface">再読込テスト</button>
-        </div>
+        <section>
+          <p id="mermaidSvgError" class="md-mermaid-error md-hidden" aria-live="polite"></p>
+          <div id="mermaidSvgPreview" class="md-mermaid-preview-stage">
+            <div class="md-preview-empty">Mermaid を生成すると、ここに SVG を表示します。</div>
+          </div>
+        </section>
 
         <div class="md-summary-grid">
           <div class="md-summary-card">
@@ -146,6 +147,10 @@
         <details class="md-debug-accordion">
           <summary class="md-debug-accordion__summary">デバッグ情報</summary>
           <div class="md-debug-accordion__body">
+            <div class="md-panel-actions">
+              <button id="roundTripBtn" type="button" class="md-button md-button--surface">再読込テスト</button>
+            </div>
+
             <div class="md-form-grid">
               <lht-text-field-help field-id="modelOutput" label="内部モデル(JSON)" rows="16" readonly></lht-text-field-help>
             </div>
@@ -176,16 +181,6 @@
                 <div id="calendarPreview" class="md-preview-list"></div>
               </section>
             </div>
-
-            <section class="md-preview-card">
-              <h3 class="md-preview-card__title">Mermaid Preview</h3>
-              <p id="mermaidSvgError" class="md-mermaid-error md-hidden" aria-live="polite"></p>
-              <div class="md-mermaid-preview-wrap">
-                <div id="mermaidSvgPreview" class="md-mermaid-preview-stage">
-                  <div class="md-preview-empty">Mermaid を生成すると、ここに SVG を表示します。</div>
-                </div>
-              </div>
-            </section>
           </div>
         </details>
 
@@ -203,17 +198,17 @@
         <div class="md-flow-section__header">
           <h2 class="md-flow-section__title">
             <span class="md-flow-section__step">3</span>
-            <span>Export</span>
+            <span>Output</span>
           </h2>
           <p class="md-flow-section__text">出力設定と生成結果の確認をここにまとめます。</p>
         </div>
 
         <div class="md-panel-actions">
-          <button id="downloadXmlBtn" type="button" class="md-button md-button--surface">XML Export</button>
-          <button id="downloadMermaidSvgBtn" type="button" class="md-button md-button--surface" disabled>SVG保存</button>
-          <button id="exportCsvBtn" type="button" class="md-button md-button--surface">CSV を生成</button>
-          <button id="exportXlsxBtn" type="button" class="md-button md-button--surface">XLSX Export</button>
-          <button id="exportWbsXlsxBtn" type="button" class="md-button md-button--surface">WBS XLSX Export</button>
+          <button id="downloadXmlBtn" type="button" class="md-button md-button--surface">MS Project XML</button>
+          <button id="exportXlsxBtn" type="button" class="md-button md-button--surface">XLSX</button>
+          <button id="exportWbsXlsxBtn" type="button" class="md-button md-button--surface">WBS XLSX</button>
+          <button id="downloadMermaidSvgBtn" type="button" class="md-button md-button--surface" disabled>SVG</button>
+          <button id="exportCsvBtn" type="button" class="md-button md-button--surface">CSV</button>
         </div>
 
         <details class="md-debug-accordion">

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -1618,18 +1618,9 @@ lht-index-card-link {
   display: none;
 }
 
-.md-mermaid-preview-wrap {
-  border: 1px solid var(--md-project-border);
-  border-radius: 18px;
-  background:
-    linear-gradient(180deg, rgba(251, 254, 255, 0.96) 0%, rgba(255, 255, 255, 0.98) 100%);
-  padding: 16px;
-  overflow: auto;
-  min-height: 18rem;
-}
-
 .md-mermaid-preview-stage {
   min-height: 16rem;
+  overflow: auto;
 }
 
 .md-mermaid-preview-stage svg {
@@ -1690,7 +1681,7 @@ lht-index-card-link {
         </button>
         <button type="button" class="md-top-tab" data-tab="output" role="tab" aria-selected="false" aria-controls="tabPanelOutput">
           <span class="md-top-tab-no">3</span>
-          <span class="md-top-tab-label">Export</span>
+          <span class="md-top-tab-label">Output</span>
         </button>
       </div>
 
@@ -1704,10 +1695,10 @@ lht-index-card-link {
         </div>
 
         <div class="md-panel-actions">
-          <button id="importXmlBtn" type="button" class="md-button md-button--primary">XML Import</button>
-          <button id="importXlsxBtn" type="button" class="md-button md-button--surface">XLSX Import</button>
-          <button id="parseCsvBtn" type="button" class="md-button md-button--surface">CSV を解析</button>
-          <button id="loadSampleBtn" type="button" class="md-button md-button--surface">サンプル読込</button>
+          <button id="importXmlBtn" type="button" class="md-button md-button--primary">MS Project XML</button>
+          <button id="importXlsxBtn" type="button" class="md-button md-button--surface">XLSX</button>
+          <button id="parseCsvBtn" type="button" class="md-button md-button--surface">CSV</button>
+          <button id="loadSampleBtn" type="button" class="md-button md-button--surface">サンプル</button>
           <input id="importXmlInput" type="file" accept=".xml,text/xml,application/xml" class="md-hidden" />
           <input id="importXlsxInput" type="file" accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" class="md-hidden" />
         </div>
@@ -1768,11 +1759,12 @@ lht-index-card-link {
           <p class="md-flow-section__text">内部モデル、要約、プレビューをここで確認します。</p>
         </div>
 
-        <div class="md-panel-actions">
-          <button id="parseXmlBtn" type="button" class="md-button md-button--surface">XML を解析</button>
-          <button id="exportMermaidBtn" type="button" class="md-button md-button--surface">Mermaid を生成</button>
-          <button id="roundTripBtn" type="button" class="md-button md-button--surface">再読込テスト</button>
-        </div>
+        <section>
+          <p id="mermaidSvgError" class="md-mermaid-error md-hidden" aria-live="polite"></p>
+          <div id="mermaidSvgPreview" class="md-mermaid-preview-stage">
+            <div class="md-preview-empty">Mermaid を生成すると、ここに SVG を表示します。</div>
+          </div>
+        </section>
 
         <div class="md-summary-grid">
           <div class="md-summary-card">
@@ -1800,6 +1792,10 @@ lht-index-card-link {
         <details class="md-debug-accordion">
           <summary class="md-debug-accordion__summary">デバッグ情報</summary>
           <div class="md-debug-accordion__body">
+            <div class="md-panel-actions">
+              <button id="roundTripBtn" type="button" class="md-button md-button--surface">再読込テスト</button>
+            </div>
+
             <div class="md-form-grid">
               <lht-text-field-help field-id="modelOutput" label="内部モデル(JSON)" rows="16" readonly></lht-text-field-help>
             </div>
@@ -1830,16 +1826,6 @@ lht-index-card-link {
                 <div id="calendarPreview" class="md-preview-list"></div>
               </section>
             </div>
-
-            <section class="md-preview-card">
-              <h3 class="md-preview-card__title">Mermaid Preview</h3>
-              <p id="mermaidSvgError" class="md-mermaid-error md-hidden" aria-live="polite"></p>
-              <div class="md-mermaid-preview-wrap">
-                <div id="mermaidSvgPreview" class="md-mermaid-preview-stage">
-                  <div class="md-preview-empty">Mermaid を生成すると、ここに SVG を表示します。</div>
-                </div>
-              </div>
-            </section>
           </div>
         </details>
 
@@ -1857,17 +1843,17 @@ lht-index-card-link {
         <div class="md-flow-section__header">
           <h2 class="md-flow-section__title">
             <span class="md-flow-section__step">3</span>
-            <span>Export</span>
+            <span>Output</span>
           </h2>
           <p class="md-flow-section__text">出力設定と生成結果の確認をここにまとめます。</p>
         </div>
 
         <div class="md-panel-actions">
-          <button id="downloadXmlBtn" type="button" class="md-button md-button--surface">XML Export</button>
-          <button id="downloadMermaidSvgBtn" type="button" class="md-button md-button--surface" disabled>SVG保存</button>
-          <button id="exportCsvBtn" type="button" class="md-button md-button--surface">CSV を生成</button>
-          <button id="exportXlsxBtn" type="button" class="md-button md-button--surface">XLSX Export</button>
-          <button id="exportWbsXlsxBtn" type="button" class="md-button md-button--surface">WBS XLSX Export</button>
+          <button id="downloadXmlBtn" type="button" class="md-button md-button--surface">MS Project XML</button>
+          <button id="exportXlsxBtn" type="button" class="md-button md-button--surface">XLSX</button>
+          <button id="exportWbsXlsxBtn" type="button" class="md-button md-button--surface">WBS XLSX</button>
+          <button id="downloadMermaidSvgBtn" type="button" class="md-button md-button--surface" disabled>SVG</button>
+          <button id="exportCsvBtn" type="button" class="md-button md-button--surface">CSV</button>
         </div>
 
         <details class="md-debug-accordion">
@@ -12491,6 +12477,8 @@ globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default;
     let lastSavedXmlText = "";
     let lastSavedXmlStamp = "";
     let currentTabId = "input";
+    let isXmlSourceDirty = true;
+    let isRefreshingTransformTab = false;
     function getElement(id) {
         const element = document.getElementById(id);
         if (!element) {
@@ -12510,7 +12498,7 @@ globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default;
     function getTabPanels() {
         return Array.from(document.querySelectorAll(".md-tab-panel[data-tab-panel]"));
     }
-    function setActiveTab(tabId) {
+    function setActiveTab(tabId, options = {}) {
         currentTabId = tabId;
         for (const button of getTabButtons()) {
             const isActive = button.dataset.tab === tabId;
@@ -12520,6 +12508,31 @@ globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default;
         }
         for (const panel of getTabPanels()) {
             panel.hidden = panel.dataset.tabPanel !== tabId;
+        }
+        if (tabId === "transform" && !options.skipTransformRefresh && !isRefreshingTransformTab) {
+            void refreshTransformTab().catch((error) => {
+                setStatus(error instanceof Error ? error.message : "Transform の更新に失敗しました");
+            });
+        }
+    }
+    async function refreshTransformTab() {
+        if (isRefreshingTransformTab) {
+            return;
+        }
+        isRefreshingTransformTab = true;
+        try {
+            if (!currentModel || isXmlSourceDirty) {
+                const xmlText = getTextArea("xmlInput").value.trim();
+                if (!xmlText) {
+                    setStatus("XML が空です");
+                    return;
+                }
+                parseCurrentXml({ silent: true });
+            }
+            await exportCurrentMermaid({ silent: true });
+        }
+        finally {
+            isRefreshingTransformTab = false;
         }
     }
     function moveTabFocus(currentButton, direction) {
@@ -12772,6 +12785,7 @@ globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default;
     function syncXmlTextFromModel(model) {
         const xmlText = mikuprojectXml.exportMsProjectXml(model);
         getTextArea("xmlInput").value = xmlText;
+        isXmlSourceDirty = false;
         refreshXmlSaveState();
         return xmlText;
     }
@@ -13105,7 +13119,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     `) : []);
     }
     function loadSample() {
+        currentModel = null;
         getTextArea("xmlInput").value = mikuprojectXml.SAMPLE_XML;
+        isXmlSourceDirty = true;
         markXmlDirty();
         setStatus("サンプル XML を読み込みました");
         setActiveTab("input");
@@ -13118,13 +13134,15 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         getTextArea("xmlInput").value = xmlText;
         markXmlDirty();
         currentModel = mikuprojectXml.importMsProjectXml(xmlText);
+        isXmlSourceDirty = false;
         const issues = mikuprojectXml.validateProjectModel(currentModel);
         updateSummary(currentModel);
         renderValidationIssues(issues);
         renderXlsxImportSummary([]);
         setStatus(issues.length > 0 ? `XML ファイルを読み込んで解析しました。検証で ${issues.length} 件の問題があります` : "XML ファイルを読み込んで解析しました");
         showToast("XML を読み込んで解析しました");
-        setActiveTab("transform");
+        setActiveTab("transform", { skipTransformRefresh: true });
+        await exportCurrentMermaid({ silent: true });
     }
     function ensureCurrentModel() {
         if (currentModel) {
@@ -13135,24 +13153,28 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             throw new Error("内部モデルがありません");
         }
         currentModel = mikuprojectXml.importMsProjectXml(xmlText);
+        isXmlSourceDirty = false;
         return currentModel;
     }
-    function parseCurrentXml() {
+    function parseCurrentXml(options = {}) {
         const xmlText = getTextArea("xmlInput").value.trim();
         if (!xmlText) {
             setStatus("XML が空です");
             return;
         }
         currentModel = mikuprojectXml.importMsProjectXml(xmlText);
+        isXmlSourceDirty = false;
         const issues = mikuprojectXml.validateProjectModel(currentModel);
         updateSummary(currentModel);
         renderValidationIssues(issues);
         renderXlsxImportSummary([]);
-        setStatus(issues.length > 0 ? `XML を解析しました。検証で ${issues.length} 件の問題があります` : "XML を内部モデルへ変換しました");
-        showToast("XML を解析しました");
-        setActiveTab("transform");
+        if (!options.silent) {
+            setStatus(issues.length > 0 ? `XML を解析しました。検証で ${issues.length} 件の問題があります` : "XML を内部モデルへ変換しました");
+            showToast("XML を解析しました");
+        }
+        setActiveTab("transform", { skipTransformRefresh: true });
     }
-    async function exportCurrentMermaid() {
+    async function exportCurrentMermaid(options = {}) {
         if (!currentModel) {
             setStatus("内部モデルがありません");
             return;
@@ -13160,9 +13182,11 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         const mermaidText = mikuprojectXml.exportMermaidGantt(currentModel);
         getTextArea("mermaidOutput").value = mermaidText;
         await renderMermaidPreview(mermaidText);
-        setStatus("内部モデルから Mermaid gantt を生成し、SVG プレビューを更新しました");
-        showToast("Mermaid を生成しました");
-        setActiveTab("transform");
+        if (!options.silent) {
+            setStatus("内部モデルから Mermaid gantt を生成し、SVG プレビューを更新しました");
+            showToast("Mermaid を生成しました");
+        }
+        setActiveTab("transform", { skipTransformRefresh: true });
     }
     function exportCurrentCsv() {
         const model = ensureCurrentModel();
@@ -13251,24 +13275,28 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         const summaryText = result.changes.length > 0
             ? `XLSX を読み込んで ${result.changes.length} 件の変更を反映しました。XML は再生成済みで、必要なら XML Export で保存できます`
             : "XLSX に反映対象の変更はありませんでした。XML は未変更です";
+        isXmlSourceDirty = false;
         setStatus(issues.length > 0 ? `${summaryText}。検証で ${issues.length} 件の問題があります` : summaryText);
         showToast("XLSX を反映しました");
-        setActiveTab("transform");
+        setActiveTab("transform", { skipTransformRefresh: true });
+        await exportCurrentMermaid({ silent: true });
     }
-    function parseCurrentCsv() {
+    async function parseCurrentCsv() {
         const csvText = getTextArea("csvInput").value.trim();
         if (!csvText) {
             setStatus("CSV が空です");
             return;
         }
         currentModel = mikuprojectXml.importCsvParentId(csvText);
+        isXmlSourceDirty = false;
         const issues = mikuprojectXml.validateProjectModel(currentModel);
         updateSummary(currentModel);
         renderValidationIssues(issues);
         renderXlsxImportSummary([]);
         setStatus(issues.length > 0 ? `CSV を解析しました。検証で ${issues.length} 件の問題があります` : "CSV + ParentID を内部モデルへ変換しました");
         showToast("CSV を解析しました");
-        setActiveTab("transform");
+        setActiveTab("transform", { skipTransformRefresh: true });
+        await exportCurrentMermaid({ silent: true });
     }
     function downloadCurrentXml() {
         const model = ensureCurrentModel();
@@ -13338,19 +13366,6 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         getElement("importXmlBtn").addEventListener("click", () => {
             getElement("importXmlInput").click();
         });
-        getElement("parseXmlBtn").addEventListener("click", () => {
-            try {
-                parseCurrentXml();
-            }
-            catch (error) {
-                setStatus(error instanceof Error ? error.message : "XML 解析に失敗しました");
-            }
-        });
-        getElement("exportMermaidBtn").addEventListener("click", () => {
-            void exportCurrentMermaid().catch((error) => {
-                setStatus(error instanceof Error ? error.message : "Mermaid 生成に失敗しました");
-            });
-        });
         getElement("downloadMermaidSvgBtn").addEventListener("click", () => {
             void downloadCurrentMermaidSvg().catch((error) => {
                 setStatus(error instanceof Error ? error.message : "SVG 保存に失敗しました");
@@ -13388,9 +13403,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
                 setStatus(error instanceof Error ? error.message : "WBS 祝日入力のリセットに失敗しました");
             }
         });
-        getElement("parseCsvBtn").addEventListener("click", () => {
+        getElement("parseCsvBtn").addEventListener("click", async () => {
             try {
-                parseCurrentCsv();
+                await parseCurrentCsv();
             }
             catch (error) {
                 setStatus(error instanceof Error ? error.message : "CSV 解析に失敗しました");
@@ -13446,6 +13461,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             }
         });
         getTextArea("xmlInput").addEventListener("input", () => {
+            isXmlSourceDirty = true;
             refreshXmlSaveState();
         });
     }
@@ -13460,6 +13476,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         loadSample();
     }
     globalThis.__mikuprojectMainTestHooks = {
+        parseCurrentXml,
+        exportCurrentMermaid,
         renderValidationIssues,
         renderXlsxImportSummary,
         updateFeedbackVisibility

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -557,18 +557,9 @@
   display: none;
 }
 
-.md-mermaid-preview-wrap {
-  border: 1px solid var(--md-project-border);
-  border-radius: 18px;
-  background:
-    linear-gradient(180deg, rgba(251, 254, 255, 0.96) 0%, rgba(255, 255, 255, 0.98) 100%);
-  padding: 16px;
-  overflow: auto;
-  min-height: 18rem;
-}
-
 .md-mermaid-preview-stage {
   min-height: 16rem;
+  overflow: auto;
 }
 
 .md-mermaid-preview-stage svg {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -26,6 +26,8 @@
     let lastSavedXmlText = "";
     let lastSavedXmlStamp = "";
     let currentTabId = "input";
+    let isXmlSourceDirty = true;
+    let isRefreshingTransformTab = false;
     function getElement(id) {
         const element = document.getElementById(id);
         if (!element) {
@@ -45,7 +47,7 @@
     function getTabPanels() {
         return Array.from(document.querySelectorAll(".md-tab-panel[data-tab-panel]"));
     }
-    function setActiveTab(tabId) {
+    function setActiveTab(tabId, options = {}) {
         currentTabId = tabId;
         for (const button of getTabButtons()) {
             const isActive = button.dataset.tab === tabId;
@@ -55,6 +57,31 @@
         }
         for (const panel of getTabPanels()) {
             panel.hidden = panel.dataset.tabPanel !== tabId;
+        }
+        if (tabId === "transform" && !options.skipTransformRefresh && !isRefreshingTransformTab) {
+            void refreshTransformTab().catch((error) => {
+                setStatus(error instanceof Error ? error.message : "Transform の更新に失敗しました");
+            });
+        }
+    }
+    async function refreshTransformTab() {
+        if (isRefreshingTransformTab) {
+            return;
+        }
+        isRefreshingTransformTab = true;
+        try {
+            if (!currentModel || isXmlSourceDirty) {
+                const xmlText = getTextArea("xmlInput").value.trim();
+                if (!xmlText) {
+                    setStatus("XML が空です");
+                    return;
+                }
+                parseCurrentXml({ silent: true });
+            }
+            await exportCurrentMermaid({ silent: true });
+        }
+        finally {
+            isRefreshingTransformTab = false;
         }
     }
     function moveTabFocus(currentButton, direction) {
@@ -307,6 +334,7 @@
     function syncXmlTextFromModel(model) {
         const xmlText = mikuprojectXml.exportMsProjectXml(model);
         getTextArea("xmlInput").value = xmlText;
+        isXmlSourceDirty = false;
         refreshXmlSaveState();
         return xmlText;
     }
@@ -640,7 +668,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     `) : []);
     }
     function loadSample() {
+        currentModel = null;
         getTextArea("xmlInput").value = mikuprojectXml.SAMPLE_XML;
+        isXmlSourceDirty = true;
         markXmlDirty();
         setStatus("サンプル XML を読み込みました");
         setActiveTab("input");
@@ -653,13 +683,15 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         getTextArea("xmlInput").value = xmlText;
         markXmlDirty();
         currentModel = mikuprojectXml.importMsProjectXml(xmlText);
+        isXmlSourceDirty = false;
         const issues = mikuprojectXml.validateProjectModel(currentModel);
         updateSummary(currentModel);
         renderValidationIssues(issues);
         renderXlsxImportSummary([]);
         setStatus(issues.length > 0 ? `XML ファイルを読み込んで解析しました。検証で ${issues.length} 件の問題があります` : "XML ファイルを読み込んで解析しました");
         showToast("XML を読み込んで解析しました");
-        setActiveTab("transform");
+        setActiveTab("transform", { skipTransformRefresh: true });
+        await exportCurrentMermaid({ silent: true });
     }
     function ensureCurrentModel() {
         if (currentModel) {
@@ -670,24 +702,28 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             throw new Error("内部モデルがありません");
         }
         currentModel = mikuprojectXml.importMsProjectXml(xmlText);
+        isXmlSourceDirty = false;
         return currentModel;
     }
-    function parseCurrentXml() {
+    function parseCurrentXml(options = {}) {
         const xmlText = getTextArea("xmlInput").value.trim();
         if (!xmlText) {
             setStatus("XML が空です");
             return;
         }
         currentModel = mikuprojectXml.importMsProjectXml(xmlText);
+        isXmlSourceDirty = false;
         const issues = mikuprojectXml.validateProjectModel(currentModel);
         updateSummary(currentModel);
         renderValidationIssues(issues);
         renderXlsxImportSummary([]);
-        setStatus(issues.length > 0 ? `XML を解析しました。検証で ${issues.length} 件の問題があります` : "XML を内部モデルへ変換しました");
-        showToast("XML を解析しました");
-        setActiveTab("transform");
+        if (!options.silent) {
+            setStatus(issues.length > 0 ? `XML を解析しました。検証で ${issues.length} 件の問題があります` : "XML を内部モデルへ変換しました");
+            showToast("XML を解析しました");
+        }
+        setActiveTab("transform", { skipTransformRefresh: true });
     }
-    async function exportCurrentMermaid() {
+    async function exportCurrentMermaid(options = {}) {
         if (!currentModel) {
             setStatus("内部モデルがありません");
             return;
@@ -695,9 +731,11 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         const mermaidText = mikuprojectXml.exportMermaidGantt(currentModel);
         getTextArea("mermaidOutput").value = mermaidText;
         await renderMermaidPreview(mermaidText);
-        setStatus("内部モデルから Mermaid gantt を生成し、SVG プレビューを更新しました");
-        showToast("Mermaid を生成しました");
-        setActiveTab("transform");
+        if (!options.silent) {
+            setStatus("内部モデルから Mermaid gantt を生成し、SVG プレビューを更新しました");
+            showToast("Mermaid を生成しました");
+        }
+        setActiveTab("transform", { skipTransformRefresh: true });
     }
     function exportCurrentCsv() {
         const model = ensureCurrentModel();
@@ -786,24 +824,28 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         const summaryText = result.changes.length > 0
             ? `XLSX を読み込んで ${result.changes.length} 件の変更を反映しました。XML は再生成済みで、必要なら XML Export で保存できます`
             : "XLSX に反映対象の変更はありませんでした。XML は未変更です";
+        isXmlSourceDirty = false;
         setStatus(issues.length > 0 ? `${summaryText}。検証で ${issues.length} 件の問題があります` : summaryText);
         showToast("XLSX を反映しました");
-        setActiveTab("transform");
+        setActiveTab("transform", { skipTransformRefresh: true });
+        await exportCurrentMermaid({ silent: true });
     }
-    function parseCurrentCsv() {
+    async function parseCurrentCsv() {
         const csvText = getTextArea("csvInput").value.trim();
         if (!csvText) {
             setStatus("CSV が空です");
             return;
         }
         currentModel = mikuprojectXml.importCsvParentId(csvText);
+        isXmlSourceDirty = false;
         const issues = mikuprojectXml.validateProjectModel(currentModel);
         updateSummary(currentModel);
         renderValidationIssues(issues);
         renderXlsxImportSummary([]);
         setStatus(issues.length > 0 ? `CSV を解析しました。検証で ${issues.length} 件の問題があります` : "CSV + ParentID を内部モデルへ変換しました");
         showToast("CSV を解析しました");
-        setActiveTab("transform");
+        setActiveTab("transform", { skipTransformRefresh: true });
+        await exportCurrentMermaid({ silent: true });
     }
     function downloadCurrentXml() {
         const model = ensureCurrentModel();
@@ -873,19 +915,6 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         getElement("importXmlBtn").addEventListener("click", () => {
             getElement("importXmlInput").click();
         });
-        getElement("parseXmlBtn").addEventListener("click", () => {
-            try {
-                parseCurrentXml();
-            }
-            catch (error) {
-                setStatus(error instanceof Error ? error.message : "XML 解析に失敗しました");
-            }
-        });
-        getElement("exportMermaidBtn").addEventListener("click", () => {
-            void exportCurrentMermaid().catch((error) => {
-                setStatus(error instanceof Error ? error.message : "Mermaid 生成に失敗しました");
-            });
-        });
         getElement("downloadMermaidSvgBtn").addEventListener("click", () => {
             void downloadCurrentMermaidSvg().catch((error) => {
                 setStatus(error instanceof Error ? error.message : "SVG 保存に失敗しました");
@@ -923,9 +952,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
                 setStatus(error instanceof Error ? error.message : "WBS 祝日入力のリセットに失敗しました");
             }
         });
-        getElement("parseCsvBtn").addEventListener("click", () => {
+        getElement("parseCsvBtn").addEventListener("click", async () => {
             try {
-                parseCurrentCsv();
+                await parseCurrentCsv();
             }
             catch (error) {
                 setStatus(error instanceof Error ? error.message : "CSV 解析に失敗しました");
@@ -981,6 +1010,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             }
         });
         getTextArea("xmlInput").addEventListener("input", () => {
+            isXmlSourceDirty = true;
             refreshXmlSaveState();
         });
     }
@@ -995,6 +1025,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         loadSample();
     }
     globalThis.__mikuprojectMainTestHooks = {
+        parseCurrentXml,
+        exportCurrentMermaid,
         renderValidationIssues,
         renderXlsxImportSummary,
         updateFeedbackVisibility

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -88,6 +88,8 @@
   let lastSavedXmlText = "";
   let lastSavedXmlStamp = "";
   let currentTabId: "input" | "transform" | "output" = "input";
+  let isXmlSourceDirty = true;
+  let isRefreshingTransformTab = false;
 
   function getElement<T extends HTMLElement>(id: string): T {
     const element = document.getElementById(id);
@@ -113,7 +115,10 @@
     return Array.from(document.querySelectorAll<HTMLElement>(".md-tab-panel[data-tab-panel]"));
   }
 
-  function setActiveTab(tabId: "input" | "transform" | "output"): void {
+  function setActiveTab(
+    tabId: "input" | "transform" | "output",
+    options: { skipTransformRefresh?: boolean } = {}
+  ): void {
     currentTabId = tabId;
     for (const button of getTabButtons()) {
       const isActive = button.dataset.tab === tabId;
@@ -123,6 +128,31 @@
     }
     for (const panel of getTabPanels()) {
       panel.hidden = panel.dataset.tabPanel !== tabId;
+    }
+    if (tabId === "transform" && !options.skipTransformRefresh && !isRefreshingTransformTab) {
+      void refreshTransformTab().catch((error) => {
+        setStatus(error instanceof Error ? error.message : "Transform の更新に失敗しました");
+      });
+    }
+  }
+
+  async function refreshTransformTab(): Promise<void> {
+    if (isRefreshingTransformTab) {
+      return;
+    }
+    isRefreshingTransformTab = true;
+    try {
+      if (!currentModel || isXmlSourceDirty) {
+        const xmlText = getTextArea("xmlInput").value.trim();
+        if (!xmlText) {
+          setStatus("XML が空です");
+          return;
+        }
+        parseCurrentXml({ silent: true });
+      }
+      await exportCurrentMermaid({ silent: true });
+    } finally {
+      isRefreshingTransformTab = false;
     }
   }
 
@@ -405,6 +435,7 @@
   function syncXmlTextFromModel(model: ProjectModel): string {
     const xmlText = mikuprojectXml.exportMsProjectXml(model);
     getTextArea("xmlInput").value = xmlText;
+    isXmlSourceDirty = false;
     refreshXmlSaveState();
     return xmlText;
   }
@@ -780,7 +811,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
   }
 
   function loadSample(): void {
+    currentModel = null;
     getTextArea("xmlInput").value = mikuprojectXml.SAMPLE_XML;
+    isXmlSourceDirty = true;
     markXmlDirty();
     setStatus("サンプル XML を読み込みました");
     setActiveTab("input");
@@ -794,13 +827,15 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     getTextArea("xmlInput").value = xmlText;
     markXmlDirty();
     currentModel = mikuprojectXml.importMsProjectXml(xmlText);
+    isXmlSourceDirty = false;
     const issues = mikuprojectXml.validateProjectModel(currentModel);
     updateSummary(currentModel);
     renderValidationIssues(issues);
     renderXlsxImportSummary([]);
     setStatus(issues.length > 0 ? `XML ファイルを読み込んで解析しました。検証で ${issues.length} 件の問題があります` : "XML ファイルを読み込んで解析しました");
     showToast("XML を読み込んで解析しました");
-    setActiveTab("transform");
+    setActiveTab("transform", { skipTransformRefresh: true });
+    await exportCurrentMermaid({ silent: true });
   }
 
   function ensureCurrentModel(): ProjectModel {
@@ -812,26 +847,30 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
       throw new Error("内部モデルがありません");
     }
     currentModel = mikuprojectXml.importMsProjectXml(xmlText);
+    isXmlSourceDirty = false;
     return currentModel;
   }
 
-  function parseCurrentXml(): void {
+  function parseCurrentXml(options: { silent?: boolean } = {}): void {
     const xmlText = getTextArea("xmlInput").value.trim();
     if (!xmlText) {
       setStatus("XML が空です");
       return;
     }
     currentModel = mikuprojectXml.importMsProjectXml(xmlText);
+    isXmlSourceDirty = false;
     const issues = mikuprojectXml.validateProjectModel(currentModel);
     updateSummary(currentModel);
     renderValidationIssues(issues);
     renderXlsxImportSummary([]);
-    setStatus(issues.length > 0 ? `XML を解析しました。検証で ${issues.length} 件の問題があります` : "XML を内部モデルへ変換しました");
-    showToast("XML を解析しました");
-    setActiveTab("transform");
+    if (!options.silent) {
+      setStatus(issues.length > 0 ? `XML を解析しました。検証で ${issues.length} 件の問題があります` : "XML を内部モデルへ変換しました");
+      showToast("XML を解析しました");
+    }
+    setActiveTab("transform", { skipTransformRefresh: true });
   }
 
-  async function exportCurrentMermaid(): Promise<void> {
+  async function exportCurrentMermaid(options: { silent?: boolean } = {}): Promise<void> {
     if (!currentModel) {
       setStatus("内部モデルがありません");
       return;
@@ -839,9 +878,11 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     const mermaidText = mikuprojectXml.exportMermaidGantt(currentModel);
     getTextArea("mermaidOutput").value = mermaidText;
     await renderMermaidPreview(mermaidText);
-    setStatus("内部モデルから Mermaid gantt を生成し、SVG プレビューを更新しました");
-    showToast("Mermaid を生成しました");
-    setActiveTab("transform");
+    if (!options.silent) {
+      setStatus("内部モデルから Mermaid gantt を生成し、SVG プレビューを更新しました");
+      showToast("Mermaid を生成しました");
+    }
+    setActiveTab("transform", { skipTransformRefresh: true });
   }
 
   function exportCurrentCsv(): void {
@@ -940,25 +981,29 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     const summaryText = result.changes.length > 0
       ? `XLSX を読み込んで ${result.changes.length} 件の変更を反映しました。XML は再生成済みで、必要なら XML Export で保存できます`
       : "XLSX に反映対象の変更はありませんでした。XML は未変更です";
+    isXmlSourceDirty = false;
     setStatus(issues.length > 0 ? `${summaryText}。検証で ${issues.length} 件の問題があります` : summaryText);
     showToast("XLSX を反映しました");
-    setActiveTab("transform");
+    setActiveTab("transform", { skipTransformRefresh: true });
+    await exportCurrentMermaid({ silent: true });
   }
 
-  function parseCurrentCsv(): void {
+  async function parseCurrentCsv(): Promise<void> {
     const csvText = getTextArea("csvInput").value.trim();
     if (!csvText) {
       setStatus("CSV が空です");
       return;
     }
     currentModel = mikuprojectXml.importCsvParentId(csvText);
+    isXmlSourceDirty = false;
     const issues = mikuprojectXml.validateProjectModel(currentModel);
     updateSummary(currentModel);
     renderValidationIssues(issues);
     renderXlsxImportSummary([]);
     setStatus(issues.length > 0 ? `CSV を解析しました。検証で ${issues.length} 件の問題があります` : "CSV + ParentID を内部モデルへ変換しました");
     showToast("CSV を解析しました");
-    setActiveTab("transform");
+    setActiveTab("transform", { skipTransformRefresh: true });
+    await exportCurrentMermaid({ silent: true });
   }
 
   function downloadCurrentXml(): void {
@@ -1032,18 +1077,6 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     getElement<HTMLButtonElement>("importXmlBtn").addEventListener("click", () => {
       getElement<HTMLInputElement>("importXmlInput").click();
     });
-    getElement<HTMLButtonElement>("parseXmlBtn").addEventListener("click", () => {
-      try {
-        parseCurrentXml();
-      } catch (error) {
-        setStatus(error instanceof Error ? error.message : "XML 解析に失敗しました");
-      }
-    });
-    getElement<HTMLButtonElement>("exportMermaidBtn").addEventListener("click", () => {
-      void exportCurrentMermaid().catch((error) => {
-        setStatus(error instanceof Error ? error.message : "Mermaid 生成に失敗しました");
-      });
-    });
     getElement<HTMLButtonElement>("downloadMermaidSvgBtn").addEventListener("click", () => {
       void downloadCurrentMermaidSvg().catch((error) => {
         setStatus(error instanceof Error ? error.message : "SVG 保存に失敗しました");
@@ -1077,9 +1110,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         setStatus(error instanceof Error ? error.message : "WBS 祝日入力のリセットに失敗しました");
       }
     });
-    getElement<HTMLButtonElement>("parseCsvBtn").addEventListener("click", () => {
+    getElement<HTMLButtonElement>("parseCsvBtn").addEventListener("click", async () => {
       try {
-        parseCurrentCsv();
+        await parseCurrentCsv();
       } catch (error) {
         setStatus(error instanceof Error ? error.message : "CSV 解析に失敗しました");
       }
@@ -1128,6 +1161,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
       }
     });
     getTextArea("xmlInput").addEventListener("input", () => {
+      isXmlSourceDirty = true;
       refreshXmlSaveState();
     });
   }
@@ -1145,6 +1179,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
 
   (globalThis as typeof globalThis & {
     __mikuprojectMainTestHooks?: {
+      parseCurrentXml: () => void;
+      exportCurrentMermaid: () => Promise<void>;
       renderValidationIssues: (issues: ValidationIssue[]) => void;
       renderXlsxImportSummary: (changes: Array<{
         scope: "project" | "tasks" | "resources" | "assignments" | "calendars";
@@ -1157,6 +1193,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
       updateFeedbackVisibility: () => void;
     };
   }).__mikuprojectMainTestHooks = {
+    parseCurrentXml,
+    exportCurrentMermaid,
     renderValidationIssues,
     renderXlsxImportSummary,
     updateFeedbackVisibility

--- a/tests/mikuproject-main.test.js
+++ b/tests/mikuproject-main.test.js
@@ -48,19 +48,16 @@ const dependencyXml = readFileSync(
 
 function mountDom() {
   document.body.innerHTML = `
-    <button id="importXmlBtn" type="button">XML Import</button>
-    <button id="importXlsxBtn" type="button">XLSX Import</button>
-    <button id="parseCsvBtn" type="button">CSV を解析</button>
-    <button id="loadSampleBtn" type="button">サンプル読込</button>
-    <button id="parseXmlBtn" type="button">XML を解析</button>
-    <button id="exportMermaidBtn" type="button">Mermaid を生成</button>
-    <button id="downloadMermaidSvgBtn" type="button" disabled>SVG保存</button>
-    <button id="exportCsvBtn" type="button">CSV を生成</button>
-    <button id="exportXlsxBtn" type="button">XLSX Export</button>
-    <button id="exportWbsXlsxBtn" type="button">WBS XLSX Export</button>
+    <button id="importXmlBtn" type="button">MS Project XML</button>
+    <button id="importXlsxBtn" type="button">XLSX</button>
+    <button id="parseCsvBtn" type="button">CSV</button>
+    <button id="loadSampleBtn" type="button">サンプル</button>
+    <button id="exportXlsxBtn" type="button">XLSX</button>
+    <button id="exportWbsXlsxBtn" type="button">WBS XLSX</button>
+    <button id="downloadMermaidSvgBtn" type="button" disabled>SVG</button>
+    <button id="exportCsvBtn" type="button">CSV</button>
     <button id="resetWbsHolidayDatesBtn" type="button">WBS 祝日を既定値へ戻す</button>
-    <button id="downloadXmlBtn" type="button">XML Export</button>
-    <button id="roundTripBtn" type="button">再読込テスト</button>
+    <button id="downloadXmlBtn" type="button">MS Project XML</button>
     <input id="importXmlInput" type="file" />
     <input id="importXlsxInput" type="file" />
     <div id="statusMessage"></div>
@@ -118,9 +115,12 @@ function mountDom() {
       <div id="summaryResourceCount"></div>
       <div id="summaryAssignmentCount"></div>
       <div id="summaryCalendarCount"></div>
+      <div id="mermaidSvgError" class="md-hidden"></div>
+      <div id="mermaidSvgPreview"></div>
       <details class="md-debug-accordion">
         <summary class="md-debug-accordion__summary">デバッグ情報</summary>
         <div class="md-debug-accordion__body">
+          <button id="roundTripBtn" type="button">再読込テスト</button>
           <textarea id="modelOutput"></textarea>
           <textarea id="mermaidOutput"></textarea>
           <div id="projectPreview"></div>
@@ -128,8 +128,6 @@ function mountDom() {
           <div id="resourcePreview"></div>
           <div id="assignmentPreview"></div>
           <div id="calendarPreview"></div>
-          <div id="mermaidSvgError" class="md-hidden"></div>
-          <div id="mermaidSvgPreview"></div>
         </div>
       </details>
       <div class="md-feedback-stack md-hidden">
@@ -191,6 +189,14 @@ function bootXmlModule() {
 
 function getMainHooks() {
   return globalThis.__mikuprojectMainTestHooks;
+}
+
+function parseXmlViaHook() {
+  getMainHooks().parseCurrentXml();
+}
+
+async function exportMermaidViaHook() {
+  await getMainHooks().exportCurrentMermaid();
 }
 
 const SAMPLE_HOLIDAY_COUNT = 89;
@@ -269,7 +275,7 @@ describe("mikuproject main", () => {
     expect(document.querySelector(".md-feedback-stack")?.classList.contains("md-hidden")).toBe(true);
   });
 
-  it("switches top tabs and toggles panels", () => {
+  it("switches top tabs and toggles panels", async () => {
     bootPage();
 
     expect(document.getElementById("tabPanelInput").hidden).toBe(false);
@@ -277,9 +283,13 @@ describe("mikuproject main", () => {
     expect(document.getElementById("tabPanelOutput").hidden).toBe(true);
 
     document.querySelector('.md-top-tab[data-tab="transform"]').click();
+    await flushAsyncWork();
+    await flushAsyncWork();
     expect(document.getElementById("tabPanelInput").hidden).toBe(true);
     expect(document.getElementById("tabPanelTransform").hidden).toBe(false);
     expect(document.getElementById("tabPanelOutput").hidden).toBe(true);
+    expect(document.getElementById("summaryProjectName").textContent).toBe("Sample Project");
+    expect(document.getElementById("mermaidOutput").value).toContain("gantt");
 
     document.querySelector('.md-top-tab[data-tab="output"]').click();
     expect(document.getElementById("tabPanelInput").hidden).toBe(true);
@@ -290,7 +300,7 @@ describe("mikuproject main", () => {
   it("parses xml into internal model summary", () => {
     bootPage();
 
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
 
     expect(document.getElementById("summaryProjectName").textContent).toBe("Sample Project");
     expect(document.getElementById("summaryTaskCount").textContent).toBe("3");
@@ -453,7 +463,7 @@ describe("mikuproject main", () => {
   it("exports xml from the current model", () => {
     bootPage();
 
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
     document.getElementById("downloadXmlBtn").click();
 
     const xmlText = document.getElementById("xmlInput").value;
@@ -601,9 +611,8 @@ describe("mikuproject main", () => {
   it("exports mermaid gantt from the current model", async () => {
     bootPage();
 
-    document.getElementById("parseXmlBtn").click();
-    document.getElementById("exportMermaidBtn").click();
-    await flushAsyncWork();
+    parseXmlViaHook();
+    await exportMermaidViaHook();
 
     const mermaidText = document.getElementById("mermaidOutput").value;
     expect(mermaidText).toContain("gantt");
@@ -703,7 +712,7 @@ describe("mikuproject main", () => {
   it("exports csv with parent id from the current model", () => {
     bootPage();
 
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
     document.getElementById("downloadXmlBtn").click();
     const xmlInput = document.getElementById("xmlInput");
     xmlInput.value = `${xmlInput.value}\n<!-- edited -->`;
@@ -720,7 +729,7 @@ describe("mikuproject main", () => {
     expect(document.getElementById("statusMessage").textContent).toContain("CSV + ParentID を生成しました");
   });
 
-  it("parses csv with parent id into internal model summary", () => {
+  it("parses csv with parent id into internal model summary", async () => {
     bootPage();
 
     document.getElementById("csvInput").value = [
@@ -731,6 +740,7 @@ describe("mikuproject main", () => {
     ].join("\n");
 
     document.getElementById("parseCsvBtn").click();
+    await Promise.resolve();
 
     expect(document.getElementById("summaryProjectName").textContent).toBe("CSV Imported Project");
     expect(document.getElementById("summaryTaskCount").textContent).toBe("3");
@@ -742,13 +752,15 @@ describe("mikuproject main", () => {
     expect(document.getElementById("resourcePreview").textContent).toContain("Miku");
     expect(document.getElementById("assignmentPreview").textContent).toContain("Task=2 (Design)");
     expect(document.getElementById("assignmentPreview").textContent).toContain("Resource=1 (Miku)");
+    expect(document.getElementById("mermaidOutput").value).toContain("gantt");
+    expect(document.getElementById("mermaidSvgPreview").innerHTML).toContain("<svg");
     expect(document.getElementById("statusMessage").textContent).toContain("CSV + ParentID を内部モデルへ変換しました");
   });
 
   it("passes round-trip check", () => {
     bootPage();
 
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
     document.getElementById("roundTripBtn").click();
 
     expect(document.getElementById("statusMessage").textContent).toContain("再読込テストに成功");
@@ -776,13 +788,15 @@ describe("mikuproject main", () => {
     expect(document.getElementById("xmlInput").value).toContain("<Name>Imported</Name>");
     expect(document.getElementById("summaryProjectName").textContent).toBe("Imported");
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Imported\"");
+    expect(document.getElementById("mermaidOutput").value).toContain("gantt");
+    expect(document.getElementById("mermaidSvgPreview").innerHTML).toContain("<svg");
     expect(document.getElementById("statusMessage").textContent).toContain("XML ファイルを読み込んで解析しました");
   });
 
   it("downloads current xlsx", () => {
     bootPage();
 
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
     document.getElementById("downloadXmlBtn").click();
     const xmlInput = document.getElementById("xmlInput");
     xmlInput.value = `${xmlInput.value}\n<!-- edited -->`;
@@ -802,7 +816,7 @@ describe("mikuproject main", () => {
     bootPage();
     const exportSpy = vi.spyOn(globalThis.__mikuprojectWbsXlsx, "exportWbsWorkbook");
 
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
     document.getElementById("downloadXmlBtn").click();
     const xmlInput = document.getElementById("xmlInput");
     xmlInput.value = `${xmlInput.value}\n<!-- edited -->`;
@@ -833,7 +847,7 @@ describe("mikuproject main", () => {
     bootPage();
     const exportSpy = vi.spyOn(globalThis.__mikuprojectWbsXlsx, "exportWbsWorkbook");
 
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
     document.getElementById("wbsExtraHolidayDatesInput").value = "2026-03-20, 2026-03-20\n2026-03-21";
     document.getElementById("exportWbsXlsxBtn").click();
     const defaultHolidayDates = getDefaultSampleHolidayDates();
@@ -861,7 +875,7 @@ describe("mikuproject main", () => {
     bootPage();
     const exportSpy = vi.spyOn(globalThis.__mikuprojectWbsXlsx, "exportWbsWorkbook");
 
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
     document.getElementById("wbsDisplayDaysBeforeInput").value = "1";
     document.getElementById("wbsDisplayDaysAfterInput").value = "2";
     document.getElementById("exportWbsXlsxBtn").click();
@@ -882,7 +896,7 @@ describe("mikuproject main", () => {
     bootPage();
     const exportSpy = vi.spyOn(globalThis.__mikuprojectWbsXlsx, "exportWbsWorkbook");
 
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
     document.getElementById("wbsDisplayDaysBeforeInput").value = "1";
     document.getElementById("wbsDisplayDaysAfterInput").value = "2";
     document.getElementById("wbsBusinessDayRangeInput").checked = true;
@@ -903,7 +917,7 @@ describe("mikuproject main", () => {
     bootPage();
     const exportSpy = vi.spyOn(globalThis.__mikuprojectWbsXlsx, "exportWbsWorkbook");
 
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
     document.getElementById("wbsBusinessDayProgressInput").checked = true;
     document.getElementById("exportWbsXlsxBtn").click();
     const defaultHolidayDates = getDefaultSampleHolidayDates();
@@ -921,7 +935,7 @@ describe("mikuproject main", () => {
   it("fills wbs holiday input from model defaults when xml is parsed", () => {
     bootPage();
 
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
     const defaultHolidayDates = getDefaultSampleHolidayDates();
 
     expect(document.getElementById("wbsHolidayDatesInput").value.split("\n")).toEqual(defaultHolidayDates);
@@ -933,7 +947,7 @@ describe("mikuproject main", () => {
   it("resets wbs holiday input back to model defaults", () => {
     bootPage();
 
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
     document.getElementById("wbsExtraHolidayDatesInput").value = "2026-03-25\n2026-03-26";
     document.getElementById("resetWbsHolidayDatesBtn").click();
     const defaultHolidayDates = getDefaultSampleHolidayDates();
@@ -947,7 +961,7 @@ describe("mikuproject main", () => {
 
   it("imports xlsx edits back into the current model and xml", async () => {
     bootPage();
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
     document.getElementById("downloadXmlBtn").click();
     expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 保存済み (2026-03-16 23:12)");
 
@@ -996,7 +1010,7 @@ describe("mikuproject main", () => {
 
   it("imports project sheet edits back into the current model and xml", async () => {
     bootPage();
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
 
     const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
     const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
@@ -1058,7 +1072,7 @@ describe("mikuproject main", () => {
 
   it("reports when xlsx import has no applicable changes", async () => {
     bootPage();
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
 
     const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
     const originalXml = document.getElementById("xmlInput").value;
@@ -1086,14 +1100,22 @@ describe("mikuproject main", () => {
 
     expect(document.getElementById("statusMessage").textContent).toContain("XLSX に反映対象の変更はありませんでした");
     expect(document.getElementById("statusMessage").textContent).toContain("XML は未変更です");
-    expect(document.getElementById("xmlInput").value).toBe(originalXml);
+    expect(
+      globalThis.__mikuprojectXml.normalizeProjectModel(
+        globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+      )
+    ).toEqual(
+      globalThis.__mikuprojectXml.normalizeProjectModel(
+        globalThis.__mikuprojectXml.importMsProjectXml(originalXml)
+      )
+    );
     expect(document.getElementById("xlsxImportSummary").textContent).toBe("");
     expect(document.getElementById("xlsxImportSummary").classList.contains("md-hidden")).toBe(true);
   });
 
   it("ignores edits in unsupported xlsx columns and sheets", async () => {
     bootPage();
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
 
     const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
     const originalXml = document.getElementById("xmlInput").value;
@@ -1135,7 +1157,7 @@ describe("mikuproject main", () => {
 
   it("ignores calendar WeekDays, Exceptions, and WorkWeeks edits in xlsx import", async () => {
     bootPage();
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
 
     const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
     const originalXml = document.getElementById("xmlInput").value;
@@ -1253,7 +1275,7 @@ describe("mikuproject main", () => {
   it("exports regenerated xml instead of manual textarea edits when a model exists", async () => {
     bootPage();
 
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
     const xmlInput = document.getElementById("xmlInput");
     xmlInput.value = `${xmlInput.value}\n<!-- edited -->`;
     xmlInput.dispatchEvent(new Event("input"));
@@ -1294,7 +1316,7 @@ describe("mikuproject main", () => {
   it("downloads rendered mermaid svg", async () => {
     bootPage();
 
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
     document.getElementById("downloadXmlBtn").click();
     const xmlInput = document.getElementById("xmlInput");
     xmlInput.value = `${xmlInput.value}\n<!-- edited -->`;
@@ -1322,7 +1344,7 @@ describe("mikuproject main", () => {
       "<ResourceUID>1</ResourceUID>",
       "<ResourceUID>99</ResourceUID>"
     );
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
     document.getElementById("roundTripBtn").click();
 
     expect(document.getElementById("statusMessage").textContent).toContain("Assignment ResourceUID");
@@ -1340,7 +1362,7 @@ describe("mikuproject main", () => {
       "<CalendarUID>1</CalendarUID>",
       "<CalendarUID>99</CalendarUID>"
     );
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
 
     expect(document.getElementById("statusMessage").textContent).toContain("検証で");
     expect(document.getElementById("validationIssues").textContent).toContain("Project");
@@ -1354,7 +1376,7 @@ describe("mikuproject main", () => {
       "<CalendarUID>1</CalendarUID>\n      <Priority>700</Priority>",
       "<CalendarUID>99</CalendarUID>\n      <Priority>700</Priority>"
     );
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
 
     expect(document.getElementById("statusMessage").textContent).toContain("検証で");
     expect(document.getElementById("validationIssues").textContent).toContain("Task CalendarUID");
@@ -1369,7 +1391,7 @@ describe("mikuproject main", () => {
       "<PercentComplete>100</PercentComplete>",
       "<PercentComplete>120</PercentComplete>"
     );
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
 
     expect(document.getElementById("validationIssues").textContent).toContain("PercentComplete");
   });
@@ -1381,7 +1403,7 @@ describe("mikuproject main", () => {
       "<Start>2026-03-18T09:00:00</Start>\n      <Finish>2026-03-20T18:00:00</Finish>",
       "<Start>2026-03-21T09:00:00</Start>\n      <Finish>2026-03-20T18:00:00</Finish>"
     );
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
 
     expect(document.getElementById("validationIssues").textContent).toContain("Task Start が Finish より後");
   });
@@ -1393,7 +1415,7 @@ describe("mikuproject main", () => {
       "<PredecessorUID>2</PredecessorUID>",
       "<PredecessorUID>99</PredecessorUID>"
     );
-    document.getElementById("parseXmlBtn").click();
+    parseXmlViaHook();
     document.getElementById("roundTripBtn").click();
 
     expect(document.getElementById("statusMessage").textContent).toContain("PredecessorUID");


### PR DESCRIPTION
## 概要

- `Input / Transform / Output` の各タブで、操作ボタン、説明、デバッグ情報の配置を見直します。
- `Transform` タブ表示時に `XML` 解析と `Mermaid` 生成を暗黙実行するよう変更します。
- export 系操作の前に、内部モデルから `XML` を暗黙再生成する挙動へ統一します。

## 変更内容

### タブと操作導線の整理

- タブ名を `Input / Transform / Output` に整理
- `Input` のボタン順を `MS Project XML / XLSX / CSV / サンプル` に変更
- `Input` の primary を `MS Project XML` に変更
- `Output` のボタン順を `MS Project XML / XLSX / WBS XLSX / SVG / CSV` に変更
- `Output` のボタン名を短い表記へ変更

### Transform の自動処理

- `Transform` タブを開くタイミングで、暗黙に `XML` 解析と `Mermaid` 生成を実行するよう変更
- その前提で `XML を解析` と `Mermaid を生成` ボタンを削除
- `XML` 読込、`XLSX` 取込、`CSV` 解析から `Transform` へ遷移した場合でも、初回表示で `Mermaid Preview` が表示されるよう修正
- 自動実行時は silent 扱いにして、取込結果のステータス表示を不要に上書きしないよう調整

### Export フローの整理

- `XML Export` 実行時に、テキストエリアの手編集内容ではなく、内部モデルから再生成した `XML` を保存するよう変更
- `SVG`、`CSV`、`XLSX`、`WBS XLSX` についても、クリック時に内部モデルから `XML` を同期してから出力するよう変更
- `SVG` 保存時は `Mermaid gantt` と SVG も再生成してから保存するよう変更
- `XML を再生成` ボタンを削除

### 情報配置の見直し

- `XLSX 編集の扱い` の説明一式を `(i)` ヘルプ内へ集約
- `Input` に `デバッグ情報` アコーディオンを追加し、`MS Project XML` と `CSV + ParentID` 入力を格納
- `XML 保存状態` を `デバッグ情報` の下へ移動
- `Transform` に `デバッグ情報` アコーディオンを追加し、`内部モデル(JSON)`、`Mermaid gantt`、`Project / Tasks / Resources / Assignments / Calendars`、`再読込テスト` を格納
- `Transform` の `取込結果` を末尾へ移動
- `Output` に `設定` アコーディオンを追加し、`WBS XLSX の祝日指定` を格納
- `Output` に `デバッグ情報` アコーディオンを追加し、`CSV + ParentID` 出力を格納
- 各アコーディオンはデフォルトで閉じる構成

### Mermaid Preview の見直し

- `Mermaid Preview` の見出し文言を除去
- `Mermaid Preview` を囲っていた角丸の枠を除去
- 要約カード群を `Mermaid` 表示の下へ移動

### テストと生成物

- `tests/mikuproject-main.test.js` の DOM 構造と挙動確認を新レイアウトへ追従
- `XML` 読込と `CSV` 解析後に、初回の `Transform` 表示で `Mermaid` が生成済みであることを確認するテストを追加
- `mikuproject.html` は生成物更新を含む

## テスト

- `npm run build:js`
- `npm run build:html`
- `npx vitest run tests/mikuproject-main.test.js tests/mikuproject-single-html.test.js`