### PR TITLE
CSV 入出力をファイルベースへ変更し、生成AI連携と XLSX ヘルプの UI を整理

### DIFF
--- a/mikuproject-src.html
+++ b/mikuproject-src.html
@@ -40,8 +40,6 @@
     </header>
 
     <section class="md-section md-stack-md">
-      <div id="statusMessage" class="md-status">未実行</div>
-
       <div class="md-top-tabs ms-top-tabs" role="tablist" aria-label="mikuproject sections">
         <button type="button" class="md-top-tab ms-top-tab is-active" data-tab="input" role="tab" aria-selected="true" aria-controls="tabPanelInput">
           <span class="md-top-tab-no ms-top-tab-no">1</span>
@@ -57,6 +55,8 @@
         </button>
       </div>
 
+      <div id="statusMessage" class="md-status">未実行</div>
+
       <section id="tabPanelInput" class="md-flow-section md-tab-panel" data-tab-panel="input" aria-label="input">
         <div class="md-flow-section__header">
           <h2 class="md-flow-section__title">
@@ -68,64 +68,63 @@
 
         <div class="md-panel-actions">
           <button id="importXmlBtn" type="button" class="md-button md-button--primary">MS Project XML</button>
-          <button id="importXlsxBtn" type="button" class="md-button md-button--surface">XLSX</button>
+          <span class="md-button-with-help">
+            <button id="importXlsxBtn" type="button" class="md-button md-button--surface">XLSX</button>
+            <span class="md-button-help-anchor">
+              <lht-help-tooltip label="XLSX 編集の扱い" placement="right" wide>
+                <p class="md-note-card__text">
+                  `.xlsx` は `MS Project XML` の代替正本ではなく、確認と限定編集のための周辺表現として扱います。
+                </p>
+                <p class="md-note-card__text">
+                  現在の `XLSX Import` で反映するのは限定列のみです。
+                </p>
+                <p class="md-note-card__text">
+                  反映結果は、`Project / Tasks / Resources / Assignments / Calendars` ごとの件数と、`UID` 単位の差分要約として画面上に表示します。
+                </p>
+                <p class="md-note-card__text"><strong>反映対象</strong></p>
+                <ul class="md-note-list">
+                  <li>`Project`: `Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart`</li>
+                  <li>`Tasks`: `Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes`</li>
+                  <li>`Resources`: `Name / Group / MaxUnits`</li>
+                  <li>`Assignments`: `Units / Work / PercentWorkComplete`</li>
+                  <li>`Calendars`: `Name / IsBaseCalendar / BaseCalendarUID`</li>
+                  <li>`NonWorkingDays`: `Name / Date / FromDate / ToDate / DayWorking`</li>
+                </ul>
+                <p class="md-note-card__text"><strong>現在は反映しないもの</strong></p>
+                <ul class="md-note-list">
+                  <li>対象外の列や未対応シートの編集</li>
+                  <li>`Calendars` の `WeekDays / WorkWeeks` と、`Baseline / TimephasedData / ExtendedAttributes`</li>
+                </ul>
+              </lht-help-tooltip>
+            </span>
+          </span>
           <button id="parseCsvBtn" type="button" class="md-button md-button--surface">CSV</button>
           <button id="loadSampleBtn" type="button" class="md-button md-button--surface">サンプル</button>
           <input id="importXmlInput" type="file" accept=".xml,text/xml,application/xml" class="md-hidden" />
           <input id="importXlsxInput" type="file" accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" class="md-hidden" />
+          <input id="importCsvInput" type="file" accept=".csv,text/csv,text/plain" class="md-hidden" />
           <input id="importProjectDraftInput" type="file" accept=".json,application/json,text/plain" class="md-hidden" />
         </div>
-
-        <section class="md-note-card" aria-label="XLSX import export notes">
-          <div class="md-note-card__title-row">
-            <h3 class="md-note-card__title">XLSX 編集の扱い</h3>
-            <lht-help-tooltip label="XLSX 編集の扱い" placement="right" wide>
-              <p class="md-note-card__text">
-                `.xlsx` は `MS Project XML` の代替正本ではなく、確認と限定編集のための周辺表現として扱います。
-              </p>
-              <p class="md-note-card__text">
-                現在の `XLSX Import` で反映するのは限定列のみです。
-              </p>
-              <p class="md-note-card__text">
-                反映結果は、`Project / Tasks / Resources / Assignments / Calendars` ごとの件数と、`UID` 単位の差分要約として画面上に表示します。
-              </p>
-              <p class="md-note-card__text"><strong>反映対象</strong></p>
-              <ul class="md-note-list">
-                <li>`Project`: `Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart`</li>
-                <li>`Tasks`: `Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes`</li>
-                <li>`Resources`: `Name / Group / MaxUnits`</li>
-                <li>`Assignments`: `Units / Work / PercentWorkComplete`</li>
-                <li>`Calendars`: `Name / IsBaseCalendar / BaseCalendarUID`</li>
-                <li>`NonWorkingDays`: `Name / Date / FromDate / ToDate / DayWorking`</li>
-              </ul>
-              <p class="md-note-card__text"><strong>現在は反映しないもの</strong></p>
-              <ul class="md-note-list">
-                <li>対象外の列や未対応シートの編集</li>
-                <li>`Calendars` の `WeekDays / WorkWeeks` と、`Baseline / TimephasedData / ExtendedAttributes`</li>
-              </ul>
-            </lht-help-tooltip>
-          </div>
-        </section>
 
         <section class="md-note-card" aria-label="AI draft generation">
           <div class="md-note-card__title-row">
             <h3 class="md-note-card__title">新規生成AI連携</h3>
+            <lht-help-tooltip label="新規生成AI連携の説明" wide>
+              (i) まず生成AIに 生成AIプロンプト を読み込ませます。<br><br>
+              (ii) その前提で生成AIに `project_draft_view` を作らせます。<br><br>
+              (iii) 返ってきた JSON を、ここでファイル読込または貼り付けで取り込みます。
+            </lht-help-tooltip>
+            <a class="md-inline-link md-inline-link--compact" href="https://raw.githubusercontent.com/igapyon/mikuproject/refs/heads/devel/docs/mikuproject-ai-json-spec.md" target="_blank" rel="noopener noreferrer">生成AIプロンプト</a>
           </div>
           <p class="md-note-card__text">
             生成AIとの会話は別途行います。生成AIが返した `project_draft_view` は、JSON ファイルとして開くか、JSON テキストを貼り付けてここから取り込みます。
           </p>
-          <p class="md-note-card__text">
-            (i) まず生成AIに <a class="md-inline-link" href="https://raw.githubusercontent.com/igapyon/mikuproject/refs/heads/devel/docs/mikuproject-ai-json-spec.md" target="_blank" rel="noopener noreferrer">生成AIプロンプト</a> を読み込ませます。
-          </p>
-          <p class="md-note-card__text">
-            (ii) その前提で生成AIに `project_draft_view` を作らせます。
-          </p>
-          <p class="md-note-card__text">
-            (iii) 返ってきた JSON を、ここでファイル読込または貼り付けで取り込みます。
-          </p>
           <div class="md-panel-actions">
             <button id="importProjectDraftFileBtn" type="button" class="md-button md-button--surface">JSON ファイルを開く</button>
             <button id="importProjectDraftBtn" type="button" class="md-button md-button--surface">貼り付けた JSON を取り込む</button>
+          </div>
+          <div class="md-form-grid">
+            <lht-text-field-help field-id="projectDraftImportInput" label="生成AIが返した JSON" rows="14" help-text="生成AIが返した `project_draft_view` の JSON テキストを貼り付けます。最後に json フェンスを持つ応答全体でもかまいません。"></lht-text-field-help>
           </div>
         </section>
 
@@ -134,14 +133,6 @@
           <div class="md-debug-accordion__body">
             <div class="md-form-grid">
               <lht-text-field-help field-id="xmlInput" label="MS Project XML" rows="16" placeholder="ここに XML を入力" help-text="MS Project XML を読み込みます。"></lht-text-field-help>
-            </div>
-
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="csvInput" label="CSV + ParentID 入力" rows="12" placeholder="ここに CSV を入力" help-text="CSV + ParentID を内部モデルへ変換します。"></lht-text-field-help>
-            </div>
-
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="projectDraftImportInput" label="生成AIが返した JSON" rows="14" help-text="生成AIが返した `project_draft_view` の JSON テキストを貼り付けます。最後に json フェンスを持つ応答全体でもかまいません。"></lht-text-field-help>
             </div>
           </div>
         </details>
@@ -347,9 +338,6 @@
         <details class="md-debug-accordion">
           <summary class="md-debug-accordion__summary">デバッグ情報</summary>
           <div class="md-debug-accordion__body">
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="csvOutput" label="CSV + ParentID" rows="12" readonly></lht-text-field-help>
-            </div>
             <div class="md-form-grid">
               <lht-text-field-help field-id="projectOverviewOutput" label="project_overview_view" rows="14" readonly></lht-text-field-help>
             </div>

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -1375,6 +1375,41 @@ lht-index-card-link {
   flex-wrap: wrap;
 }
 
+.md-button-with-help {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.md-button-help-anchor {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
+.md-button-help-anchor lht-help-tooltip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.md-button-help-anchor .md-tooltip-group > .md-tooltip {
+  display: none;
+}
+
+.md-panel-actions + .md-form-grid {
+  margin-top: 12px;
+}
+
+.md-panel-actions + .md-note-card {
+  margin-top: 12px;
+}
+
+.md-form-grid + .md-panel-actions {
+  margin-top: 12px;
+}
+
 .md-button {
   display: inline-flex;
   align-items: center;
@@ -1522,6 +1557,7 @@ lht-index-card-link {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .md-note-card__title {
@@ -1551,6 +1587,12 @@ lht-index-card-link {
 .md-inline-link:hover,
 .md-inline-link:focus-visible {
   text-decoration: underline;
+}
+
+.md-inline-link--compact {
+  margin-left: auto;
+  font-size: 0.86rem;
+  font-weight: 700;
 }
 
 md-outlined-text-field.md-outlined-field {
@@ -1937,8 +1979,6 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
     </header>
 
     <section class="md-section md-stack-md">
-      <div id="statusMessage" class="md-status">未実行</div>
-
       <div class="md-top-tabs ms-top-tabs" role="tablist" aria-label="mikuproject sections">
         <button type="button" class="md-top-tab ms-top-tab is-active" data-tab="input" role="tab" aria-selected="true" aria-controls="tabPanelInput">
           <span class="md-top-tab-no ms-top-tab-no">1</span>
@@ -1954,6 +1994,8 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
         </button>
       </div>
 
+      <div id="statusMessage" class="md-status">未実行</div>
+
       <section id="tabPanelInput" class="md-flow-section md-tab-panel" data-tab-panel="input" aria-label="input">
         <div class="md-flow-section__header">
           <h2 class="md-flow-section__title">
@@ -1965,64 +2007,63 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 
         <div class="md-panel-actions">
           <button id="importXmlBtn" type="button" class="md-button md-button--primary">MS Project XML</button>
-          <button id="importXlsxBtn" type="button" class="md-button md-button--surface">XLSX</button>
+          <span class="md-button-with-help">
+            <button id="importXlsxBtn" type="button" class="md-button md-button--surface">XLSX</button>
+            <span class="md-button-help-anchor">
+              <lht-help-tooltip label="XLSX 編集の扱い" placement="right" wide>
+                <p class="md-note-card__text">
+                  `.xlsx` は `MS Project XML` の代替正本ではなく、確認と限定編集のための周辺表現として扱います。
+                </p>
+                <p class="md-note-card__text">
+                  現在の `XLSX Import` で反映するのは限定列のみです。
+                </p>
+                <p class="md-note-card__text">
+                  反映結果は、`Project / Tasks / Resources / Assignments / Calendars` ごとの件数と、`UID` 単位の差分要約として画面上に表示します。
+                </p>
+                <p class="md-note-card__text"><strong>反映対象</strong></p>
+                <ul class="md-note-list">
+                  <li>`Project`: `Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart`</li>
+                  <li>`Tasks`: `Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes`</li>
+                  <li>`Resources`: `Name / Group / MaxUnits`</li>
+                  <li>`Assignments`: `Units / Work / PercentWorkComplete`</li>
+                  <li>`Calendars`: `Name / IsBaseCalendar / BaseCalendarUID`</li>
+                  <li>`NonWorkingDays`: `Name / Date / FromDate / ToDate / DayWorking`</li>
+                </ul>
+                <p class="md-note-card__text"><strong>現在は反映しないもの</strong></p>
+                <ul class="md-note-list">
+                  <li>対象外の列や未対応シートの編集</li>
+                  <li>`Calendars` の `WeekDays / WorkWeeks` と、`Baseline / TimephasedData / ExtendedAttributes`</li>
+                </ul>
+              </lht-help-tooltip>
+            </span>
+          </span>
           <button id="parseCsvBtn" type="button" class="md-button md-button--surface">CSV</button>
           <button id="loadSampleBtn" type="button" class="md-button md-button--surface">サンプル</button>
           <input id="importXmlInput" type="file" accept=".xml,text/xml,application/xml" class="md-hidden" />
           <input id="importXlsxInput" type="file" accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" class="md-hidden" />
+          <input id="importCsvInput" type="file" accept=".csv,text/csv,text/plain" class="md-hidden" />
           <input id="importProjectDraftInput" type="file" accept=".json,application/json,text/plain" class="md-hidden" />
         </div>
-
-        <section class="md-note-card" aria-label="XLSX import export notes">
-          <div class="md-note-card__title-row">
-            <h3 class="md-note-card__title">XLSX 編集の扱い</h3>
-            <lht-help-tooltip label="XLSX 編集の扱い" placement="right" wide>
-              <p class="md-note-card__text">
-                `.xlsx` は `MS Project XML` の代替正本ではなく、確認と限定編集のための周辺表現として扱います。
-              </p>
-              <p class="md-note-card__text">
-                現在の `XLSX Import` で反映するのは限定列のみです。
-              </p>
-              <p class="md-note-card__text">
-                反映結果は、`Project / Tasks / Resources / Assignments / Calendars` ごとの件数と、`UID` 単位の差分要約として画面上に表示します。
-              </p>
-              <p class="md-note-card__text"><strong>反映対象</strong></p>
-              <ul class="md-note-list">
-                <li>`Project`: `Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart`</li>
-                <li>`Tasks`: `Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes`</li>
-                <li>`Resources`: `Name / Group / MaxUnits`</li>
-                <li>`Assignments`: `Units / Work / PercentWorkComplete`</li>
-                <li>`Calendars`: `Name / IsBaseCalendar / BaseCalendarUID`</li>
-                <li>`NonWorkingDays`: `Name / Date / FromDate / ToDate / DayWorking`</li>
-              </ul>
-              <p class="md-note-card__text"><strong>現在は反映しないもの</strong></p>
-              <ul class="md-note-list">
-                <li>対象外の列や未対応シートの編集</li>
-                <li>`Calendars` の `WeekDays / WorkWeeks` と、`Baseline / TimephasedData / ExtendedAttributes`</li>
-              </ul>
-            </lht-help-tooltip>
-          </div>
-        </section>
 
         <section class="md-note-card" aria-label="AI draft generation">
           <div class="md-note-card__title-row">
             <h3 class="md-note-card__title">新規生成AI連携</h3>
+            <lht-help-tooltip label="新規生成AI連携の説明" wide>
+              (i) まず生成AIに 生成AIプロンプト を読み込ませます。<br><br>
+              (ii) その前提で生成AIに `project_draft_view` を作らせます。<br><br>
+              (iii) 返ってきた JSON を、ここでファイル読込または貼り付けで取り込みます。
+            </lht-help-tooltip>
+            <a class="md-inline-link md-inline-link--compact" href="https://raw.githubusercontent.com/igapyon/mikuproject/refs/heads/devel/docs/mikuproject-ai-json-spec.md" target="_blank" rel="noopener noreferrer">生成AIプロンプト</a>
           </div>
           <p class="md-note-card__text">
             生成AIとの会話は別途行います。生成AIが返した `project_draft_view` は、JSON ファイルとして開くか、JSON テキストを貼り付けてここから取り込みます。
           </p>
-          <p class="md-note-card__text">
-            (i) まず生成AIに <a class="md-inline-link" href="https://raw.githubusercontent.com/igapyon/mikuproject/refs/heads/devel/docs/mikuproject-ai-json-spec.md" target="_blank" rel="noopener noreferrer">生成AIプロンプト</a> を読み込ませます。
-          </p>
-          <p class="md-note-card__text">
-            (ii) その前提で生成AIに `project_draft_view` を作らせます。
-          </p>
-          <p class="md-note-card__text">
-            (iii) 返ってきた JSON を、ここでファイル読込または貼り付けで取り込みます。
-          </p>
           <div class="md-panel-actions">
             <button id="importProjectDraftFileBtn" type="button" class="md-button md-button--surface">JSON ファイルを開く</button>
             <button id="importProjectDraftBtn" type="button" class="md-button md-button--surface">貼り付けた JSON を取り込む</button>
+          </div>
+          <div class="md-form-grid">
+            <lht-text-field-help field-id="projectDraftImportInput" label="生成AIが返した JSON" rows="14" help-text="生成AIが返した `project_draft_view` の JSON テキストを貼り付けます。最後に json フェンスを持つ応答全体でもかまいません。"></lht-text-field-help>
           </div>
         </section>
 
@@ -2031,14 +2072,6 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
           <div class="md-debug-accordion__body">
             <div class="md-form-grid">
               <lht-text-field-help field-id="xmlInput" label="MS Project XML" rows="16" placeholder="ここに XML を入力" help-text="MS Project XML を読み込みます。"></lht-text-field-help>
-            </div>
-
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="csvInput" label="CSV + ParentID 入力" rows="12" placeholder="ここに CSV を入力" help-text="CSV + ParentID を内部モデルへ変換します。"></lht-text-field-help>
-            </div>
-
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="projectDraftImportInput" label="生成AIが返した JSON" rows="14" help-text="生成AIが返した `project_draft_view` の JSON テキストを貼り付けます。最後に json フェンスを持つ応答全体でもかまいません。"></lht-text-field-help>
             </div>
           </div>
         </details>
@@ -2244,9 +2277,6 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
         <details class="md-debug-accordion">
           <summary class="md-debug-accordion__summary">デバッグ情報</summary>
           <div class="md-debug-accordion__body">
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="csvOutput" label="CSV + ParentID" rows="12" readonly></lht-text-field-help>
-            </div>
             <div class="md-form-grid">
               <lht-text-field-help field-id="projectOverviewOutput" label="project_overview_view" rows="14" readonly></lht-text-field-help>
             </div>
@@ -14040,9 +14070,18 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     function exportCurrentCsv() {
         const model = ensureCurrentModel();
         syncXmlTextFromModel(model);
-        getTextArea("csvOutput").value = mikuprojectXml.exportCsvParentId(model);
-        setStatus("内部モデルから CSV + ParentID を生成しました");
-        showToast("CSV を生成しました");
+        const csvText = mikuprojectXml.exportCsvParentId(model);
+        const now = new Date();
+        const stamp = [
+            now.getFullYear(),
+            String(now.getMonth() + 1).padStart(2, "0"),
+            String(now.getDate()).padStart(2, "0"),
+            String(now.getHours()).padStart(2, "0"),
+            String(now.getMinutes()).padStart(2, "0")
+        ].join("");
+        downloadBlob(new Blob([`${csvText}\n`], { type: "text/csv;charset=utf-8" }), `mikuproject-export-${stamp}.csv`);
+        setStatus("内部モデルから CSV + ParentID を生成して保存しました");
+        showToast("CSV を保存しました");
         setActiveTab("output");
     }
     function exportCurrentProjectOverviewView() {
@@ -14206,8 +14245,11 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         setActiveTab("transform", { skipTransformRefresh: true });
         await exportCurrentMermaid({ silent: true });
     }
-    async function parseCurrentCsv() {
-        const csvText = getTextArea("csvInput").value.trim();
+    async function importCsvFromFile(file) {
+        if (!file) {
+            return;
+        }
+        const csvText = (await file.text()).trim();
         if (!csvText) {
             setStatus("CSV が空です");
             return;
@@ -14218,8 +14260,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         updateSummary(currentModel);
         renderValidationIssues(issues);
         renderXlsxImportSummary([]);
-        setStatus(issues.length > 0 ? `CSV を解析しました。検証で ${issues.length} 件の問題があります` : "CSV + ParentID を内部モデルへ変換しました");
-        showToast("CSV を解析しました");
+        setStatus(issues.length > 0 ? `CSV ファイルを読み込んで解析しました。検証で ${issues.length} 件の問題があります` : "CSV + ParentID を内部モデルへ変換しました");
+        showToast("CSV を読み込みました");
         setActiveTab("transform", { skipTransformRefresh: true });
         await exportCurrentMermaid({ silent: true });
     }
@@ -14364,12 +14406,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             }
         });
         getElement("parseCsvBtn").addEventListener("click", async () => {
-            try {
-                await parseCurrentCsv();
-            }
-            catch (error) {
-                setStatus(error instanceof Error ? error.message : "CSV 解析に失敗しました");
-            }
+            getElement("importCsvInput").click();
         });
         getElement("importXlsxBtn").addEventListener("click", () => {
             getElement("importXlsxInput").click();
@@ -14413,6 +14450,21 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             }
             catch (error) {
                 setStatus(error instanceof Error ? error.message : "XLSX 読み込みに失敗しました");
+            }
+            finally {
+                if (input) {
+                    input.value = "";
+                }
+            }
+        });
+        getElement("importCsvInput").addEventListener("change", async (event) => {
+            const input = event.target;
+            const file = (input === null || input === void 0 ? void 0 : input.files) && input.files[0];
+            try {
+                await importCsvFromFile(file);
+            }
+            catch (error) {
+                setStatus(error instanceof Error ? error.message : "CSV 読み込みに失敗しました");
             }
             finally {
                 if (input) {

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -314,6 +314,41 @@
   flex-wrap: wrap;
 }
 
+.md-button-with-help {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.md-button-help-anchor {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
+.md-button-help-anchor lht-help-tooltip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.md-button-help-anchor .md-tooltip-group > .md-tooltip {
+  display: none;
+}
+
+.md-panel-actions + .md-form-grid {
+  margin-top: 12px;
+}
+
+.md-panel-actions + .md-note-card {
+  margin-top: 12px;
+}
+
+.md-form-grid + .md-panel-actions {
+  margin-top: 12px;
+}
+
 .md-button {
   display: inline-flex;
   align-items: center;
@@ -461,6 +496,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
 .md-note-card__title {
@@ -490,6 +526,12 @@
 .md-inline-link:hover,
 .md-inline-link:focus-visible {
   text-decoration: underline;
+}
+
+.md-inline-link--compact {
+  margin-left: auto;
+  font-size: 0.86rem;
+  font-weight: 700;
 }
 
 md-outlined-text-field.md-outlined-field {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -740,9 +740,18 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     function exportCurrentCsv() {
         const model = ensureCurrentModel();
         syncXmlTextFromModel(model);
-        getTextArea("csvOutput").value = mikuprojectXml.exportCsvParentId(model);
-        setStatus("内部モデルから CSV + ParentID を生成しました");
-        showToast("CSV を生成しました");
+        const csvText = mikuprojectXml.exportCsvParentId(model);
+        const now = new Date();
+        const stamp = [
+            now.getFullYear(),
+            String(now.getMonth() + 1).padStart(2, "0"),
+            String(now.getDate()).padStart(2, "0"),
+            String(now.getHours()).padStart(2, "0"),
+            String(now.getMinutes()).padStart(2, "0")
+        ].join("");
+        downloadBlob(new Blob([`${csvText}\n`], { type: "text/csv;charset=utf-8" }), `mikuproject-export-${stamp}.csv`);
+        setStatus("内部モデルから CSV + ParentID を生成して保存しました");
+        showToast("CSV を保存しました");
         setActiveTab("output");
     }
     function exportCurrentProjectOverviewView() {
@@ -906,8 +915,11 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         setActiveTab("transform", { skipTransformRefresh: true });
         await exportCurrentMermaid({ silent: true });
     }
-    async function parseCurrentCsv() {
-        const csvText = getTextArea("csvInput").value.trim();
+    async function importCsvFromFile(file) {
+        if (!file) {
+            return;
+        }
+        const csvText = (await file.text()).trim();
         if (!csvText) {
             setStatus("CSV が空です");
             return;
@@ -918,8 +930,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         updateSummary(currentModel);
         renderValidationIssues(issues);
         renderXlsxImportSummary([]);
-        setStatus(issues.length > 0 ? `CSV を解析しました。検証で ${issues.length} 件の問題があります` : "CSV + ParentID を内部モデルへ変換しました");
-        showToast("CSV を解析しました");
+        setStatus(issues.length > 0 ? `CSV ファイルを読み込んで解析しました。検証で ${issues.length} 件の問題があります` : "CSV + ParentID を内部モデルへ変換しました");
+        showToast("CSV を読み込みました");
         setActiveTab("transform", { skipTransformRefresh: true });
         await exportCurrentMermaid({ silent: true });
     }
@@ -1064,12 +1076,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             }
         });
         getElement("parseCsvBtn").addEventListener("click", async () => {
-            try {
-                await parseCurrentCsv();
-            }
-            catch (error) {
-                setStatus(error instanceof Error ? error.message : "CSV 解析に失敗しました");
-            }
+            getElement("importCsvInput").click();
         });
         getElement("importXlsxBtn").addEventListener("click", () => {
             getElement("importXlsxInput").click();
@@ -1113,6 +1120,21 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             }
             catch (error) {
                 setStatus(error instanceof Error ? error.message : "XLSX 読み込みに失敗しました");
+            }
+            finally {
+                if (input) {
+                    input.value = "";
+                }
+            }
+        });
+        getElement("importCsvInput").addEventListener("change", async (event) => {
+            const input = event.target;
+            const file = (input === null || input === void 0 ? void 0 : input.files) && input.files[0];
+            try {
+                await importCsvFromFile(file);
+            }
+            catch (error) {
+                setStatus(error instanceof Error ? error.message : "CSV 読み込みに失敗しました");
             }
             finally {
                 if (input) {

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -907,9 +907,21 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
   function exportCurrentCsv(): void {
     const model = ensureCurrentModel();
     syncXmlTextFromModel(model);
-    getTextArea("csvOutput").value = mikuprojectXml.exportCsvParentId(model);
-    setStatus("内部モデルから CSV + ParentID を生成しました");
-    showToast("CSV を生成しました");
+    const csvText = mikuprojectXml.exportCsvParentId(model);
+    const now = new Date();
+    const stamp = [
+      now.getFullYear(),
+      String(now.getMonth() + 1).padStart(2, "0"),
+      String(now.getDate()).padStart(2, "0"),
+      String(now.getHours()).padStart(2, "0"),
+      String(now.getMinutes()).padStart(2, "0")
+    ].join("");
+    downloadBlob(
+      new Blob([`${csvText}\n`], { type: "text/csv;charset=utf-8" }),
+      `mikuproject-export-${stamp}.csv`
+    );
+    setStatus("内部モデルから CSV + ParentID を生成して保存しました");
+    showToast("CSV を保存しました");
     setActiveTab("output");
   }
 
@@ -1095,8 +1107,11 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     await exportCurrentMermaid({ silent: true });
   }
 
-  async function parseCurrentCsv(): Promise<void> {
-    const csvText = getTextArea("csvInput").value.trim();
+  async function importCsvFromFile(file: File | null | undefined): Promise<void> {
+    if (!file) {
+      return;
+    }
+    const csvText = (await file.text()).trim();
     if (!csvText) {
       setStatus("CSV が空です");
       return;
@@ -1107,8 +1122,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     updateSummary(currentModel);
     renderValidationIssues(issues);
     renderXlsxImportSummary([]);
-    setStatus(issues.length > 0 ? `CSV を解析しました。検証で ${issues.length} 件の問題があります` : "CSV + ParentID を内部モデルへ変換しました");
-    showToast("CSV を解析しました");
+    setStatus(issues.length > 0 ? `CSV ファイルを読み込んで解析しました。検証で ${issues.length} 件の問題があります` : "CSV + ParentID を内部モデルへ変換しました");
+    showToast("CSV を読み込みました");
     setActiveTab("transform", { skipTransformRefresh: true });
     await exportCurrentMermaid({ silent: true });
   }
@@ -1249,11 +1264,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
       }
     });
     getElement<HTMLButtonElement>("parseCsvBtn").addEventListener("click", async () => {
-      try {
-        await parseCurrentCsv();
-      } catch (error) {
-        setStatus(error instanceof Error ? error.message : "CSV 解析に失敗しました");
-      }
+      getElement<HTMLInputElement>("importCsvInput").click();
     });
     getElement<HTMLButtonElement>("importXlsxBtn").addEventListener("click", () => {
       getElement<HTMLInputElement>("importXlsxInput").click();
@@ -1292,6 +1303,19 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         await importXlsxFromFile(file);
       } catch (error) {
         setStatus(error instanceof Error ? error.message : "XLSX 読み込みに失敗しました");
+      } finally {
+        if (input) {
+          input.value = "";
+        }
+      }
+    });
+    getElement<HTMLInputElement>("importCsvInput").addEventListener("change", async (event) => {
+      const input = event.target as HTMLInputElement | null;
+      const file = input?.files && input.files[0];
+      try {
+        await importCsvFromFile(file);
+      } catch (error) {
+        setStatus(error instanceof Error ? error.message : "CSV 読み込みに失敗しました");
       } finally {
         if (input) {
           input.value = "";

--- a/tests/mikuproject-main.test.js
+++ b/tests/mikuproject-main.test.js
@@ -65,6 +65,7 @@ function mountDom() {
     <button id="downloadXmlBtn" type="button">MS Project XML</button>
     <input id="importXmlInput" type="file" />
     <input id="importXlsxInput" type="file" />
+    <input id="importCsvInput" type="file" />
     <input id="importProjectDraftInput" type="file" />
     <input id="phaseDetailUidInput" type="text" />
     <input id="phaseDetailRootUidInput" type="text" />
@@ -85,35 +86,18 @@ function mountDom() {
       </button>
     </div>
     <section id="tabPanelInput" class="md-flow-section md-tab-panel" data-tab-panel="input">
-      <section class="md-note-card">
-        <div class="md-note-card__title-row">
-          <h3 class="md-note-card__title">XLSX 編集の扱い</h3>
+      <span class="md-button-with-help">
+        <button id="importXlsxBtnWithHelp" type="button">XLSX help host</button>
+        <span class="md-button-help-anchor">
           <lht-help-tooltip label="XLSX 編集の扱い" placement="right" wide>
-            <p class="md-note-card__text">XLSX は MS Project XML の代替正本ではなく、確認と限定編集のための周辺表現として扱います。</p>
-            <p class="md-note-card__text">現在の XLSX Import で反映するのは限定列のみです。</p>
-            <p class="md-note-card__text">反映結果は、Project / Tasks / Resources / Assignments / Calendars ごとの件数と、UID 単位の差分要約として画面上に表示します。</p>
-            <p class="md-note-card__text"><strong>反映対象</strong></p>
-            <ul class="md-note-list">
-              <li>Project: Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart</li>
-              <li>Tasks: Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes</li>
-              <li>Resources: Name / Group / MaxUnits</li>
-              <li>Assignments: Units / Work / PercentWorkComplete</li>
-              <li>Calendars: Name / IsBaseCalendar / BaseCalendarUID</li>
-              <li>NonWorkingDays: Name / Date / FromDate / ToDate / DayWorking</li>
-            </ul>
-            <p class="md-note-card__text"><strong>現在は反映しないもの</strong></p>
-            <ul class="md-note-list">
-              <li>対象外の列や未対応シートの編集</li>
-              <li>Calendars の WeekDays / WorkWeeks と、Baseline / TimephasedData / ExtendedAttributes</li>
-            </ul>
+            <p>XLSX は MS Project XML の代替正本ではなく、確認と限定編集のための周辺表現として扱います。</p>
           </lht-help-tooltip>
-        </div>
-      </section>
+        </span>
+      </span>
       <details class="md-debug-accordion">
         <summary class="md-debug-accordion__summary">デバッグ情報</summary>
         <div class="md-debug-accordion__body">
           <textarea id="xmlInput"></textarea>
-          <textarea id="csvInput"></textarea>
         </div>
       </details>
       <div id="xmlSaveState" class="md-save-state md-save-state--dirty">XML 保存状態: 未保存</div>
@@ -169,7 +153,6 @@ function mountDom() {
       <details class="md-debug-accordion">
         <summary class="md-debug-accordion__summary">デバッグ情報</summary>
         <div class="md-debug-accordion__body">
-          <textarea id="csvOutput"></textarea>
           <textarea id="projectDraftImportInput"></textarea>
           <textarea id="projectOverviewOutput"></textarea>
           <input id="phaseDetailUidInput" />
@@ -251,12 +234,7 @@ describe("mikuproject main", () => {
 
     expect(document.getElementById("xmlInput").value).toContain("<Project");
     expect(document.getElementById("statusMessage").textContent).toContain("サンプル XML");
-    expect(document.body.textContent).toContain("XLSX 編集の扱い");
     expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 未保存");
-    expect(document.body.textContent).toContain("現在の XLSX Import で反映するのは限定列のみです");
-    expect(document.body.textContent).toContain("UID 単位の差分要約として画面上に表示します");
-    expect(document.body.textContent).toContain("反映対象");
-    expect(document.body.textContent).toContain("現在は反映しないもの");
     expect(document.querySelector('lht-help-tooltip[label="XLSX 編集の扱い"]')).not.toBeNull();
     expect(document.body.textContent).toContain("取込結果");
     expect(document.body.textContent).toContain("検証メッセージ");
@@ -265,11 +243,6 @@ describe("mikuproject main", () => {
     expect(document.body.textContent).toContain("デバッグ情報");
     expect(document.querySelector(".md-debug-accordion")?.hasAttribute("open")).toBe(false);
     expect(document.querySelectorAll(".md-debug-accordion")[1]?.hasAttribute("open")).toBe(false);
-    expect(document.body.textContent).toContain("Project: Name / Title / Author / Company");
-    expect(document.body.textContent).toContain("Tasks: Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes");
-    expect(document.body.textContent).toContain("Calendars: Name / IsBaseCalendar / BaseCalendarUID");
-    expect(document.body.textContent).toContain("NonWorkingDays: Name / Date / FromDate / ToDate / DayWorking");
-    expect(document.body.textContent).toContain("Calendars の WeekDays / WorkWeeks");
     expect(document.body.textContent).toContain("WBS XLSX の祝日指定");
     expect(document.body.textContent).toContain("設定");
     expect(document.querySelectorAll(".md-debug-accordion")[2]?.hasAttribute("open")).toBe(false);
@@ -797,38 +770,55 @@ describe("mikuproject main", () => {
     expect(mermaidText).toContain("%% dependency(note): Ship has multiple predecessors");
   });
 
-  it("exports csv with parent id from the current model", () => {
+  it("exports csv with parent id from the current model", async () => {
     bootPage();
 
     parseXmlViaHook();
     document.getElementById("downloadXmlBtn").click();
+    const createObjectUrlCalls = URL.createObjectURL.mock.calls.length;
+    const anchorClickCalls = HTMLAnchorElement.prototype.click.mock.calls.length;
     const xmlInput = document.getElementById("xmlInput");
     xmlInput.value = `${xmlInput.value}\n<!-- edited -->`;
     xmlInput.dispatchEvent(new Event("input"));
     document.getElementById("exportCsvBtn").click();
 
-    const csvText = document.getElementById("csvOutput").value;
-    expect(csvText).toContain("ID,ParentID,WBS,Name,Start,Finish,PredecessorID,Resource,PercentComplete,PercentWorkComplete,Milestone,Summary,Critical,Type,Priority,Work,CalendarUID,ConstraintType,ConstraintDate,Deadline,Notes");
-    expect(csvText).toContain("1,,1,Project Summary,2026-03-16T09:00:00,2026-03-20T18:00:00,,,50,50,0,1,0,1,500,PT40H0M0S,1,,,,");
-    expect(csvText).toContain("2,1,1.1,Design,2026-03-16T09:00:00,2026-03-17T18:00:00,,Miku,100,100,0,0,0,1,500,PT16H0M0S,1,,,,Design completed");
-    expect(csvText).toContain("3,1,1.2,Implementation,2026-03-18T09:00:00,2026-03-20T18:00:00,2,Miku,0,0,0,0,1,1,700,PT24H0M0S,1,4,2026-03-18T09:00:00,2026-03-21T18:00:00,Implementation starts after design");
+    expect(URL.createObjectURL.mock.calls.length - createObjectUrlCalls).toBeGreaterThan(0);
+    expect(HTMLAnchorElement.prototype.click.mock.calls.length - anchorClickCalls).toBeGreaterThan(0);
+    const csvBlob = URL.createObjectURL.mock.calls.at(-1)?.[0];
+    expect(csvBlob).toBeTruthy();
+    expect(csvBlob.type).toBe("text/csv;charset=utf-8");
     expect(document.getElementById("xmlInput").value).not.toContain("<!-- edited -->");
     expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 保存済み (2026-03-16 23:12)");
-    expect(document.getElementById("statusMessage").textContent).toContain("CSV + ParentID を生成しました");
+    expect(document.getElementById("statusMessage").textContent).toContain("CSV + ParentID を生成して保存しました");
   });
 
   it("parses csv with parent id into internal model summary", async () => {
     bootPage();
 
-    document.getElementById("csvInput").value = [
+    const file = new File([[
       "ID,ParentID,WBS,Name,Start,Finish,PredecessorID,Resource,PercentComplete",
       "1,,1,Project Summary,2026-03-16T09:00:00,2026-03-20T18:00:00,,,50",
       "2,1,1.1,Design,2026-03-16T09:00:00,2026-03-17T18:00:00,,Miku,100",
       "3,1,1.2,Implementation,2026-03-18T09:00:00,2026-03-20T18:00:00,2,Miku,0"
-    ].join("\n");
+    ].join("\n")], "sample.csv", { type: "text/csv" });
+    Object.defineProperty(file, "text", {
+      configurable: true,
+      value: () => Promise.resolve([
+        "ID,ParentID,WBS,Name,Start,Finish,PredecessorID,Resource,PercentComplete",
+        "1,,1,Project Summary,2026-03-16T09:00:00,2026-03-20T18:00:00,,,50",
+        "2,1,1.1,Design,2026-03-16T09:00:00,2026-03-17T18:00:00,,Miku,100",
+        "3,1,1.2,Implementation,2026-03-18T09:00:00,2026-03-20T18:00:00,2,Miku,0"
+      ].join("\n"))
+    });
 
-    document.getElementById("parseCsvBtn").click();
-    await Promise.resolve();
+    const csvInput = document.getElementById("importCsvInput");
+    Object.defineProperty(csvInput, "files", {
+      value: [file],
+      configurable: true
+    });
+    csvInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
 
     expect(document.getElementById("summaryProjectName").textContent).toBe("CSV Imported Project");
     expect(document.getElementById("summaryTaskCount").textContent).toBe("3");


### PR DESCRIPTION
## 概要

`mikuproject` の Input / Output UI を整理し、CSV の扱いをテキストエリア中心からファイルベースへ変更します。あわせて、`新規生成AI連携` と `XLSX` ヘルプの表示位置を見直し、関連テストも更新します。

## 変更内容

### CSV 入出力の変更

- Input の `CSV` ボタンを、CSV ファイル選択と読込の入口に変更
- `importCsvInput` を追加
- Output の `CSV` ボタンを、内部モデルから生成した CSV のダウンロードに変更
- `csvOutput` への出力を廃止
- `csvInput` テキストエリアを廃止
- CSV 保存時のステータス文言を更新
- CSV 読込時のステータス文言とトースト文言を更新

### 生成AI連携 UI の整理

- `新規生成AI連携` の説明を、カード本文からヘルプツールチップへ移動
- `生成AIプロンプト` リンクをタイトル行へ配置
- `projectDraftImportInput` をデバッグ領域から `新規生成AI連携` カード内へ移動
- JSON 取込ボタンの近くで、そのまま JSON を貼り付けられる構成へ変更

### XLSX ヘルプ表示の整理

- `XLSX 編集の扱い` の独立カードを廃止
- `XLSX` ボタン横のヘルプ導線へ集約
- `XLSX 編集の扱い` の説明は `lht-help-tooltip` で表示する構成に変更

### レイアウト調整

- `statusMessage` を上部タブの下へ移動
- ボタン群とフォーム/カードの間隔を追加
- ヘルプアンカー用スタイルを追加

### テスト更新

- CSV 取込テストを、テキストエリア入力からファイル入力前提へ変更
- CSV 出力テストを、テキストエリア確認からダウンロード前提へ変更
- `XLSX 編集の扱い` の表示確認を、独立カード前提からツールチップ存在確認へ変更

## 変更ファイル

- `mikuproject-src.html`
- `mikuproject.html`
- `src/css/app.css`
- `src/js/main.js`
- `src/ts/main.ts`
- `tests/mikuproject-main.test.js`