### PR TITLE
miku 系テーマに合わせてヒーローと上部タブの UI を刷新

### DIFF
--- a/mikuproject-src.html
+++ b/mikuproject-src.html
@@ -17,36 +17,43 @@
     </symbol>
   </svg>
   <div class="md-surface-card md-card">
-    <lht-page-hero
-      title="mikuproject"
-      icon="📋"
-      help-label="mikuproject の説明"
-      help-wide
-      action-href="https://github.com/igapyon/mikuproject"
-      action-label="GitHub"
-      action-aria-label="Open mikuproject repository"
-      action-icon-id="md-icon-github"
-      menu-home-href="README.md"
-      menu-home-label="README">
-      MS Project XML を読み込み、内部モデルへ落として、再度 MS Project XML を生成するための実験アプリです。<br><br>
-      STEP 1 では、意味的ラウンドトリップを主目的にします。
-    </lht-page-hero>
+    <header class="ms-hero">
+      <h1 class="ms-hero-title">
+        <span class="ms-hero-icon" aria-hidden="true">📋</span>
+        <span>mikuproject</span>
+        <lht-help-tooltip label="mikuproject の説明" wide>
+          MS Project XML を読み込み、内部モデル・XLSX・生成AI向け JSON を行き来しながら、プロジェクト計画を確認・編集するためのアプリです。
+        </lht-help-tooltip>
+        <a
+          href="https://github.com/igapyon/mikuproject"
+          class="ms-hero-link"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Open mikuproject GitHub repository"
+        >
+          <svg aria-hidden="true" viewBox="0 0 16 16" class="ms-btn-icon" fill="currentColor">
+            <use href="#md-icon-github" xlink:href="#md-icon-github"></use>
+          </svg>
+          <span>GitHub</span>
+        </a>
+      </h1>
+    </header>
 
     <section class="md-section md-stack-md">
       <div id="statusMessage" class="md-status">未実行</div>
 
-      <div class="md-top-tabs" role="tablist" aria-label="mikuproject sections">
-        <button type="button" class="md-top-tab is-active" data-tab="input" role="tab" aria-selected="true" aria-controls="tabPanelInput">
-          <span class="md-top-tab-no">1</span>
-          <span class="md-top-tab-label">Input</span>
+      <div class="md-top-tabs ms-top-tabs" role="tablist" aria-label="mikuproject sections">
+        <button type="button" class="md-top-tab ms-top-tab is-active" data-tab="input" role="tab" aria-selected="true" aria-controls="tabPanelInput">
+          <span class="md-top-tab-no ms-top-tab-no">1</span>
+          <span class="md-top-tab-label ms-top-tab-label">Input</span>
         </button>
-        <button type="button" class="md-top-tab" data-tab="transform" role="tab" aria-selected="false" aria-controls="tabPanelTransform">
-          <span class="md-top-tab-no">2</span>
-          <span class="md-top-tab-label">Transform</span>
+        <button type="button" class="md-top-tab ms-top-tab" data-tab="transform" role="tab" aria-selected="false" aria-controls="tabPanelTransform">
+          <span class="md-top-tab-no ms-top-tab-no">2</span>
+          <span class="md-top-tab-label ms-top-tab-label">Transform</span>
         </button>
-        <button type="button" class="md-top-tab" data-tab="output" role="tab" aria-selected="false" aria-controls="tabPanelOutput">
-          <span class="md-top-tab-no">3</span>
-          <span class="md-top-tab-label">Output</span>
+        <button type="button" class="md-top-tab ms-top-tab" data-tab="output" role="tab" aria-selected="false" aria-controls="tabPanelOutput">
+          <span class="md-top-tab-no ms-top-tab-no">3</span>
+          <span class="md-top-tab-label ms-top-tab-label">Output</span>
         </button>
       </div>
 
@@ -108,7 +115,7 @@
             生成AIとの会話は別途行います。生成AIが返した `project_draft_view` は、JSON ファイルとして開くか、JSON テキストを貼り付けてここから取り込みます。
           </p>
           <p class="md-note-card__text">
-            (i) まず生成AIに <a class="md-inline-link" href="https://raw.githubusercontent.com/igapyon/mikuproject/refs/heads/devel/docs/mikuproject-ai-json-spec.md" target="_blank" rel="noopener noreferrer">mikuproject-ai-json-spec.md</a> を読み込ませます。
+            (i) まず生成AIに <a class="md-inline-link" href="https://raw.githubusercontent.com/igapyon/mikuproject/refs/heads/devel/docs/mikuproject-ai-json-spec.md" target="_blank" rel="noopener noreferrer">生成AIプロンプト</a> を読み込ませます。
           </p>
           <p class="md-note-card__text">
             (ii) その前提で生成AIに `project_draft_view` を作らせます。

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -1066,6 +1066,9 @@ lht-index-card-link {
   --md-project-border: rgba(148, 163, 184, 0.2);
   --md-project-surface: rgba(255, 255, 255, 0.94);
   --md-project-shadow: 0 18px 48px rgba(15, 23, 42, 0.08);
+  --ms-miku-surface: #cbf3f0;
+  --ms-miku-border: #a8e3e0;
+  --ms-miku-text: #1c1b1f;
   --md-sys-color-primary: #6750a4;
   --md-sys-color-surface: #ffffff;
   --md-sys-color-on-surface: #102a43;
@@ -1106,50 +1109,91 @@ lht-index-card-link {
   padding: 28px;
 }
 
-lht-page-hero {
-  background: linear-gradient(180deg, #f6fbff 0%, #fbfdff 100%);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+.ms-hero {
+  position: relative;
+  margin: -6px -6px 18px;
+  padding: 14px 16px 12px;
+  border-radius: 18px;
+  border: 1px solid var(--ms-miku-border);
+  background: var(--ms-miku-surface);
+  box-shadow: 0 8px 20px rgba(86, 58, 132, 0.12);
 }
 
-lht-page-hero .lht-page-hero__title {
-  color: #102a43;
+.ms-hero-title {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0;
+  color: var(--ms-miku-text);
+  font-size: clamp(1.12rem, 4vw, 1.9rem);
+  font-weight: 800;
 }
 
-lht-page-hero .lht-page-hero__subtitle {
-  color: #52606d;
+.ms-hero-subtitle {
+  margin: 0.75rem 0 0;
+  max-width: 72ch;
+  color: #243b53;
+  font-size: 0.95rem;
+  line-height: 1.6;
 }
 
-lht-page-hero .lht-page-hero__icon {
-  background: rgba(103, 80, 164, 0.14);
-}
-
-.ms-hero-link {
+.ms-hero-icon {
+  width: 1.95rem;
+  height: 1.95rem;
+  border-radius: 999px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 999px;
-  color: #514a5f;
+  background: rgba(103, 80, 164, 0.08);
+  color: #5b33a8;
+  border: 1px solid rgba(103, 80, 164, 0.38);
+  flex: 0 0 auto;
+}
+
+.ms-hero lht-help-tooltip:not([data-initialized="true"]) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  inline-size: 1.35rem;
+  block-size: 1.35rem;
+  overflow: hidden;
+  flex: 0 0 1.35rem;
+  color: transparent;
+  white-space: nowrap;
+}
+
+.ms-hero-link {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  color: var(--ms-miku-text);
   text-decoration: none;
+  border: none;
+  background: transparent;
+  border-radius: 0;
+  padding: 0;
+  font-size: 0.8rem;
+  font-weight: 700;
   line-height: 1;
   transition:
-    transform 0.16s ease,
     color 0.16s ease,
-    background 0.16s ease,
-    opacity 0.16s ease;
+    text-decoration-color 0.16s ease;
 }
 
 .ms-hero-link:hover,
 .ms-hero-link:focus-visible {
-  transform: translateY(-1px);
   color: #2f1f52;
-  background: #f0edf5;
-  opacity: 1;
+  text-decoration: underline;
 }
 
-.ms-hero-link span {
+.ms-hero-link--text {
+  margin-left: 0;
+  padding-inline: 0.2rem;
+}
+
+.ms-hero-link .ms-btn-icon + span {
   display: none;
 }
 
@@ -1235,59 +1279,93 @@ lht-page-hero .lht-page-hero__icon {
   display: none !important;
 }
 
-.md-top-tabs {
+.md-top-tabs,
+.ms-top-tabs {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 10px;
+  gap: 0.6rem;
+  align-items: center;
+  margin-bottom: 0.2rem;
+  padding: 0.35rem 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
-.md-top-tab {
+.md-top-tab,
+.ms-top-tab {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.6rem;
-  min-height: 3rem;
-  border: 1px solid var(--md-project-border);
-  border-radius: 999px;
-  background: #f3f7fb;
-  color: #52606d;
+  justify-content: flex-start;
+  gap: 0.5rem;
+  appearance: none;
+  min-height: 3.25rem;
+  border: 1px solid #ddd2f0;
+  background: #f7f3fc;
+  color: #4a4458;
+  border-radius: 14px;
+  padding: 0.45rem 0.85rem;
   font: inherit;
+  font-size: 0.95rem;
   font-weight: 700;
+  white-space: nowrap;
   cursor: pointer;
   transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease, border-color 150ms ease;
 }
 
-.md-top-tab:hover {
+.md-top-tab::after,
+.ms-top-tab::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: calc(100% + 0.2rem);
+  width: 0.45rem;
+  height: 2px;
+  background: #d8cceb;
+  transform: translateY(-50%);
+}
+
+.md-top-tab:last-child::after,
+.ms-top-tab:last-child::after {
+  display: none;
+}
+
+.md-top-tab:hover,
+.ms-top-tab:hover {
   transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(32, 54, 84, 0.1);
+  box-shadow: 0 6px 16px rgba(103, 80, 164, 0.12);
 }
 
-.md-top-tab.is-active {
-  border-color: rgba(103, 80, 164, 0.28);
-  color: #4f378b;
-  background: #f3edff;
-  box-shadow: 0 4px 10px rgba(103, 80, 164, 0.14);
+.md-top-tab.is-active,
+.ms-top-tab.is-active {
+  border-color: rgba(98, 0, 238, 0.5);
+  color: #4d2aa5;
+  background: rgba(98, 0, 238, 0.14);
 }
 
-.md-top-tab-no {
+.md-top-tab-no,
+.ms-top-tab-no {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.55rem;
-  height: 1.55rem;
+  width: 1.4rem;
+  height: 1.4rem;
   border-radius: 999px;
-  background: #d9e2ec;
-  color: #334e68;
-  font-size: 0.8rem;
+  background: #ece5f8;
+  color: #5a4b79;
+  font-size: 0.76rem;
   font-weight: 800;
 }
 
-.md-top-tab.is-active .md-top-tab-no {
-  background: rgba(103, 80, 164, 0.18);
-  color: #4f378b;
+.md-top-tab.is-active .md-top-tab-no,
+.ms-top-tab.is-active .ms-top-tab-no {
+  background: rgba(98, 0, 238, 0.22);
+  color: #4d2aa5;
 }
 
-.md-top-tab-label {
+.md-top-tab-label,
+.ms-top-tab-label {
+  display: inline-block;
   letter-spacing: 0.01em;
 }
 
@@ -1775,7 +1853,8 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 }
 
 @media (max-width: 900px) {
-  .md-top-tabs {
+  .md-top-tabs,
+  .ms-top-tabs {
     grid-template-columns: minmax(0, 1fr);
   }
 
@@ -1793,6 +1872,34 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
     padding: 16px;
   }
 
+  .ms-hero {
+    margin: -2px -2px 14px;
+    padding: 12px 12px 10px;
+  }
+
+  .md-top-tab,
+  .ms-top-tab {
+    min-width: 0;
+    padding: 0.42rem 0.45rem;
+    justify-content: center;
+    width: 100%;
+  }
+
+  .md-top-tab::after,
+  .ms-top-tab::after {
+    display: none;
+  }
+
+  .md-top-tab-label,
+  .ms-top-tab-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .ms-hero-title {
+    flex-wrap: wrap;
+  }
+
   .md-summary-grid {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -1807,36 +1914,43 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
     </symbol>
   </svg>
   <div class="md-surface-card md-card">
-    <lht-page-hero
-      title="mikuproject"
-      icon="📋"
-      help-label="mikuproject の説明"
-      help-wide
-      action-href="https://github.com/igapyon/mikuproject"
-      action-label="GitHub"
-      action-aria-label="Open mikuproject repository"
-      action-icon-id="md-icon-github"
-      menu-home-href="README.md"
-      menu-home-label="README">
-      MS Project XML を読み込み、内部モデルへ落として、再度 MS Project XML を生成するための実験アプリです。<br><br>
-      STEP 1 では、意味的ラウンドトリップを主目的にします。
-    </lht-page-hero>
+    <header class="ms-hero">
+      <h1 class="ms-hero-title">
+        <span class="ms-hero-icon" aria-hidden="true">📋</span>
+        <span>mikuproject</span>
+        <lht-help-tooltip label="mikuproject の説明" wide>
+          MS Project XML を読み込み、内部モデル・XLSX・生成AI向け JSON を行き来しながら、プロジェクト計画を確認・編集するためのアプリです。
+        </lht-help-tooltip>
+        <a
+          href="https://github.com/igapyon/mikuproject"
+          class="ms-hero-link"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Open mikuproject GitHub repository"
+        >
+          <svg aria-hidden="true" viewBox="0 0 16 16" class="ms-btn-icon" fill="currentColor">
+            <use href="#md-icon-github" xlink:href="#md-icon-github"></use>
+          </svg>
+          <span>GitHub</span>
+        </a>
+      </h1>
+    </header>
 
     <section class="md-section md-stack-md">
       <div id="statusMessage" class="md-status">未実行</div>
 
-      <div class="md-top-tabs" role="tablist" aria-label="mikuproject sections">
-        <button type="button" class="md-top-tab is-active" data-tab="input" role="tab" aria-selected="true" aria-controls="tabPanelInput">
-          <span class="md-top-tab-no">1</span>
-          <span class="md-top-tab-label">Input</span>
+      <div class="md-top-tabs ms-top-tabs" role="tablist" aria-label="mikuproject sections">
+        <button type="button" class="md-top-tab ms-top-tab is-active" data-tab="input" role="tab" aria-selected="true" aria-controls="tabPanelInput">
+          <span class="md-top-tab-no ms-top-tab-no">1</span>
+          <span class="md-top-tab-label ms-top-tab-label">Input</span>
         </button>
-        <button type="button" class="md-top-tab" data-tab="transform" role="tab" aria-selected="false" aria-controls="tabPanelTransform">
-          <span class="md-top-tab-no">2</span>
-          <span class="md-top-tab-label">Transform</span>
+        <button type="button" class="md-top-tab ms-top-tab" data-tab="transform" role="tab" aria-selected="false" aria-controls="tabPanelTransform">
+          <span class="md-top-tab-no ms-top-tab-no">2</span>
+          <span class="md-top-tab-label ms-top-tab-label">Transform</span>
         </button>
-        <button type="button" class="md-top-tab" data-tab="output" role="tab" aria-selected="false" aria-controls="tabPanelOutput">
-          <span class="md-top-tab-no">3</span>
-          <span class="md-top-tab-label">Output</span>
+        <button type="button" class="md-top-tab ms-top-tab" data-tab="output" role="tab" aria-selected="false" aria-controls="tabPanelOutput">
+          <span class="md-top-tab-no ms-top-tab-no">3</span>
+          <span class="md-top-tab-label ms-top-tab-label">Output</span>
         </button>
       </div>
 
@@ -1898,7 +2012,7 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
             生成AIとの会話は別途行います。生成AIが返した `project_draft_view` は、JSON ファイルとして開くか、JSON テキストを貼り付けてここから取り込みます。
           </p>
           <p class="md-note-card__text">
-            (i) まず生成AIに <a class="md-inline-link" href="https://raw.githubusercontent.com/igapyon/mikuproject/refs/heads/devel/docs/mikuproject-ai-json-spec.md" target="_blank" rel="noopener noreferrer">mikuproject-ai-json-spec.md</a> を読み込ませます。
+            (i) まず生成AIに <a class="md-inline-link" href="https://raw.githubusercontent.com/igapyon/mikuproject/refs/heads/devel/docs/mikuproject-ai-json-spec.md" target="_blank" rel="noopener noreferrer">生成AIプロンプト</a> を読み込ませます。
           </p>
           <p class="md-note-card__text">
             (ii) その前提で生成AIに `project_draft_view` を作らせます。

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -5,6 +5,9 @@
   --md-project-border: rgba(148, 163, 184, 0.2);
   --md-project-surface: rgba(255, 255, 255, 0.94);
   --md-project-shadow: 0 18px 48px rgba(15, 23, 42, 0.08);
+  --ms-miku-surface: #cbf3f0;
+  --ms-miku-border: #a8e3e0;
+  --ms-miku-text: #1c1b1f;
   --md-sys-color-primary: #6750a4;
   --md-sys-color-surface: #ffffff;
   --md-sys-color-on-surface: #102a43;
@@ -45,50 +48,91 @@
   padding: 28px;
 }
 
-lht-page-hero {
-  background: linear-gradient(180deg, #f6fbff 0%, #fbfdff 100%);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.65);
+.ms-hero {
+  position: relative;
+  margin: -6px -6px 18px;
+  padding: 14px 16px 12px;
+  border-radius: 18px;
+  border: 1px solid var(--ms-miku-border);
+  background: var(--ms-miku-surface);
+  box-shadow: 0 8px 20px rgba(86, 58, 132, 0.12);
 }
 
-lht-page-hero .lht-page-hero__title {
-  color: #102a43;
+.ms-hero-title {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin: 0;
+  color: var(--ms-miku-text);
+  font-size: clamp(1.12rem, 4vw, 1.9rem);
+  font-weight: 800;
 }
 
-lht-page-hero .lht-page-hero__subtitle {
-  color: #52606d;
+.ms-hero-subtitle {
+  margin: 0.75rem 0 0;
+  max-width: 72ch;
+  color: #243b53;
+  font-size: 0.95rem;
+  line-height: 1.6;
 }
 
-lht-page-hero .lht-page-hero__icon {
-  background: rgba(103, 80, 164, 0.14);
-}
-
-.ms-hero-link {
+.ms-hero-icon {
+  width: 1.95rem;
+  height: 1.95rem;
+  border-radius: 999px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 999px;
-  color: #514a5f;
+  background: rgba(103, 80, 164, 0.08);
+  color: #5b33a8;
+  border: 1px solid rgba(103, 80, 164, 0.38);
+  flex: 0 0 auto;
+}
+
+.ms-hero lht-help-tooltip:not([data-initialized="true"]) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  inline-size: 1.35rem;
+  block-size: 1.35rem;
+  overflow: hidden;
+  flex: 0 0 1.35rem;
+  color: transparent;
+  white-space: nowrap;
+}
+
+.ms-hero-link {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  color: var(--ms-miku-text);
   text-decoration: none;
+  border: none;
+  background: transparent;
+  border-radius: 0;
+  padding: 0;
+  font-size: 0.8rem;
+  font-weight: 700;
   line-height: 1;
   transition:
-    transform 0.16s ease,
     color 0.16s ease,
-    background 0.16s ease,
-    opacity 0.16s ease;
+    text-decoration-color 0.16s ease;
 }
 
 .ms-hero-link:hover,
 .ms-hero-link:focus-visible {
-  transform: translateY(-1px);
   color: #2f1f52;
-  background: #f0edf5;
-  opacity: 1;
+  text-decoration: underline;
 }
 
-.ms-hero-link span {
+.ms-hero-link--text {
+  margin-left: 0;
+  padding-inline: 0.2rem;
+}
+
+.ms-hero-link .ms-btn-icon + span {
   display: none;
 }
 
@@ -174,59 +218,93 @@ lht-page-hero .lht-page-hero__icon {
   display: none !important;
 }
 
-.md-top-tabs {
+.md-top-tabs,
+.ms-top-tabs {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 10px;
+  gap: 0.6rem;
+  align-items: center;
+  margin-bottom: 0.2rem;
+  padding: 0.35rem 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
 }
 
-.md-top-tab {
+.md-top-tab,
+.ms-top-tab {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 0.6rem;
-  min-height: 3rem;
-  border: 1px solid var(--md-project-border);
-  border-radius: 999px;
-  background: #f3f7fb;
-  color: #52606d;
+  justify-content: flex-start;
+  gap: 0.5rem;
+  appearance: none;
+  min-height: 3.25rem;
+  border: 1px solid #ddd2f0;
+  background: #f7f3fc;
+  color: #4a4458;
+  border-radius: 14px;
+  padding: 0.45rem 0.85rem;
   font: inherit;
+  font-size: 0.95rem;
   font-weight: 700;
+  white-space: nowrap;
   cursor: pointer;
   transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease, border-color 150ms ease;
 }
 
-.md-top-tab:hover {
+.md-top-tab::after,
+.ms-top-tab::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: calc(100% + 0.2rem);
+  width: 0.45rem;
+  height: 2px;
+  background: #d8cceb;
+  transform: translateY(-50%);
+}
+
+.md-top-tab:last-child::after,
+.ms-top-tab:last-child::after {
+  display: none;
+}
+
+.md-top-tab:hover,
+.ms-top-tab:hover {
   transform: translateY(-1px);
-  box-shadow: 0 6px 16px rgba(32, 54, 84, 0.1);
+  box-shadow: 0 6px 16px rgba(103, 80, 164, 0.12);
 }
 
-.md-top-tab.is-active {
-  border-color: rgba(103, 80, 164, 0.28);
-  color: #4f378b;
-  background: #f3edff;
-  box-shadow: 0 4px 10px rgba(103, 80, 164, 0.14);
+.md-top-tab.is-active,
+.ms-top-tab.is-active {
+  border-color: rgba(98, 0, 238, 0.5);
+  color: #4d2aa5;
+  background: rgba(98, 0, 238, 0.14);
 }
 
-.md-top-tab-no {
+.md-top-tab-no,
+.ms-top-tab-no {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.55rem;
-  height: 1.55rem;
+  width: 1.4rem;
+  height: 1.4rem;
   border-radius: 999px;
-  background: #d9e2ec;
-  color: #334e68;
-  font-size: 0.8rem;
+  background: #ece5f8;
+  color: #5a4b79;
+  font-size: 0.76rem;
   font-weight: 800;
 }
 
-.md-top-tab.is-active .md-top-tab-no {
-  background: rgba(103, 80, 164, 0.18);
-  color: #4f378b;
+.md-top-tab.is-active .md-top-tab-no,
+.ms-top-tab.is-active .ms-top-tab-no {
+  background: rgba(98, 0, 238, 0.22);
+  color: #4d2aa5;
 }
 
-.md-top-tab-label {
+.md-top-tab-label,
+.ms-top-tab-label {
+  display: inline-block;
   letter-spacing: 0.01em;
 }
 
@@ -714,7 +792,8 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 }
 
 @media (max-width: 900px) {
-  .md-top-tabs {
+  .md-top-tabs,
+  .ms-top-tabs {
     grid-template-columns: minmax(0, 1fr);
   }
 
@@ -730,6 +809,34 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 @media (max-width: 640px) {
   .md-page {
     padding: 16px;
+  }
+
+  .ms-hero {
+    margin: -2px -2px 14px;
+    padding: 12px 12px 10px;
+  }
+
+  .md-top-tab,
+  .ms-top-tab {
+    min-width: 0;
+    padding: 0.42rem 0.45rem;
+    justify-content: center;
+    width: 100%;
+  }
+
+  .md-top-tab::after,
+  .ms-top-tab::after {
+    display: none;
+  }
+
+  .md-top-tab-label,
+  .ms-top-tab-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .ms-hero-title {
+    flex-wrap: wrap;
   }
 
   .md-summary-grid {


### PR DESCRIPTION
## 概要

`mikuproject` の UI について、ヒーロー領域と上部タブを中心に見た目を更新します。`miku` 系の色味を取り入れつつ、GitHub への導線と生成AI連携の案内文も整理します。

## 変更内容

### ヒーロー領域の更新

- `lht-page-hero` ベースの構成をやめ、独自の `ms-hero` ヘッダーへ変更
- ヒーロー右側に GitHub リポジトリへのリンクを追加
- タイトル右のヘルプツールチップ文言を更新
- ヒーロー本文は削除し、説明はツールチップ側へ集約
- `README` へのリンクは削除

### 上部タブの見た目調整

- 上部タブに `ms-top-tab` 系クラスを追加
- タブの見た目を `mikuscore` 風の接続線つきデザインへ変更
- アクティブタブの配色を紫系アクセントへ調整
- モバイル幅では接続線を消し、横幅に応じて崩れるよう調整
- ホバー時に上側が欠けないよう、タブ列に余白を追加

### 色・スタイルの調整

- `miku` 系のミント色ヒーロー用変数を追加
- ヒーロー背景、境界線、文字色を `miku` 系の配色へ調整
- `PRIMARY` ボタン、フォーカス色、ヘルプアイコンなどを紫系アクセントへ調整
- GitHub アイコン表示用のスタイルを追加
- `生成AIプロンプト` への案内リンク文言を更新

## 変更ファイル

- `mikuproject-src.html`
- `mikuproject.html`
- `src/css/app.css`