### PR TITLE
UI テーマを紫系アクセントへ調整し、ヒーローに GitHub 導線と AI 仕様リンクを追加

### DIFF
--- a/mikuproject-src.html
+++ b/mikuproject-src.html
@@ -10,12 +10,22 @@
   <script src="lht-cmn/js/components.js" defer></script>
 </head>
 <body class="md-page">
+  <main class="md-shell">
+  <svg width="0" height="0" aria-hidden="true" focusable="false" class="md-icons">
+    <symbol id="md-icon-github" viewBox="0 0 16 16">
+      <path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.5 7.5 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8 8 0 0 0 16 8c0-4.42-3.58-8-8-8Z"></path>
+    </symbol>
+  </svg>
   <div class="md-surface-card md-card">
     <lht-page-hero
       title="mikuproject"
       icon="📋"
       help-label="mikuproject の説明"
       help-wide
+      action-href="https://github.com/igapyon/mikuproject"
+      action-label="GitHub"
+      action-aria-label="Open mikuproject repository"
+      action-icon-id="md-icon-github"
       menu-home-href="README.md"
       menu-home-label="README">
       MS Project XML を読み込み、内部モデルへ落として、再度 MS Project XML を生成するための実験アプリです。<br><br>
@@ -98,7 +108,7 @@
             生成AIとの会話は別途行います。生成AIが返した `project_draft_view` は、JSON ファイルとして開くか、JSON テキストを貼り付けてここから取り込みます。
           </p>
           <p class="md-note-card__text">
-            (i) まず生成AIに [docs/mikuproject-ai-json-spec.md](/Users/igapyon/Documents/git/mikuproject/docs/mikuproject-ai-json-spec.md) を読み込ませます。
+            (i) まず生成AIに <a class="md-inline-link" href="https://raw.githubusercontent.com/igapyon/mikuproject/refs/heads/devel/docs/mikuproject-ai-json-spec.md" target="_blank" rel="noopener noreferrer">mikuproject-ai-json-spec.md</a> を読み込ませます。
           </p>
           <p class="md-note-card__text">
             (ii) その前提で生成AIに `project_draft_view` を作らせます。
@@ -346,6 +356,7 @@
 
     <lht-toast id="toast"></lht-toast>
   </div>
+  </main>
   <script src="src/js/types.js"></script>
   <script src="src/js/excel-io.js"></script>
   <script src="src/js/msproject-xml.js"></script>

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -1061,11 +1061,18 @@ lht-index-card-link {
 
 :root {
   color-scheme: light;
-  --md-project-accent: #0f766e;
-  --md-project-accent-soft: #dff6f3;
-  --md-project-border: #d5dee7;
+  --md-project-accent: #6750a4;
+  --md-project-accent-soft: #f3edff;
+  --md-project-border: rgba(148, 163, 184, 0.2);
   --md-project-surface: rgba(255, 255, 255, 0.94);
-  --md-project-shadow: 0 24px 60px rgba(32, 54, 84, 0.12);
+  --md-project-shadow: 0 18px 48px rgba(15, 23, 42, 0.08);
+  --md-sys-color-primary: #6750a4;
+  --md-sys-color-surface: #ffffff;
+  --md-sys-color-on-surface: #102a43;
+  --md-sys-color-on-surface-variant: #52606d;
+  --md-sys-color-outline: #bdb7c8;
+  --md-sys-color-state-layer: rgba(103, 80, 164, 0.08);
+  --md-sys-color-focus-ring: rgba(103, 80, 164, 0.22);
 }
 
 .md-page {
@@ -1073,22 +1080,101 @@ lht-index-card-link {
   margin: 0;
   padding: 24px;
   background:
-    radial-gradient(circle at top right, rgba(172, 233, 223, 0.55), transparent 28%),
-    radial-gradient(circle at top left, rgba(206, 230, 255, 0.5), transparent 24%),
-    linear-gradient(180deg, #f5f8fb 0%, #eef3f8 100%);
-  color: #1c1b1f;
+    radial-gradient(circle at top left, rgba(9, 132, 227, 0.12), transparent 38%),
+    linear-gradient(180deg, #f7fbff 0%, #eef4f9 100%);
+  color: #1f2933;
   box-sizing: border-box;
 }
 
-.md-surface-card.md-card {
+.md-shell {
   max-width: 1180px;
   margin: 0 auto;
+}
+
+.md-icons {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}
+
+.md-surface-card.md-card {
   background: var(--md-project-surface);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(215, 223, 232, 0.95);
-  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 24px;
   box-shadow: var(--md-project-shadow);
   padding: 28px;
+}
+
+lht-page-hero {
+  background: linear-gradient(180deg, #f6fbff 0%, #fbfdff 100%);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+lht-page-hero .lht-page-hero__title {
+  color: #102a43;
+}
+
+lht-page-hero .lht-page-hero__subtitle {
+  color: #52606d;
+}
+
+lht-page-hero .lht-page-hero__icon {
+  background: rgba(103, 80, 164, 0.14);
+}
+
+.ms-hero-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  color: #514a5f;
+  text-decoration: none;
+  line-height: 1;
+  transition:
+    transform 0.16s ease,
+    color 0.16s ease,
+    background 0.16s ease,
+    opacity 0.16s ease;
+}
+
+.ms-hero-link:hover,
+.ms-hero-link:focus-visible {
+  transform: translateY(-1px);
+  color: #2f1f52;
+  background: #f0edf5;
+  opacity: 1;
+}
+
+.ms-hero-link span {
+  display: none;
+}
+
+.ms-btn-icon {
+  width: 1.05rem;
+  height: 1.05rem;
+  flex: 0 0 auto;
+}
+
+.md-icon-btn {
+  background: #f0edf5;
+  color: #3f3b46;
+}
+
+.md-icon-btn:hover {
+  background: #ebe6f3;
+}
+
+.md-menu-panel {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: #ffffff;
+}
+
+.md-menu-link:hover {
+  background: #f2edf8;
 }
 
 .md-section {
@@ -1101,9 +1187,9 @@ lht-index-card-link {
 }
 
 .md-flow-section {
-  border: 1px solid rgba(214, 222, 235, 0.96);
-  border-radius: 24px;
-  background: linear-gradient(180deg, #fbfcff 0%, #ffffff 100%);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(245, 248, 252, 0.94) 100%);
   padding: 18px 20px;
   display: grid;
   gap: 16px;
@@ -1120,7 +1206,7 @@ lht-index-card-link {
   align-items: center;
   gap: 0.55rem;
   flex-wrap: wrap;
-  color: #294851;
+  color: #102a43;
   font-size: 1.04rem;
   font-weight: 800;
 }
@@ -1132,7 +1218,7 @@ lht-index-card-link {
   width: 1.75rem;
   height: 1.75rem;
   border-radius: 999px;
-  background: rgba(15, 118, 110, 0.12);
+  background: rgba(103, 80, 164, 0.12);
   color: var(--md-project-accent);
   font-size: 0.82rem;
   font-weight: 800;
@@ -1140,7 +1226,7 @@ lht-index-card-link {
 
 .md-flow-section__text {
   margin: 0;
-  color: #58707d;
+  color: #52606d;
   font-size: 0.88rem;
   line-height: 1.55;
 }
@@ -1163,8 +1249,8 @@ lht-index-card-link {
   min-height: 3rem;
   border: 1px solid var(--md-project-border);
   border-radius: 999px;
-  background: #f6fbfb;
-  color: #44616a;
+  background: #f3f7fb;
+  color: #52606d;
   font: inherit;
   font-weight: 700;
   cursor: pointer;
@@ -1177,10 +1263,10 @@ lht-index-card-link {
 }
 
 .md-top-tab.is-active {
-  border-color: rgba(15, 118, 110, 0.45);
-  color: #0f5d56;
-  background: rgba(15, 118, 110, 0.14);
-  box-shadow: 0 4px 10px rgba(15, 118, 110, 0.14);
+  border-color: rgba(103, 80, 164, 0.28);
+  color: #4f378b;
+  background: #f3edff;
+  box-shadow: 0 4px 10px rgba(103, 80, 164, 0.14);
 }
 
 .md-top-tab-no {
@@ -1190,15 +1276,15 @@ lht-index-card-link {
   width: 1.55rem;
   height: 1.55rem;
   border-radius: 999px;
-  background: #e2f1ef;
-  color: #406761;
+  background: #d9e2ec;
+  color: #334e68;
   font-size: 0.8rem;
   font-weight: 800;
 }
 
 .md-top-tab.is-active .md-top-tab-no {
-  background: rgba(15, 118, 110, 0.2);
-  color: #0f5d56;
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
 }
 
 .md-top-tab-label {
@@ -1219,8 +1305,8 @@ lht-index-card-link {
   border-radius: 999px;
   padding: 0.38rem 1.02rem;
   border: 1px solid var(--md-project-border);
-  background: transparent;
-  color: #3f3b46;
+  background: linear-gradient(180deg, #ffffff 0%, #f3f7fb 100%);
+  color: #102a43;
   font: inherit;
   font-weight: 600;
   font-size: 0.9rem;
@@ -1230,25 +1316,26 @@ lht-index-card-link {
 
 .md-button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 4px 10px rgba(15, 118, 110, 0.18);
+  box-shadow: 0 4px 12px rgba(103, 80, 164, 0.12);
 }
 
 .md-button--primary {
-  background: var(--md-project-accent);
-  border-color: transparent;
+  background: linear-gradient(135deg, #6750a4, #7b61c7);
+  border-color: rgba(103, 80, 164, 0.45);
   color: #fff;
+  box-shadow: 0 8px 20px rgba(103, 80, 164, 0.22);
 }
 
 .md-button--surface {
-  background: #fff;
+  background: #d9e2ec;
 }
 
 .md-status {
   border: 1px solid var(--md-project-border);
-  border-radius: 16px;
-  background: linear-gradient(180deg, #fbfeff 0%, #fff 100%);
+  border-radius: 12px;
+  background: rgba(230, 240, 255, 0.72);
   padding: 14px 16px;
-  color: #35515d;
+  color: #102a43;
   font-weight: 600;
 }
 
@@ -1347,9 +1434,9 @@ lht-index-card-link {
 }
 
 .md-note-card {
-  border: 1px solid #cfe2dc;
+  border: 1px solid rgba(148, 163, 184, 0.18);
   border-radius: 18px;
-  background: linear-gradient(180deg, #f3fbf9 0%, #ffffff 100%);
+  background: rgba(255, 255, 255, 0.72);
   padding: 16px 18px;
 }
 
@@ -1363,7 +1450,7 @@ lht-index-card-link {
   margin: 0 0 8px;
   font-size: 0.98rem;
   font-weight: 700;
-  color: #1f4f4a;
+  color: #102a43;
 }
 
 .md-note-card__title-row .md-note-card__title {
@@ -1372,9 +1459,67 @@ lht-index-card-link {
 
 .md-note-card__text {
   margin: 0;
-  color: #3f5f5b;
+  color: #52606d;
   font-size: 0.88rem;
   line-height: 1.6;
+}
+
+.md-inline-link {
+  color: #4f378b;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.md-inline-link:hover,
+.md-inline-link:focus-visible {
+  text-decoration: underline;
+}
+
+md-outlined-text-field.md-outlined-field {
+  --md-outlined-text-field-outline-color: #bdb7c8;
+  --md-outlined-field-outline-color: #bdb7c8;
+  --md-outlined-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-field-hover-outline-color: #b1aac0;
+  --md-outlined-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-field-focus-outline-color: #6c3eea;
+  --md-outlined-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-text-field-caret-color: #6c3eea;
+  --md-outlined-field-caret-color: #6c3eea;
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+md-outlined-select.md-outlined-field {
+  --md-outlined-select-text-field-outline-color: #bdb7c8;
+  --md-outlined-select-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-select-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-select-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-select-text-field-caret-color: #6c3eea;
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+.md-help-icon-button,
+.md-help-icon-button--fallback {
+  --md-focus-ring-color: rgba(103, 80, 164, 0.22);
+}
+
+.md-help-icon-button--fallback {
+  background: #f0edf5;
+  color: #3f3b46;
 }
 
 .md-note-card__text + .md-note-card__text,
@@ -1412,9 +1557,9 @@ lht-index-card-link {
 
 .md-debug-accordion {
   margin-top: 16px;
-  border: 1px solid #d6e3ef;
+  border: 1px solid rgba(148, 163, 184, 0.18);
   border-radius: 18px;
-  background: linear-gradient(180deg, #f8fbfe 0%, #ffffff 100%);
+  background: rgba(255, 255, 255, 0.72);
   overflow: clip;
 }
 
@@ -1424,7 +1569,7 @@ lht-index-card-link {
   padding: 14px 18px;
   font-size: 0.92rem;
   font-weight: 700;
-  color: #315267;
+  color: #102a43;
   display: flex;
   align-items: center;
   gap: 10px;
@@ -1437,7 +1582,7 @@ lht-index-card-link {
 .md-debug-accordion__summary::before {
   content: "▸";
   font-size: 0.9rem;
-  color: #4c7b97;
+  color: #52606d;
   transition: transform 160ms ease;
 }
 
@@ -1447,7 +1592,7 @@ lht-index-card-link {
 
 .md-debug-accordion__body {
   padding: 0 18px 18px;
-  border-top: 1px solid #e2ebf3;
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
 }
 
 .md-debug-accordion__body .md-form-grid + .md-form-grid {
@@ -1540,12 +1685,12 @@ lht-index-card-link {
 .md-summary-card {
   border: 1px solid var(--md-project-border);
   border-radius: 18px;
-  background: linear-gradient(180deg, #f9fffe 0%, #fff 100%);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(245, 248, 252, 0.94) 100%);
   padding: 16px;
 }
 
 .md-summary-label {
-  color: #4f6771;
+  color: #52606d;
   font-size: 0.84rem;
   font-weight: 700;
 }
@@ -1554,7 +1699,7 @@ lht-index-card-link {
   margin-top: 6px;
   font-size: 1.1rem;
   font-weight: 700;
-  color: #1f3137;
+  color: #102a43;
 }
 
 .md-preview-grid {
@@ -1566,7 +1711,7 @@ lht-index-card-link {
 .md-preview-card {
   border: 1px solid var(--md-project-border);
   border-radius: 18px;
-  background: linear-gradient(180deg, #fbfeff 0%, #fff 100%);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(245, 248, 252, 0.94) 100%);
   padding: 16px;
 }
 
@@ -1574,7 +1719,7 @@ lht-index-card-link {
   margin: 0 0 10px;
   font-size: 0.98rem;
   font-weight: 700;
-  color: #244148;
+  color: #102a43;
 }
 
 .md-preview-list {
@@ -1583,7 +1728,7 @@ lht-index-card-link {
 }
 
 .md-preview-item {
-  border: 1px solid #dfe7ee;
+  border: 1px solid rgba(148, 163, 184, 0.18);
   border-radius: 14px;
   background: #fff;
   padding: 10px 12px;
@@ -1592,7 +1737,7 @@ lht-index-card-link {
 .md-preview-item__title {
   font-size: 0.9rem;
   font-weight: 700;
-  color: #1f3137;
+  color: #102a43;
 }
 
 .md-preview-item__meta {
@@ -1645,7 +1790,7 @@ lht-index-card-link {
 
 @media (max-width: 640px) {
   .md-page {
-    padding: 14px;
+    padding: 16px;
   }
 
   .md-summary-grid {
@@ -1655,12 +1800,22 @@ lht-index-card-link {
   </style>
 </head>
 <body class="md-page">
+  <main class="md-shell">
+  <svg width="0" height="0" aria-hidden="true" focusable="false" class="md-icons">
+    <symbol id="md-icon-github" viewBox="0 0 16 16">
+      <path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.5 7.5 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8 8 0 0 0 16 8c0-4.42-3.58-8-8-8Z"></path>
+    </symbol>
+  </svg>
   <div class="md-surface-card md-card">
     <lht-page-hero
       title="mikuproject"
       icon="📋"
       help-label="mikuproject の説明"
       help-wide
+      action-href="https://github.com/igapyon/mikuproject"
+      action-label="GitHub"
+      action-aria-label="Open mikuproject repository"
+      action-icon-id="md-icon-github"
       menu-home-href="README.md"
       menu-home-label="README">
       MS Project XML を読み込み、内部モデルへ落として、再度 MS Project XML を生成するための実験アプリです。<br><br>
@@ -1743,7 +1898,7 @@ lht-index-card-link {
             生成AIとの会話は別途行います。生成AIが返した `project_draft_view` は、JSON ファイルとして開くか、JSON テキストを貼り付けてここから取り込みます。
           </p>
           <p class="md-note-card__text">
-            (i) まず生成AIに [docs/mikuproject-ai-json-spec.md](/Users/igapyon/Documents/git/mikuproject/docs/mikuproject-ai-json-spec.md) を読み込ませます。
+            (i) まず生成AIに <a class="md-inline-link" href="https://raw.githubusercontent.com/igapyon/mikuproject/refs/heads/devel/docs/mikuproject-ai-json-spec.md" target="_blank" rel="noopener noreferrer">mikuproject-ai-json-spec.md</a> を読み込ませます。
           </p>
           <p class="md-note-card__text">
             (ii) その前提で生成AIに `project_draft_view` を作らせます。
@@ -1991,6 +2146,7 @@ lht-index-card-link {
 
     <lht-toast id="toast"></lht-toast>
   </div>
+  </main>
   
   
   

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -1,10 +1,17 @@
 :root {
   color-scheme: light;
-  --md-project-accent: #0f766e;
-  --md-project-accent-soft: #dff6f3;
-  --md-project-border: #d5dee7;
+  --md-project-accent: #6750a4;
+  --md-project-accent-soft: #f3edff;
+  --md-project-border: rgba(148, 163, 184, 0.2);
   --md-project-surface: rgba(255, 255, 255, 0.94);
-  --md-project-shadow: 0 24px 60px rgba(32, 54, 84, 0.12);
+  --md-project-shadow: 0 18px 48px rgba(15, 23, 42, 0.08);
+  --md-sys-color-primary: #6750a4;
+  --md-sys-color-surface: #ffffff;
+  --md-sys-color-on-surface: #102a43;
+  --md-sys-color-on-surface-variant: #52606d;
+  --md-sys-color-outline: #bdb7c8;
+  --md-sys-color-state-layer: rgba(103, 80, 164, 0.08);
+  --md-sys-color-focus-ring: rgba(103, 80, 164, 0.22);
 }
 
 .md-page {
@@ -12,22 +19,101 @@
   margin: 0;
   padding: 24px;
   background:
-    radial-gradient(circle at top right, rgba(172, 233, 223, 0.55), transparent 28%),
-    radial-gradient(circle at top left, rgba(206, 230, 255, 0.5), transparent 24%),
-    linear-gradient(180deg, #f5f8fb 0%, #eef3f8 100%);
-  color: #1c1b1f;
+    radial-gradient(circle at top left, rgba(9, 132, 227, 0.12), transparent 38%),
+    linear-gradient(180deg, #f7fbff 0%, #eef4f9 100%);
+  color: #1f2933;
   box-sizing: border-box;
 }
 
-.md-surface-card.md-card {
+.md-shell {
   max-width: 1180px;
   margin: 0 auto;
+}
+
+.md-icons {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}
+
+.md-surface-card.md-card {
   background: var(--md-project-surface);
-  backdrop-filter: blur(10px);
-  border: 1px solid rgba(215, 223, 232, 0.95);
-  border-radius: 28px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 24px;
   box-shadow: var(--md-project-shadow);
   padding: 28px;
+}
+
+lht-page-hero {
+  background: linear-gradient(180deg, #f6fbff 0%, #fbfdff 100%);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+}
+
+lht-page-hero .lht-page-hero__title {
+  color: #102a43;
+}
+
+lht-page-hero .lht-page-hero__subtitle {
+  color: #52606d;
+}
+
+lht-page-hero .lht-page-hero__icon {
+  background: rgba(103, 80, 164, 0.14);
+}
+
+.ms-hero-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  color: #514a5f;
+  text-decoration: none;
+  line-height: 1;
+  transition:
+    transform 0.16s ease,
+    color 0.16s ease,
+    background 0.16s ease,
+    opacity 0.16s ease;
+}
+
+.ms-hero-link:hover,
+.ms-hero-link:focus-visible {
+  transform: translateY(-1px);
+  color: #2f1f52;
+  background: #f0edf5;
+  opacity: 1;
+}
+
+.ms-hero-link span {
+  display: none;
+}
+
+.ms-btn-icon {
+  width: 1.05rem;
+  height: 1.05rem;
+  flex: 0 0 auto;
+}
+
+.md-icon-btn {
+  background: #f0edf5;
+  color: #3f3b46;
+}
+
+.md-icon-btn:hover {
+  background: #ebe6f3;
+}
+
+.md-menu-panel {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: #ffffff;
+}
+
+.md-menu-link:hover {
+  background: #f2edf8;
 }
 
 .md-section {
@@ -40,9 +126,9 @@
 }
 
 .md-flow-section {
-  border: 1px solid rgba(214, 222, 235, 0.96);
-  border-radius: 24px;
-  background: linear-gradient(180deg, #fbfcff 0%, #ffffff 100%);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(245, 248, 252, 0.94) 100%);
   padding: 18px 20px;
   display: grid;
   gap: 16px;
@@ -59,7 +145,7 @@
   align-items: center;
   gap: 0.55rem;
   flex-wrap: wrap;
-  color: #294851;
+  color: #102a43;
   font-size: 1.04rem;
   font-weight: 800;
 }
@@ -71,7 +157,7 @@
   width: 1.75rem;
   height: 1.75rem;
   border-radius: 999px;
-  background: rgba(15, 118, 110, 0.12);
+  background: rgba(103, 80, 164, 0.12);
   color: var(--md-project-accent);
   font-size: 0.82rem;
   font-weight: 800;
@@ -79,7 +165,7 @@
 
 .md-flow-section__text {
   margin: 0;
-  color: #58707d;
+  color: #52606d;
   font-size: 0.88rem;
   line-height: 1.55;
 }
@@ -102,8 +188,8 @@
   min-height: 3rem;
   border: 1px solid var(--md-project-border);
   border-radius: 999px;
-  background: #f6fbfb;
-  color: #44616a;
+  background: #f3f7fb;
+  color: #52606d;
   font: inherit;
   font-weight: 700;
   cursor: pointer;
@@ -116,10 +202,10 @@
 }
 
 .md-top-tab.is-active {
-  border-color: rgba(15, 118, 110, 0.45);
-  color: #0f5d56;
-  background: rgba(15, 118, 110, 0.14);
-  box-shadow: 0 4px 10px rgba(15, 118, 110, 0.14);
+  border-color: rgba(103, 80, 164, 0.28);
+  color: #4f378b;
+  background: #f3edff;
+  box-shadow: 0 4px 10px rgba(103, 80, 164, 0.14);
 }
 
 .md-top-tab-no {
@@ -129,15 +215,15 @@
   width: 1.55rem;
   height: 1.55rem;
   border-radius: 999px;
-  background: #e2f1ef;
-  color: #406761;
+  background: #d9e2ec;
+  color: #334e68;
   font-size: 0.8rem;
   font-weight: 800;
 }
 
 .md-top-tab.is-active .md-top-tab-no {
-  background: rgba(15, 118, 110, 0.2);
-  color: #0f5d56;
+  background: rgba(103, 80, 164, 0.18);
+  color: #4f378b;
 }
 
 .md-top-tab-label {
@@ -158,8 +244,8 @@
   border-radius: 999px;
   padding: 0.38rem 1.02rem;
   border: 1px solid var(--md-project-border);
-  background: transparent;
-  color: #3f3b46;
+  background: linear-gradient(180deg, #ffffff 0%, #f3f7fb 100%);
+  color: #102a43;
   font: inherit;
   font-weight: 600;
   font-size: 0.9rem;
@@ -169,25 +255,26 @@
 
 .md-button:hover {
   transform: translateY(-1px);
-  box-shadow: 0 4px 10px rgba(15, 118, 110, 0.18);
+  box-shadow: 0 4px 12px rgba(103, 80, 164, 0.12);
 }
 
 .md-button--primary {
-  background: var(--md-project-accent);
-  border-color: transparent;
+  background: linear-gradient(135deg, #6750a4, #7b61c7);
+  border-color: rgba(103, 80, 164, 0.45);
   color: #fff;
+  box-shadow: 0 8px 20px rgba(103, 80, 164, 0.22);
 }
 
 .md-button--surface {
-  background: #fff;
+  background: #d9e2ec;
 }
 
 .md-status {
   border: 1px solid var(--md-project-border);
-  border-radius: 16px;
-  background: linear-gradient(180deg, #fbfeff 0%, #fff 100%);
+  border-radius: 12px;
+  background: rgba(230, 240, 255, 0.72);
   padding: 14px 16px;
-  color: #35515d;
+  color: #102a43;
   font-weight: 600;
 }
 
@@ -286,9 +373,9 @@
 }
 
 .md-note-card {
-  border: 1px solid #cfe2dc;
+  border: 1px solid rgba(148, 163, 184, 0.18);
   border-radius: 18px;
-  background: linear-gradient(180deg, #f3fbf9 0%, #ffffff 100%);
+  background: rgba(255, 255, 255, 0.72);
   padding: 16px 18px;
 }
 
@@ -302,7 +389,7 @@
   margin: 0 0 8px;
   font-size: 0.98rem;
   font-weight: 700;
-  color: #1f4f4a;
+  color: #102a43;
 }
 
 .md-note-card__title-row .md-note-card__title {
@@ -311,9 +398,67 @@
 
 .md-note-card__text {
   margin: 0;
-  color: #3f5f5b;
+  color: #52606d;
   font-size: 0.88rem;
   line-height: 1.6;
+}
+
+.md-inline-link {
+  color: #4f378b;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.md-inline-link:hover,
+.md-inline-link:focus-visible {
+  text-decoration: underline;
+}
+
+md-outlined-text-field.md-outlined-field {
+  --md-outlined-text-field-outline-color: #bdb7c8;
+  --md-outlined-field-outline-color: #bdb7c8;
+  --md-outlined-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-field-hover-outline-color: #b1aac0;
+  --md-outlined-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-field-focus-outline-color: #6c3eea;
+  --md-outlined-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-text-field-caret-color: #6c3eea;
+  --md-outlined-field-caret-color: #6c3eea;
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-text-field.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+md-outlined-select.md-outlined-field {
+  --md-outlined-select-text-field-outline-color: #bdb7c8;
+  --md-outlined-select-text-field-hover-outline-color: #b1aac0;
+  --md-outlined-select-text-field-focus-outline-color: #6c3eea;
+  --md-outlined-select-text-field-focus-state-layer-color: #6c3eea;
+  --md-outlined-select-text-field-caret-color: #6c3eea;
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(outline) {
+  filter: drop-shadow(0 0 4px rgba(108, 62, 234, 0.26)) drop-shadow(0 0 12px rgba(108, 62, 234, 0.22));
+}
+
+md-outlined-select.md-outlined-field:focus-within::part(container) {
+  box-shadow: 0 0 0 2px rgba(108, 62, 234, 0.12), 0 0 14px rgba(108, 62, 234, 0.18);
+}
+
+.md-help-icon-button,
+.md-help-icon-button--fallback {
+  --md-focus-ring-color: rgba(103, 80, 164, 0.22);
+}
+
+.md-help-icon-button--fallback {
+  background: #f0edf5;
+  color: #3f3b46;
 }
 
 .md-note-card__text + .md-note-card__text,
@@ -351,9 +496,9 @@
 
 .md-debug-accordion {
   margin-top: 16px;
-  border: 1px solid #d6e3ef;
+  border: 1px solid rgba(148, 163, 184, 0.18);
   border-radius: 18px;
-  background: linear-gradient(180deg, #f8fbfe 0%, #ffffff 100%);
+  background: rgba(255, 255, 255, 0.72);
   overflow: clip;
 }
 
@@ -363,7 +508,7 @@
   padding: 14px 18px;
   font-size: 0.92rem;
   font-weight: 700;
-  color: #315267;
+  color: #102a43;
   display: flex;
   align-items: center;
   gap: 10px;
@@ -376,7 +521,7 @@
 .md-debug-accordion__summary::before {
   content: "▸";
   font-size: 0.9rem;
-  color: #4c7b97;
+  color: #52606d;
   transition: transform 160ms ease;
 }
 
@@ -386,7 +531,7 @@
 
 .md-debug-accordion__body {
   padding: 0 18px 18px;
-  border-top: 1px solid #e2ebf3;
+  border-top: 1px solid rgba(148, 163, 184, 0.18);
 }
 
 .md-debug-accordion__body .md-form-grid + .md-form-grid {
@@ -479,12 +624,12 @@
 .md-summary-card {
   border: 1px solid var(--md-project-border);
   border-radius: 18px;
-  background: linear-gradient(180deg, #f9fffe 0%, #fff 100%);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(245, 248, 252, 0.94) 100%);
   padding: 16px;
 }
 
 .md-summary-label {
-  color: #4f6771;
+  color: #52606d;
   font-size: 0.84rem;
   font-weight: 700;
 }
@@ -493,7 +638,7 @@
   margin-top: 6px;
   font-size: 1.1rem;
   font-weight: 700;
-  color: #1f3137;
+  color: #102a43;
 }
 
 .md-preview-grid {
@@ -505,7 +650,7 @@
 .md-preview-card {
   border: 1px solid var(--md-project-border);
   border-radius: 18px;
-  background: linear-gradient(180deg, #fbfeff 0%, #fff 100%);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(245, 248, 252, 0.94) 100%);
   padding: 16px;
 }
 
@@ -513,7 +658,7 @@
   margin: 0 0 10px;
   font-size: 0.98rem;
   font-weight: 700;
-  color: #244148;
+  color: #102a43;
 }
 
 .md-preview-list {
@@ -522,7 +667,7 @@
 }
 
 .md-preview-item {
-  border: 1px solid #dfe7ee;
+  border: 1px solid rgba(148, 163, 184, 0.18);
   border-radius: 14px;
   background: #fff;
   padding: 10px 12px;
@@ -531,7 +676,7 @@
 .md-preview-item__title {
   font-size: 0.9rem;
   font-weight: 700;
-  color: #1f3137;
+  color: #102a43;
 }
 
 .md-preview-item__meta {
@@ -584,7 +729,7 @@
 
 @media (max-width: 640px) {
   .md-page {
-    padding: 14px;
+    padding: 16px;
   }
 
   .md-summary-grid {


### PR DESCRIPTION
## 概要

UI の HTML/CSS を調整し、画面全体の見た目を更新します。あわせて、ヒーロー領域から GitHub リポジトリへ遷移できる導線と、新規生成AI連携で参照する `mikuproject-ai-json-spec.md` の公開リンクを追加します。

## 変更内容

### UI / HTML

- ヒーロー領域に GitHub アイコンを追加
- GitHub アイコンから `igapyon/mikuproject` リポジトリへ遷移するリンクを追加
- `mikuproject-ai-json-spec.md` への案内を、公開 URL を使うリンクに変更
- ページ全体を `md-shell` で囲む構造へ変更
- GitHub アイコン用の SVG symbol 定義を追加

### CSS / テーマ

- アクセントカラーを紫系へ調整
- `PRIMARY` ボタンを紫系グラデーションへ変更
- アクティブなタブ表示を紫系へ変更
- `md-outlined-text-field` / `md-outlined-select` のフォーカス色を紫系へ変更
- ヘルプアイコン、メニュー、リンクなどの色味を紫系へ調整
- ヒーロー内の GitHub アイコンリンク用スタイルを追加
- `.md-shell` と `.md-icons` のスタイルを追加

## 変更ファイル

- `mikuproject-src.html`
- `mikuproject.html`
- `src/css/app.css`