### PR TITLE
README・仕様書を現行 UI に合わせて更新し、Input / Overview / Output の見た目を整理

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mikuproject
 
-`mikuproject` は、`MS Project XML` を読み込み、内部の `ProjectModel` へ変換し、再び `MS Project XML` や補助表現へ出力するためのローカル HTML ツールです。
+`mikuproject` は、`MS Project XML` を読み込み、内部モデル・`XLSX`・生成AI向け `JSON` を行き来しながら、プロジェクト計画を確認・編集するためのローカル HTML ツールです。
 
 `MS Project XML` を意味の基軸として扱い、`.xlsx` は確認・可視化・限定編集のための周辺表現として扱います。
 
@@ -10,9 +10,11 @@
 - `ProjectModel` への変換と内容確認
 - `MS Project XML` の再生成
 - Mermaid gantt テキスト生成
-- `CSV + ParentID` 生成と解析
+- `CSV + ParentID` のファイル読込とダウンロード
 - 構造忠実な `Project / Tasks / Resources / Assignments / Calendars` workbook の `XLSX Export / Import`
 - 表示専用の `WBS XLSX Export`
+- 生成AI向け `project_overview_view` / `phase_detail_view` の出力
+- 生成AIが返した `project_draft_view` の取込
 
 ## 現在の考え方
 
@@ -47,17 +49,33 @@
 
 ## 使い方
 
-もっとも簡単なのは、生成済みの [mikuproject.html](/Users/igapyon/Documents/git/mikuproject/mikuproject.html) をブラウザで開く方法です。
+もっとも簡単なのは、生成済みの [mikuproject.html](mikuproject.html) をブラウザで開く方法です。
 
 画面上では主に次の操作を行えます。
 
-- `XML Import`
-- `XML を解析`
-- `XML を再生成`
-- `XLSX Export`
-- `XLSX Import`
-- `WBS XLSX Export`
-- `Mermaid を生成`
+### Input
+
+- `MS Project XML` ファイルの読込
+- `XLSX` ファイルの限定 import
+- `CSV + ParentID` ファイルの読込
+- サンプル XML の読込
+- 生成AIが返した `project_draft_view` の JSON ファイル読込または JSON 貼り付け取込
+
+### Overview
+
+- 内部モデルの要約確認
+- validation メッセージの確認
+- Mermaid gantt プレビューの確認
+- `Project / Tasks / Resources / Assignments / Calendars` の preview 確認
+
+### Output
+
+- `MS Project XML` の保存
+- `XLSX` の保存
+- `WBS XLSX` の保存
+- `CSV + ParentID` の保存
+- Mermaid SVG の保存
+- 生成AI向け `project_overview_view` / `phase_detail_view` JSON の保存
 
 ## 開発
 
@@ -115,7 +133,7 @@ npm run build
 - `npm run build:xlsx-sample`: `local-data/` 配下へサンプル XLSX を生成します。
 - `npm run build:app`: `build:js`、`build:html`、`build:xlsx-sample` を順に実行します。
 
-[scripts/build-project.mjs](/Users/igapyon/Documents/git/mikuproject/scripts/build-project.mjs) は `--js-only` と `--html-only` を受け取り、JavaScript 生成と HTML 生成を切り替えます。
+[scripts/build-project.mjs](scripts/build-project.mjs) は `--js-only` と `--html-only` を受け取り、JavaScript 生成と HTML 生成を切り替えます。
 
 `src/ts/` を正本として扱い、`src/js/` はそこから生成する中間生成物として扱います。ただし、現状では `src/js/` も Git 管理します。ブラウザ実行、テスト、`build:xlsx-sample` は `src/js/` を参照します。
 
@@ -138,13 +156,23 @@ npm run build
 - `MS Project` 実機は未保有
 - 目標は XML の完全一致ではなく、意味的に往復できること
 - `XLSX Import` の反映対象は限定列のみ
+- `CSV + ParentID` は現在ファイルベースの補助入出力として扱う
 - `Calendars` の `WeekDays / Exceptions / WorkWeeks` などは現時点では反映対象外
 - Mermaid の SVG プレビューは `src/vendor/mermaid/mermaid.min.js` を `build:html` で内包した `mikuproject.html` を前提とする
 
+## 生成AI連携
+
+`mikuproject` は、生成AIとの直接連携に `MS Project XML` ではなく `JSON` を使います。
+
+- 既存 project 向けには `project_overview_view` と `phase_detail_view` を出力します。
+- 新規生成向けには、生成AIが返した `project_draft_view` を取り込めます。
+- 詳細な考え方は `docs/mikuproject-ai-json-spec.md` と `docs/msprojectxml-ai-integration.md` に置いています。
+
 ## 関連ドキュメント
 
-- [docs/spec.md](/Users/igapyon/Documents/git/mikuproject/docs/spec.md)
-- [docs/gap-notes.md](/Users/igapyon/Documents/git/mikuproject/docs/gap-notes.md)
-- [docs/msprojectxml-ai-integration.md](/Users/igapyon/Documents/git/mikuproject/docs/msprojectxml-ai-integration.md)
-- [docs/TODO.md](/Users/igapyon/Documents/git/mikuproject/docs/TODO.md)
-- [LICENSE](/Users/igapyon/Documents/git/mikuproject/LICENSE)
+- [docs/spec.md](docs/spec.md)
+- [docs/gap-notes.md](docs/gap-notes.md)
+- [docs/mikuproject-ai-json-spec.md](docs/mikuproject-ai-json-spec.md)
+- [docs/msprojectxml-ai-integration.md](docs/msprojectxml-ai-integration.md)
+- [docs/TODO.md](docs/TODO.md)
+- [LICENSE](LICENSE)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -10,11 +10,16 @@
 - WBS workbook と `mikuproject-sample.xlsx` のタイトル行で、フォントサイズ指定をどこまで使うか整理する
 - `Mermaid` ランタイムをこのリポジトリ内でどう扱うか決める
 - `Mermaid` の SVG プレビューを、独立リポジトリ単体で再現できるようにする
+- `mikuproject` の主要入出力を CLI からも扱えるようにするか検討する
 - `local-data/` 配下のファイルを、参照用・検証用・生成物で整理する
 - `local-data/` に置くべきでない生成物や一時ファイルがないか見直す
 - `npm test` を `scripts/run-tests.mjs` ベースへ切り替えるか検討する
 - `main.test.js` に残っている `xlsx import` の file input wiring を、UI 配線確認と import 結果確認へさらに分離する
 - `main.ts` の summary / validation / preview 描画を別モジュール化し、DOM テストをさらに軽くする
+- `phase_detail_view scoped` の `phase UID / root UID / max depth` 指定を、より選びやすい UI に改善する
+- UI の微調整として、`Input / Overview / Output` の各カードの余白・見出し・ボタン階層を見直し、`miku` 系テーマの統一感をさらに整える
+- `Overview` タブの summary / validation / preview の情報密度を見直し、どこを見る画面なのかをより直感的に伝わる構成へ調整する
+- `Output` タブの生成AI連携と各種 export ボタンの優先度表現を見直し、主操作と補助操作の区別をより明確にする
 - `build:xlsx-sample` の所要時間を個別計測し、sample workbook 生成処理の支配要因を確認する
 - `main.test.js` の初期化 DOM をケース別に最小化できるか見直す
 - CI 向けに `test:fast` と `test:full` のような実行導線を分けるか検討する

--- a/docs/gap-notes.md
+++ b/docs/gap-notes.md
@@ -261,7 +261,7 @@
 - `CSV + ParentID` は、`ID / ParentID / Name` を最小列とする「まず押さえるべき、よくある交換形式」の第1候補として整理開始した
 - `Mermaid gantt` は可視化・共有向けの片方向補助出力、`CSV + ParentID` は編集・交換向けの候補として切り分けて考える
 - `CSV + ParentID` は最小出力と最小逆変換を実装済みで、現時点の出力列は `ID / ParentID / WBS / Name / Start / Finish / PredecessorID / Resource / PercentComplete / PercentWorkComplete / Milestone / Summary / Critical / Type / Priority / Work / CalendarUID / ConstraintType / ConstraintDate / Deadline / Notes`
-- UI には `CSV を生成` に加えて `CSV を解析` 導線を追加済み
+- UI には `CSV` のダウンロード導線と、CSV ファイル読込導線を追加済み
 - 逆変換では `ParentID` から task 階層を再構築し、`PredecessorID` と `Resource` から最小の dependency / resource / assignment を復元する
 - `PredecessorID / Resource` は `|` に加えて `,` `;` `、` の複数区切りを受け、trim と重複除去をかける
 - 構造エラーとして `ID` 重複、空 `Name`、自己参照 / 欠落 / 循環 `ParentID` を import 時点で弾くようにした

--- a/docs/mikuproject-ai-json-spec.md
+++ b/docs/mikuproject-ai-json-spec.md
@@ -48,7 +48,7 @@ projection JSON の代表例:
   },
   "phases": [
     {
-      "uid": 100,
+      "uid": "100",
       "name": "要件定義",
       "wbs": "1",
       "task_count": 18,
@@ -68,7 +68,7 @@ projection JSON の代表例:
     "name": "新基幹システム導入"
   },
   "phase": {
-    "uid": 100,
+    "uid": "100",
     "name": "要件定義",
     "wbs": "1",
     "planned_start": "2026-04-01",
@@ -81,9 +81,9 @@ projection JSON の代表例:
   },
   "tasks": [
     {
-      "uid": 110,
+      "uid": "110",
       "name": "現状業務整理",
-      "parent_uid": 100,
+      "parent_uid": "100",
       "position": 0,
       "planned_duration": "PT40H",
       "planned_duration_hours": 40,
@@ -93,7 +93,7 @@ projection JSON の代表例:
   ],
   "milestones": [
     {
-      "uid": 190,
+      "uid": "190",
       "name": "要件定義完了",
       "date": "2026-05-15"
     }
@@ -116,13 +116,13 @@ projection JSON の代表例:
     "name": "新基幹システム導入"
   },
   "phase": {
-    "uid": 100,
+    "uid": "100",
     "name": "要件定義"
   },
   "target_task": {
-    "uid": 120,
+    "uid": "120",
     "name": "要件ヒアリング",
-    "parent_uid": 100,
+    "parent_uid": "100",
     "position": 1,
     "planned_duration": "PT80H",
     "planned_duration_hours": 80,
@@ -131,7 +131,7 @@ projection JSON の代表例:
   },
   "predecessors": [
     {
-      "task_uid": 110,
+      "task_uid": "110",
       "name": "現状業務整理",
       "type": "FS",
       "lag": "PT0H",
@@ -140,7 +140,7 @@ projection JSON の代表例:
   ],
   "successors": [
     {
-      "task_uid": 130,
+      "task_uid": "130",
       "name": "要件確定",
       "type": "FS",
       "lag": "PT0H",
@@ -328,8 +328,10 @@ Patch の例:
 出力ルール:
 - 対話インタフェースでは、説明文を返してよいです
 - 変更理由や不確実性を簡潔に説明してよいです
-- ただし、Patch JSON は必ず最後に 1 個の `json` コードフェンスで囲って返してください
-- `mikuproject` が処理対象にするのは、その最後の `json` コードフェンス内の Patch JSON のみです
+- ただし、最終的な機械処理対象 JSON は必ず最後に 1 個の `json` コードフェンスで囲って返してください
+- 既存編集モードでは、その最後の `json` コードフェンス内は `Patch JSON` です
+- 新規生成モードでは、その最後の `json` コードフェンス内は `project_draft_view` です
+- `mikuproject` が処理対象にするのは、その最後の `json` コードフェンス内の JSON のみです
 - 不明な場合は変更を最小にしてください
 - 変更不要なら最後の `json` コードフェンスで空の `operations` を返してください
 - 与えられていない task や field を勝手に推測しないでください

--- a/docs/msprojectxml-ai-integration.md
+++ b/docs/msprojectxml-ai-integration.md
@@ -248,6 +248,14 @@ AI 入力は 1 種類の簡約 JSON で統一するより、用途別 projection
 
 このとき、`phase_detail_view` は `full` と `scoped` の 2 モードを持てるようにしておく方が実務的である。`full` は phase 全量を渡し、`scoped` は必要に応じて `root_uid` と `max_depth` で subtree 単位に絞る。
 
+現行 UI では、既存 project 向けの生成AI連携は `Output` タブから扱う。
+
+- `project_overview_view`
+- `phase_detail_view full`
+- `phase_detail_view scoped`
+
+を JSON ファイルとして保存できる構成とし、`scoped` の場合は `phase UID`、`root UID`、`max depth` 相当の入力を伴う。
+
 一方で、既存 project の安全編集とは別に、全く新規の project 草案を AI に生成させるための `project_draft_request` / `project_draft_view` 系を分離して持つことも有効である。
 
 ## 新規生成モード
@@ -258,6 +266,13 @@ AI 入力は 1 種類の簡約 JSON で統一するより、用途別 projection
 - 新規生成モード: 粗い要件から project 草案を生成し、出力は `project_draft_view`
 
 この新規生成モードでは、AI は既存 project を変更しない。許されるのは、新しい project の全量草案を返すことだけである。
+
+現行 UI では、この新規生成モードは `Input` タブ内の `新規生成AI連携` から扱う。生成AIとの会話自体は外部で行い、`mikuproject` 側では `project_draft_view` を
+
+- JSON ファイルとして開く
+- JSON テキストを貼り付けて取り込む
+
+のいずれかで受け付ける。
 
 ### 新規生成モードの原則
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -146,6 +146,25 @@ preview / validation の現状メモ:
 - validation では、`PercentComplete` の範囲外や `Start > Finish` のような編集結果も UI 上で追えるようにする
 - validation が残っていても、`XML Export` はその時点の XML をそのまま保存できるようにする
 
+### 現在の UI 上の整理
+
+現行 UI は、概ね次の 3 画面構成で整理している。
+
+- `Input`
+  - `MS Project XML`、`XLSX`、`CSV + ParentID` の読込
+  - サンプル XML の読込
+  - 生成AIが返した `project_draft_view` の取込
+- `Overview`
+  - 内部モデルの要約確認
+  - validation の確認
+  - Mermaid gantt プレビュー
+  - preview 表示
+- `Output`
+  - `MS Project XML`、`XLSX`、`WBS XLSX`、`CSV + ParentID` の保存
+  - 生成AI向け `project_overview_view` / `phase_detail_view` の出力
+
+ここでいう `Overview` は、内部実装上の `transform` 相当タブを、ユーザー向けに読み替えた呼称である。
+
 ## STEP 1 の入力データ前提
 
 `MS Project` 実機を保有していないため、STEP 1 の入力データ前提は次のとおりとする。
@@ -720,6 +739,9 @@ STEP 1 では、次は非目標とする。
 
 - 現時点では仕様草案段階であり、`CSV + ParentID <-> ProjectModel` の完全往復仕様は未確定
 - 将来必要であれば、`tasks.csv / resources.csv / assignments.csv` の複数表構成も比較対象にする
+- 現在の UI では、`CSV + ParentID` は textarea ではなくファイルベースの補助入出力として扱う
+  - `Input` 側は CSV ファイル読込
+  - `Output` 側は CSV ダウンロード
 
 複数 CSV 構成の比較メモ:
 
@@ -832,7 +854,7 @@ STEP 1 では、次は非目標とする。
 - 最小逆変換では `ID / ParentID / Name` を必須とし、`WBS / Start / Finish / PredecessorID / Resource / PercentComplete / PercentWorkComplete / Milestone / Summary / Critical / Type / Priority / Work / CalendarUID / ConstraintType / ConstraintDate / Deadline / Notes` を可能な範囲で復元する
 - 最小逆変換では `PredecessorID / Resource` の複数値区切りとして `|` に加えて `,` `;` `、` を受け付け、trim と重複除去を行う
 - 最小逆変換では `ID` 重複、空 `Name`、自己参照 `ParentID`、欠落 `ParentID`、循環 `ParentID` を import error として扱う
-- UI には `CSV を生成` と `CSV を解析` の両導線を追加済み
+- UI には `CSV` のダウンロード導線と、CSV ファイル読込導線を追加済み
 - 現時点では `Project` 詳細、`Calendars`、`Baseline`、`TimephasedData`、assignment 詳細は CSV から完全復元しない
 
 ## 次に決めること

--- a/mikuproject-src.html
+++ b/mikuproject-src.html
@@ -47,7 +47,7 @@
         </button>
         <button type="button" class="md-top-tab ms-top-tab" data-tab="transform" role="tab" aria-selected="false" aria-controls="tabPanelTransform">
           <span class="md-top-tab-no ms-top-tab-no">2</span>
-          <span class="md-top-tab-label ms-top-tab-label">Transform</span>
+          <span class="md-top-tab-label ms-top-tab-label">Overview</span>
         </button>
         <button type="button" class="md-top-tab ms-top-tab" data-tab="output" role="tab" aria-selected="false" aria-controls="tabPanelOutput">
           <span class="md-top-tab-no ms-top-tab-no">3</span>
@@ -69,7 +69,7 @@
         <div class="md-panel-actions">
           <button id="importXmlBtn" type="button" class="md-button md-button--primary">MS Project XML</button>
           <span class="md-button-with-help">
-            <button id="importXlsxBtn" type="button" class="md-button md-button--surface">XLSX</button>
+            <button id="importXlsxBtn" type="button" class="md-button md-button--tonal">XLSX</button>
             <span class="md-button-help-anchor">
               <lht-help-tooltip label="XLSX 編集の扱い" placement="right" wide>
                 <p class="md-note-card__text">
@@ -98,7 +98,7 @@
               </lht-help-tooltip>
             </span>
           </span>
-          <button id="parseCsvBtn" type="button" class="md-button md-button--surface">CSV</button>
+          <button id="parseCsvBtn" type="button" class="md-button md-button--tonal">CSV</button>
           <button id="loadSampleBtn" type="button" class="md-button md-button--surface">サンプル</button>
           <input id="importXmlInput" type="file" accept=".xml,text/xml,application/xml" class="md-hidden" />
           <input id="importXlsxInput" type="file" accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" class="md-hidden" />
@@ -106,7 +106,7 @@
           <input id="importProjectDraftInput" type="file" accept=".json,application/json,text/plain" class="md-hidden" />
         </div>
 
-        <section class="md-note-card" aria-label="AI draft generation">
+        <section class="md-note-card md-note-card--accent" aria-label="AI draft generation">
           <div class="md-note-card__title-row">
             <h3 class="md-note-card__title">新規生成AI連携</h3>
             <lht-help-tooltip label="新規生成AI連携の説明" wide>
@@ -120,8 +120,8 @@
             生成AIとの会話は別途行います。生成AIが返した `project_draft_view` は、JSON ファイルとして開くか、JSON テキストを貼り付けてここから取り込みます。
           </p>
           <div class="md-panel-actions">
-            <button id="importProjectDraftFileBtn" type="button" class="md-button md-button--surface">JSON ファイルを開く</button>
-            <button id="importProjectDraftBtn" type="button" class="md-button md-button--surface">貼り付けた JSON を取り込む</button>
+            <button id="importProjectDraftFileBtn" type="button" class="md-button md-button--tonal">JSON ファイルを開く</button>
+            <button id="importProjectDraftBtn" type="button" class="md-button md-button--tonal">貼り付けた JSON を取り込む</button>
           </div>
           <div class="md-form-grid">
             <lht-text-field-help field-id="projectDraftImportInput" label="生成AIが返した JSON" rows="14" help-text="生成AIが返した `project_draft_view` の JSON テキストを貼り付けます。最後に json フェンスを持つ応答全体でもかまいません。"></lht-text-field-help>
@@ -140,16 +140,16 @@
         <div id="xmlSaveState" class="md-save-state md-save-state--dirty" aria-live="polite">XML 保存状態: 未保存</div>
       </section>
 
-      <section id="tabPanelTransform" class="md-flow-section md-tab-panel" data-tab-panel="transform" aria-label="transform inspect" hidden>
+      <section id="tabPanelTransform" class="md-flow-section md-tab-panel" data-tab-panel="transform" aria-label="overview" hidden>
         <div class="md-flow-section__header">
           <h2 class="md-flow-section__title">
             <span class="md-flow-section__step">2</span>
-            <span>Transform / Inspect</span>
+            <span>Overview</span>
           </h2>
-          <p class="md-flow-section__text">内部モデル、要約、プレビューをここで確認します。</p>
+          <p class="md-flow-section__text">内部モデル、要約、検証結果、プレビューをここで確認します。</p>
         </div>
 
-        <section>
+        <section class="md-note-card md-note-card--feature">
           <p id="mermaidSvgError" class="md-mermaid-error md-hidden" aria-live="polite"></p>
           <div id="mermaidSvgPreview" class="md-mermaid-preview-stage">
             <div class="md-preview-empty">Mermaid を生成すると、ここに SVG を表示します。</div>
@@ -183,7 +183,7 @@
           <summary class="md-debug-accordion__summary">デバッグ情報</summary>
           <div class="md-debug-accordion__body">
             <div class="md-panel-actions">
-              <button id="roundTripBtn" type="button" class="md-button md-button--surface">再読込テスト</button>
+              <button id="roundTripBtn" type="button" class="md-button md-button--tonal">再読込テスト</button>
             </div>
 
             <div class="md-form-grid">
@@ -239,14 +239,14 @@
         </div>
 
         <div class="md-panel-actions">
-          <button id="downloadXmlBtn" type="button" class="md-button md-button--surface">MS Project XML</button>
-          <button id="exportXlsxBtn" type="button" class="md-button md-button--surface">XLSX</button>
-          <button id="exportWbsXlsxBtn" type="button" class="md-button md-button--surface">WBS XLSX</button>
+          <button id="downloadXmlBtn" type="button" class="md-button md-button--primary">MS Project XML</button>
+          <button id="exportXlsxBtn" type="button" class="md-button md-button--tonal">XLSX</button>
+          <button id="exportWbsXlsxBtn" type="button" class="md-button md-button--tonal">WBS XLSX</button>
           <button id="downloadMermaidSvgBtn" type="button" class="md-button md-button--surface" disabled>SVG</button>
-          <button id="exportCsvBtn" type="button" class="md-button md-button--surface">CSV</button>
+          <button id="exportCsvBtn" type="button" class="md-button md-button--tonal">CSV</button>
         </div>
 
-        <section class="md-note-card" aria-label="AI integration exports">
+        <section class="md-note-card md-note-card--accent" aria-label="AI integration exports">
           <div class="md-note-card__title-row">
             <h3 class="md-note-card__title">生成AI連携</h3>
           </div>
@@ -254,10 +254,10 @@
             既存 project を生成AIへ渡すための projection JSON をここから生成します。
           </p>
           <div class="md-panel-actions">
-            <button id="exportProjectOverviewBtn" type="button" class="md-button md-button--surface">project_overview_view</button>
-            <button id="exportPhaseDetailFullBtn" type="button" class="md-button md-button--surface">phase_detail_view full</button>
+            <button id="exportProjectOverviewBtn" type="button" class="md-button md-button--tonal">project_overview_view</button>
+            <button id="exportPhaseDetailFullBtn" type="button" class="md-button md-button--tonal">phase_detail_view full</button>
           </div>
-          <section class="md-note-card" aria-label="AI scoped phase detail">
+          <section class="md-note-card md-note-card--subtle" aria-label="AI scoped phase detail">
             <h4 class="md-note-card__title">phase_detail_view scoped</h4>
             <p class="md-note-card__text">
               phase の一部だけを生成AIへ渡したい時に使います。
@@ -268,16 +268,17 @@
               <lht-text-field-help field-id="phaseDetailMaxDepthInput" label="何階層下まで含めるか" rows="1" placeholder="空欄なら全階層" help-text="起点 task から何階層下まで含めるかを指定します。0 は起点 task のみです。"></lht-text-field-help>
             </div>
             <div class="md-panel-actions">
-              <button id="exportPhaseDetailBtn" type="button" class="md-button md-button--surface">phase_detail_view scoped</button>
+              <button id="exportPhaseDetailBtn" type="button" class="md-button md-button--tonal">phase_detail_view scoped</button>
             </div>
           </section>
         </section>
 
-        <details class="md-debug-accordion">
-          <summary class="md-debug-accordion__summary">設定</summary>
-          <div class="md-debug-accordion__body">
-            <section class="md-note-card" aria-label="WBS xlsx export options">
-              <h3 class="md-note-card__title">WBS XLSX の祝日指定</h3>
+        <section class="ms-settings-card" aria-label="Output settings">
+          <details class="ms-settings-accordion">
+            <summary class="ms-settings-summary">設定</summary>
+            <div class="ms-settings-body">
+              <section class="ms-settings-block" aria-label="WBS xlsx export options">
+                <h3 class="ms-settings-subtitle">WBS XLSX の祝日指定</h3>
               <p class="md-note-card__text">
                 `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日と、`YYYY-MM-DD` 形式で指定した追加祝日を合成して WBS 日付帯へ反映します。
               </p>
@@ -331,9 +332,10 @@
               <div class="md-panel-actions">
                 <button id="resetWbsHolidayDatesBtn" type="button" class="md-button md-button--surface">WBS 祝日を既定値へ戻す</button>
               </div>
-            </section>
-          </div>
-        </details>
+              </section>
+            </div>
+          </details>
+        </section>
 
         <details class="md-debug-accordion">
           <summary class="md-debug-accordion__summary">デバッグ情報</summary>

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -1234,14 +1234,16 @@ lht-index-card-link {
   border: 1px solid rgba(148, 163, 184, 0.18);
   border-radius: 18px;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(245, 248, 252, 0.94) 100%);
-  padding: 18px 20px;
+  padding: 20px 22px;
   display: grid;
-  gap: 16px;
+  gap: 18px;
 }
 
 .md-flow-section__header {
   display: grid;
   gap: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
 }
 
 .md-flow-section__title {
@@ -1373,6 +1375,7 @@ lht-index-card-link {
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
+  align-items: center;
 }
 
 .md-button-with-help {
@@ -1439,6 +1442,12 @@ lht-index-card-link {
   box-shadow: 0 8px 20px rgba(103, 80, 164, 0.22);
 }
 
+.md-button--tonal {
+  background: linear-gradient(180deg, #f2edf8 0%, #ebe6f3 100%);
+  border-color: rgba(124, 98, 171, 0.26);
+  color: #3f315f;
+}
+
 .md-button--surface {
   background: #d9e2ec;
 }
@@ -1478,10 +1487,10 @@ lht-index-card-link {
 .md-feedback-stack {
   display: grid;
   gap: 10px;
-  padding: 10px 12px;
+  padding: 14px 16px;
   border-radius: 18px;
-  background: linear-gradient(180deg, rgba(247, 250, 253, 0.92) 0%, rgba(255, 255, 255, 0.92) 100%);
-  border: 1px solid rgba(213, 222, 231, 0.75);
+  background: linear-gradient(180deg, rgba(247, 250, 253, 0.96) 0%, rgba(255, 255, 255, 0.94) 100%);
+  border: 1px solid rgba(213, 222, 231, 0.82);
 }
 
 .md-feedback-stack.md-hidden {
@@ -1551,6 +1560,23 @@ lht-index-card-link {
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.72);
   padding: 16px 18px;
+}
+
+.md-note-card--accent {
+  border-color: rgba(157, 134, 205, 0.28);
+  background: linear-gradient(180deg, rgba(249, 245, 255, 0.96) 0%, rgba(244, 239, 252, 0.9) 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.md-note-card--subtle {
+  border-color: rgba(167, 185, 210, 0.24);
+  background: linear-gradient(180deg, rgba(250, 252, 255, 0.98) 0%, rgba(244, 247, 251, 0.96) 100%);
+}
+
+.md-note-card--feature {
+  border-color: rgba(168, 227, 224, 0.68);
+  background: linear-gradient(180deg, rgba(243, 254, 252, 0.98) 0%, rgba(233, 249, 246, 0.94) 100%);
+  box-shadow: 0 8px 18px rgba(74, 122, 118, 0.08);
 }
 
 .md-note-card__title-row {
@@ -1717,6 +1743,69 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 
 .md-debug-accordion__body .md-form-grid + .md-form-grid {
   margin-top: 16px;
+}
+
+.ms-settings-card {
+  margin-top: 16px;
+}
+
+.ms-settings-accordion {
+  border: 1px solid #d6d1e0;
+  border-radius: 16px;
+  background: #f6f2fb;
+  overflow: hidden;
+}
+
+.ms-settings-summary {
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: #4f495a;
+  padding: 14px 18px;
+  background: #eee8f6;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.ms-settings-summary::-webkit-details-marker {
+  display: none;
+}
+
+.ms-settings-summary::after {
+  content: "";
+  width: 0.52rem;
+  height: 0.52rem;
+  border-right: 1.5px solid #766f86;
+  border-bottom: 1.5px solid #766f86;
+  transform: rotate(45deg);
+  transition: transform 150ms ease;
+}
+
+.ms-settings-accordion[open] > .ms-settings-summary::after {
+  transform: rotate(225deg);
+}
+
+.ms-settings-accordion[open] > .ms-settings-summary {
+  border-bottom: 1px solid #d9d3e5;
+}
+
+.ms-settings-body {
+  padding: 16px 18px 18px;
+}
+
+.ms-settings-block {
+  display: grid;
+  gap: 4px;
+}
+
+.ms-settings-subtitle {
+  margin: 0 0 4px;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #4e495d;
 }
 
 .md-xlsx-summary {
@@ -1886,6 +1975,9 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 .md-mermaid-preview-stage {
   min-height: 16rem;
   overflow: auto;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 12px;
 }
 
 .md-mermaid-preview-stage svg {
@@ -1986,7 +2078,7 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
         </button>
         <button type="button" class="md-top-tab ms-top-tab" data-tab="transform" role="tab" aria-selected="false" aria-controls="tabPanelTransform">
           <span class="md-top-tab-no ms-top-tab-no">2</span>
-          <span class="md-top-tab-label ms-top-tab-label">Transform</span>
+          <span class="md-top-tab-label ms-top-tab-label">Overview</span>
         </button>
         <button type="button" class="md-top-tab ms-top-tab" data-tab="output" role="tab" aria-selected="false" aria-controls="tabPanelOutput">
           <span class="md-top-tab-no ms-top-tab-no">3</span>
@@ -2008,7 +2100,7 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
         <div class="md-panel-actions">
           <button id="importXmlBtn" type="button" class="md-button md-button--primary">MS Project XML</button>
           <span class="md-button-with-help">
-            <button id="importXlsxBtn" type="button" class="md-button md-button--surface">XLSX</button>
+            <button id="importXlsxBtn" type="button" class="md-button md-button--tonal">XLSX</button>
             <span class="md-button-help-anchor">
               <lht-help-tooltip label="XLSX 編集の扱い" placement="right" wide>
                 <p class="md-note-card__text">
@@ -2037,7 +2129,7 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
               </lht-help-tooltip>
             </span>
           </span>
-          <button id="parseCsvBtn" type="button" class="md-button md-button--surface">CSV</button>
+          <button id="parseCsvBtn" type="button" class="md-button md-button--tonal">CSV</button>
           <button id="loadSampleBtn" type="button" class="md-button md-button--surface">サンプル</button>
           <input id="importXmlInput" type="file" accept=".xml,text/xml,application/xml" class="md-hidden" />
           <input id="importXlsxInput" type="file" accept=".xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" class="md-hidden" />
@@ -2045,7 +2137,7 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
           <input id="importProjectDraftInput" type="file" accept=".json,application/json,text/plain" class="md-hidden" />
         </div>
 
-        <section class="md-note-card" aria-label="AI draft generation">
+        <section class="md-note-card md-note-card--accent" aria-label="AI draft generation">
           <div class="md-note-card__title-row">
             <h3 class="md-note-card__title">新規生成AI連携</h3>
             <lht-help-tooltip label="新規生成AI連携の説明" wide>
@@ -2059,8 +2151,8 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
             生成AIとの会話は別途行います。生成AIが返した `project_draft_view` は、JSON ファイルとして開くか、JSON テキストを貼り付けてここから取り込みます。
           </p>
           <div class="md-panel-actions">
-            <button id="importProjectDraftFileBtn" type="button" class="md-button md-button--surface">JSON ファイルを開く</button>
-            <button id="importProjectDraftBtn" type="button" class="md-button md-button--surface">貼り付けた JSON を取り込む</button>
+            <button id="importProjectDraftFileBtn" type="button" class="md-button md-button--tonal">JSON ファイルを開く</button>
+            <button id="importProjectDraftBtn" type="button" class="md-button md-button--tonal">貼り付けた JSON を取り込む</button>
           </div>
           <div class="md-form-grid">
             <lht-text-field-help field-id="projectDraftImportInput" label="生成AIが返した JSON" rows="14" help-text="生成AIが返した `project_draft_view` の JSON テキストを貼り付けます。最後に json フェンスを持つ応答全体でもかまいません。"></lht-text-field-help>
@@ -2079,16 +2171,16 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
         <div id="xmlSaveState" class="md-save-state md-save-state--dirty" aria-live="polite">XML 保存状態: 未保存</div>
       </section>
 
-      <section id="tabPanelTransform" class="md-flow-section md-tab-panel" data-tab-panel="transform" aria-label="transform inspect" hidden>
+      <section id="tabPanelTransform" class="md-flow-section md-tab-panel" data-tab-panel="transform" aria-label="overview" hidden>
         <div class="md-flow-section__header">
           <h2 class="md-flow-section__title">
             <span class="md-flow-section__step">2</span>
-            <span>Transform / Inspect</span>
+            <span>Overview</span>
           </h2>
-          <p class="md-flow-section__text">内部モデル、要約、プレビューをここで確認します。</p>
+          <p class="md-flow-section__text">内部モデル、要約、検証結果、プレビューをここで確認します。</p>
         </div>
 
-        <section>
+        <section class="md-note-card md-note-card--feature">
           <p id="mermaidSvgError" class="md-mermaid-error md-hidden" aria-live="polite"></p>
           <div id="mermaidSvgPreview" class="md-mermaid-preview-stage">
             <div class="md-preview-empty">Mermaid を生成すると、ここに SVG を表示します。</div>
@@ -2122,7 +2214,7 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
           <summary class="md-debug-accordion__summary">デバッグ情報</summary>
           <div class="md-debug-accordion__body">
             <div class="md-panel-actions">
-              <button id="roundTripBtn" type="button" class="md-button md-button--surface">再読込テスト</button>
+              <button id="roundTripBtn" type="button" class="md-button md-button--tonal">再読込テスト</button>
             </div>
 
             <div class="md-form-grid">
@@ -2178,14 +2270,14 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
         </div>
 
         <div class="md-panel-actions">
-          <button id="downloadXmlBtn" type="button" class="md-button md-button--surface">MS Project XML</button>
-          <button id="exportXlsxBtn" type="button" class="md-button md-button--surface">XLSX</button>
-          <button id="exportWbsXlsxBtn" type="button" class="md-button md-button--surface">WBS XLSX</button>
+          <button id="downloadXmlBtn" type="button" class="md-button md-button--primary">MS Project XML</button>
+          <button id="exportXlsxBtn" type="button" class="md-button md-button--tonal">XLSX</button>
+          <button id="exportWbsXlsxBtn" type="button" class="md-button md-button--tonal">WBS XLSX</button>
           <button id="downloadMermaidSvgBtn" type="button" class="md-button md-button--surface" disabled>SVG</button>
-          <button id="exportCsvBtn" type="button" class="md-button md-button--surface">CSV</button>
+          <button id="exportCsvBtn" type="button" class="md-button md-button--tonal">CSV</button>
         </div>
 
-        <section class="md-note-card" aria-label="AI integration exports">
+        <section class="md-note-card md-note-card--accent" aria-label="AI integration exports">
           <div class="md-note-card__title-row">
             <h3 class="md-note-card__title">生成AI連携</h3>
           </div>
@@ -2193,10 +2285,10 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
             既存 project を生成AIへ渡すための projection JSON をここから生成します。
           </p>
           <div class="md-panel-actions">
-            <button id="exportProjectOverviewBtn" type="button" class="md-button md-button--surface">project_overview_view</button>
-            <button id="exportPhaseDetailFullBtn" type="button" class="md-button md-button--surface">phase_detail_view full</button>
+            <button id="exportProjectOverviewBtn" type="button" class="md-button md-button--tonal">project_overview_view</button>
+            <button id="exportPhaseDetailFullBtn" type="button" class="md-button md-button--tonal">phase_detail_view full</button>
           </div>
-          <section class="md-note-card" aria-label="AI scoped phase detail">
+          <section class="md-note-card md-note-card--subtle" aria-label="AI scoped phase detail">
             <h4 class="md-note-card__title">phase_detail_view scoped</h4>
             <p class="md-note-card__text">
               phase の一部だけを生成AIへ渡したい時に使います。
@@ -2207,16 +2299,17 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
               <lht-text-field-help field-id="phaseDetailMaxDepthInput" label="何階層下まで含めるか" rows="1" placeholder="空欄なら全階層" help-text="起点 task から何階層下まで含めるかを指定します。0 は起点 task のみです。"></lht-text-field-help>
             </div>
             <div class="md-panel-actions">
-              <button id="exportPhaseDetailBtn" type="button" class="md-button md-button--surface">phase_detail_view scoped</button>
+              <button id="exportPhaseDetailBtn" type="button" class="md-button md-button--tonal">phase_detail_view scoped</button>
             </div>
           </section>
         </section>
 
-        <details class="md-debug-accordion">
-          <summary class="md-debug-accordion__summary">設定</summary>
-          <div class="md-debug-accordion__body">
-            <section class="md-note-card" aria-label="WBS xlsx export options">
-              <h3 class="md-note-card__title">WBS XLSX の祝日指定</h3>
+        <section class="ms-settings-card" aria-label="Output settings">
+          <details class="ms-settings-accordion">
+            <summary class="ms-settings-summary">設定</summary>
+            <div class="ms-settings-body">
+              <section class="ms-settings-block" aria-label="WBS xlsx export options">
+                <h3 class="ms-settings-subtitle">WBS XLSX の祝日指定</h3>
               <p class="md-note-card__text">
                 `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日と、`YYYY-MM-DD` 形式で指定した追加祝日を合成して WBS 日付帯へ反映します。
               </p>
@@ -2270,9 +2363,10 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
               <div class="md-panel-actions">
                 <button id="resetWbsHolidayDatesBtn" type="button" class="md-button md-button--surface">WBS 祝日を既定値へ戻す</button>
               </div>
-            </section>
-          </div>
-        </details>
+              </section>
+            </div>
+          </details>
+        </section>
 
         <details class="md-debug-accordion">
           <summary class="md-debug-accordion__summary">デバッグ情報</summary>

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -173,14 +173,16 @@
   border: 1px solid rgba(148, 163, 184, 0.18);
   border-radius: 18px;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(245, 248, 252, 0.94) 100%);
-  padding: 18px 20px;
+  padding: 20px 22px;
   display: grid;
-  gap: 16px;
+  gap: 18px;
 }
 
 .md-flow-section__header {
   display: grid;
   gap: 8px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
 }
 
 .md-flow-section__title {
@@ -312,6 +314,7 @@
   display: flex;
   gap: 12px;
   flex-wrap: wrap;
+  align-items: center;
 }
 
 .md-button-with-help {
@@ -378,6 +381,12 @@
   box-shadow: 0 8px 20px rgba(103, 80, 164, 0.22);
 }
 
+.md-button--tonal {
+  background: linear-gradient(180deg, #f2edf8 0%, #ebe6f3 100%);
+  border-color: rgba(124, 98, 171, 0.26);
+  color: #3f315f;
+}
+
 .md-button--surface {
   background: #d9e2ec;
 }
@@ -417,10 +426,10 @@
 .md-feedback-stack {
   display: grid;
   gap: 10px;
-  padding: 10px 12px;
+  padding: 14px 16px;
   border-radius: 18px;
-  background: linear-gradient(180deg, rgba(247, 250, 253, 0.92) 0%, rgba(255, 255, 255, 0.92) 100%);
-  border: 1px solid rgba(213, 222, 231, 0.75);
+  background: linear-gradient(180deg, rgba(247, 250, 253, 0.96) 0%, rgba(255, 255, 255, 0.94) 100%);
+  border: 1px solid rgba(213, 222, 231, 0.82);
 }
 
 .md-feedback-stack.md-hidden {
@@ -490,6 +499,23 @@
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.72);
   padding: 16px 18px;
+}
+
+.md-note-card--accent {
+  border-color: rgba(157, 134, 205, 0.28);
+  background: linear-gradient(180deg, rgba(249, 245, 255, 0.96) 0%, rgba(244, 239, 252, 0.9) 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.md-note-card--subtle {
+  border-color: rgba(167, 185, 210, 0.24);
+  background: linear-gradient(180deg, rgba(250, 252, 255, 0.98) 0%, rgba(244, 247, 251, 0.96) 100%);
+}
+
+.md-note-card--feature {
+  border-color: rgba(168, 227, 224, 0.68);
+  background: linear-gradient(180deg, rgba(243, 254, 252, 0.98) 0%, rgba(233, 249, 246, 0.94) 100%);
+  box-shadow: 0 8px 18px rgba(74, 122, 118, 0.08);
 }
 
 .md-note-card__title-row {
@@ -656,6 +682,69 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 
 .md-debug-accordion__body .md-form-grid + .md-form-grid {
   margin-top: 16px;
+}
+
+.ms-settings-card {
+  margin-top: 16px;
+}
+
+.ms-settings-accordion {
+  border: 1px solid #d6d1e0;
+  border-radius: 16px;
+  background: #f6f2fb;
+  overflow: hidden;
+}
+
+.ms-settings-summary {
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.92rem;
+  font-weight: 700;
+  color: #4f495a;
+  padding: 14px 18px;
+  background: #eee8f6;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.ms-settings-summary::-webkit-details-marker {
+  display: none;
+}
+
+.ms-settings-summary::after {
+  content: "";
+  width: 0.52rem;
+  height: 0.52rem;
+  border-right: 1.5px solid #766f86;
+  border-bottom: 1.5px solid #766f86;
+  transform: rotate(45deg);
+  transition: transform 150ms ease;
+}
+
+.ms-settings-accordion[open] > .ms-settings-summary::after {
+  transform: rotate(225deg);
+}
+
+.ms-settings-accordion[open] > .ms-settings-summary {
+  border-bottom: 1px solid #d9d3e5;
+}
+
+.ms-settings-body {
+  padding: 16px 18px 18px;
+}
+
+.ms-settings-block {
+  display: grid;
+  gap: 4px;
+}
+
+.ms-settings-subtitle {
+  margin: 0 0 4px;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #4e495d;
 }
 
 .md-xlsx-summary {
@@ -825,6 +914,9 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 .md-mermaid-preview-stage {
   min-height: 16rem;
   overflow: auto;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.8);
+  padding: 12px;
 }
 
 .md-mermaid-preview-stage svg {


### PR DESCRIPTION
## 概要

ドキュメントを現行の UI / 生成AI連携 / CSV 運用に合わせて更新します。あわせて、`mikuproject` の画面について `Input / Overview / Output` のカード階層やボタン強弱を見直し、`miku` 系テーマの統一感を高めます。

## 変更内容

### ドキュメント更新

- `README.md` を現行の機能と画面構成に合わせて更新
- `README.md` のリンクを相対リンクへ修正
- `README.md` に生成AI連携の説明を追加
- `docs/spec.md` に現行 UI の 3 画面構成 (`Input / Overview / Output`) を追記
- `docs/spec.md` に `CSV + ParentID` がファイルベースの補助入出力であることを追記
- `docs/msprojectxml-ai-integration.md` に現行 UI 上の生成AI連携の扱いを追記
- `docs/mikuproject-ai-json-spec.md` の example JSON で `uid` / `parent_uid` / `task_uid` を string に統一
- `docs/mikuproject-ai-json-spec.md` の出力ルールを、既存編集モードと新規生成モードの違いが分かる形へ更新
- `docs/gap-notes.md` の CSV UI 文言を現行表現へ更新
- `docs/TODO.md` に CLI 対応、`phase_detail_view scoped` の UX、UI 微調整に関する TODO を追加

### UI 調整

- `Transform` 表示を `Overview` に変更
- `Input / Overview / Output` の各カードの余白と見出しの階層を調整
- `Input` と `Output` の一部ボタンを `tonal` に変更して主操作との差を明確化
- `新規生成AI連携` と `生成AI連携` のカードをアクセント面へ調整
- `phase_detail_view scoped` を一段弱いサブカードへ整理
- `Overview` の Mermaid 領域を feature card 風に調整
- `Output` の設定カードを `mikuscore` 風の settings card に変更
- `Output` の設定はデフォルトで閉じるように変更
- `Output` の `MS Project XML` ボタンを `PRIMARY` 色に変更

## 変更ファイル

- `README.md`
- `docs/TODO.md`
- `docs/gap-notes.md`
- `docs/mikuproject-ai-json-spec.md`
- `docs/msprojectxml-ai-integration.md`
- `docs/spec.md`
- `mikuproject-src.html`
- `mikuproject.html`
- `src/css/app.css`