### PR TITLE
サンプルと Mermaid 表示を改善し、`project_draft_view` の日付補完を強化

### DIFF
--- a/mikuproject-src.html
+++ b/mikuproject-src.html
@@ -303,13 +303,15 @@
               </div>
               <div class="md-form-grid">
                 <div id="wbsHolidaySummary" class="md-status">既定祝日: 未読込</div>
-                <lht-text-field-help
-                  field-id="wbsHolidayDatesInput"
-                  label="WBS 既定祝日"
+                <label class="md-label" for="wbsHolidayDatesInput">WBS 既定祝日</label>
+                <textarea
+                  id="wbsHolidayDatesInput"
+                  class="md-textarea"
                   rows="3"
                   placeholder="2026-03-20"
                   readonly
-                  help-text="現在の ProjectModel から自動補完します。画面上では直接編集しません。"></lht-text-field-help>
+                ></textarea>
+                <div class="md-caption">現在の ProjectModel から自動補完します。画面上では直接編集しません。</div>
               </div>
               </section>
             </div>

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -2334,13 +2334,15 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
               </div>
               <div class="md-form-grid">
                 <div id="wbsHolidaySummary" class="md-status">既定祝日: 未読込</div>
-                <lht-text-field-help
-                  field-id="wbsHolidayDatesInput"
-                  label="WBS 既定祝日"
+                <label class="md-label" for="wbsHolidayDatesInput">WBS 既定祝日</label>
+                <textarea
+                  id="wbsHolidayDatesInput"
+                  class="md-textarea"
                   rows="3"
                   placeholder="2026-03-20"
                   readonly
-                  help-text="現在の ProjectModel から自動補完します。画面上では直接編集しません。"></lht-text-field-help>
+                ></textarea>
+                <div class="md-caption">現在の ProjectModel から自動補完します。画面上では直接編集しません。</div>
               </div>
               </section>
             </div>
@@ -7083,6 +7085,12 @@ if (!customElements.get("lht-page-menu")) {
         parsed.setTime(parsed.getTime() + (hours * 60 * 60 * 1000));
         return toIsoLocalString(parsed);
     }
+    function isDateOnlyText(value) {
+        return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value.trim());
+    }
+    function withTimeOnDate(dateText, timeText) {
+        return `${dateText}T${timeText}`;
+    }
     function buildProjectDraftRequest(input) {
         return {
             view_type: "project_draft_request",
@@ -7176,9 +7184,18 @@ if (!customElements.get("lht-page-menu")) {
             siblings.forEach((task, index) => {
                 const currentPath = [...outlinePath, index + 1];
                 const outlineNumber = currentPath.join(".");
-                const start = task.plannedStart || task.plannedFinish || projectStart;
-                const finish = task.plannedFinish
+                let start = task.plannedStart || task.plannedFinish || projectStart;
+                let finish = task.plannedFinish
                     || (typeof task.plannedDurationHours === "number" ? addHoursToDateTime(start, task.plannedDurationHours) : start);
+                const dateOnlyTaskRange = !task.isMilestone
+                    && isDateOnlyText(start)
+                    && isDateOnlyText(finish)
+                    && task.plannedDuration == null
+                    && typeof task.plannedDurationHours !== "number";
+                if (dateOnlyTaskRange) {
+                    start = withTimeOnDate(start, "09:00:00");
+                    finish = withTimeOnDate(finish, "18:00:00");
+                }
                 const hasChildren = (byParent.get(task.uid) || []).length > 0;
                 orderedTasks.push({
                     uid: task.uid,
@@ -14005,6 +14022,25 @@ globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default;
             return candidate;
         }
     }
+    function applyMermaidSvgTheme(svgText) {
+        if (!svgText) {
+            return svgText;
+        }
+        const styleBlock = [
+            "<style>",
+            ".section0, .section1, .section2, .section3, .section4 { fill: #f7f9ff !important; }",
+            ".task, .task0, .task1, .task2, .task3, .task4, .active, .active0, .active1, .active2, .active3, .done, .done0, .done1, .done2, .done3 { fill: #8f95e8 !important; stroke: #5d63cf !important; }",
+            ".milestone, .milestone0, .milestone1, .milestone2, .milestone3 { fill: #8f95e8 !important; stroke: #5d63cf !important; }",
+            ".grid .tick line, .tick line { stroke: #707b94 !important; }",
+            ".today { stroke: #ff3b30 !important; }",
+            ".taskText, .taskTextOutsideRight, .taskTextOutsideLeft, .sectionTitle, .titleText, text { fill: #1d2740; }",
+            "</style>"
+        ].join("");
+        if (svgText.includes(".task0") || svgText.includes(".section0")) {
+            return svgText.replace(/(<svg\b[^>]*>)/i, `$1${styleBlock}`);
+        }
+        return svgText;
+    }
     function downloadBlob(blob, filename) {
         const objectUrl = URL.createObjectURL(blob);
         const link = document.createElement("a");
@@ -14014,6 +14050,32 @@ globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default;
         link.click();
         document.body.removeChild(link);
         window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+    }
+    function getMermaidRenderConfig() {
+        return {
+            startOnLoad: false,
+            securityLevel: "strict",
+            theme: "default",
+            themeVariables: {
+                sectionBkgColor: "#f7f9ff",
+                altSectionBkgColor: "#f7f9ff",
+                sectionBkgColor2: "#f7f9ff",
+                sectionBkgColor3: "#f7f9ff",
+                sectionBkgColor4: "#f7f9ff",
+                taskBkgColor: "#8f95e8",
+                taskBorderColor: "#5d63cf",
+                taskTextColor: "#1d2740",
+                activeTaskBkgColor: "#8f95e8",
+                activeTaskBorderColor: "#5d63cf",
+                doneTaskBkgColor: "#8f95e8",
+                doneTaskBorderColor: "#5d63cf",
+                milestoneBkgColor: "#8f95e8",
+                milestoneBorderColor: "#5d63cf",
+                gridColor: "#707b94",
+                lineColor: "#707b94",
+                todayLineColor: "#ff3b30"
+            }
+        };
     }
     async function renderMermaidPreview(source) {
         if (!mermaidApi) {
@@ -14025,14 +14087,10 @@ globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default;
         }
         clearMermaidError();
         const renderId = `mikuprojectMermaidRender${++mermaidRenderCount}`;
-        mermaidApi.initialize({
-            startOnLoad: false,
-            securityLevel: "strict",
-            theme: "default"
-        });
+        mermaidApi.initialize(getMermaidRenderConfig());
         try {
             const result = await mermaidApi.render(renderId, source);
-            currentMermaidSvg = normalizeSvgForXml(result.svg);
+            currentMermaidSvg = applyMermaidSvgTheme(normalizeSvgForXml(result.svg));
             setMermaidPreviewMarkup(currentMermaidSvg);
             updateMermaidSvgButton();
         }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -245,6 +245,25 @@
             return candidate;
         }
     }
+    function applyMermaidSvgTheme(svgText) {
+        if (!svgText) {
+            return svgText;
+        }
+        const styleBlock = [
+            "<style>",
+            ".section0, .section1, .section2, .section3, .section4 { fill: #f7f9ff !important; }",
+            ".task, .task0, .task1, .task2, .task3, .task4, .active, .active0, .active1, .active2, .active3, .done, .done0, .done1, .done2, .done3 { fill: #8f95e8 !important; stroke: #5d63cf !important; }",
+            ".milestone, .milestone0, .milestone1, .milestone2, .milestone3 { fill: #8f95e8 !important; stroke: #5d63cf !important; }",
+            ".grid .tick line, .tick line { stroke: #707b94 !important; }",
+            ".today { stroke: #ff3b30 !important; }",
+            ".taskText, .taskTextOutsideRight, .taskTextOutsideLeft, .sectionTitle, .titleText, text { fill: #1d2740; }",
+            "</style>"
+        ].join("");
+        if (svgText.includes(".task0") || svgText.includes(".section0")) {
+            return svgText.replace(/(<svg\b[^>]*>)/i, `$1${styleBlock}`);
+        }
+        return svgText;
+    }
     function downloadBlob(blob, filename) {
         const objectUrl = URL.createObjectURL(blob);
         const link = document.createElement("a");
@@ -254,6 +273,32 @@
         link.click();
         document.body.removeChild(link);
         window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+    }
+    function getMermaidRenderConfig() {
+        return {
+            startOnLoad: false,
+            securityLevel: "strict",
+            theme: "default",
+            themeVariables: {
+                sectionBkgColor: "#f7f9ff",
+                altSectionBkgColor: "#f7f9ff",
+                sectionBkgColor2: "#f7f9ff",
+                sectionBkgColor3: "#f7f9ff",
+                sectionBkgColor4: "#f7f9ff",
+                taskBkgColor: "#8f95e8",
+                taskBorderColor: "#5d63cf",
+                taskTextColor: "#1d2740",
+                activeTaskBkgColor: "#8f95e8",
+                activeTaskBorderColor: "#5d63cf",
+                doneTaskBkgColor: "#8f95e8",
+                doneTaskBorderColor: "#5d63cf",
+                milestoneBkgColor: "#8f95e8",
+                milestoneBorderColor: "#5d63cf",
+                gridColor: "#707b94",
+                lineColor: "#707b94",
+                todayLineColor: "#ff3b30"
+            }
+        };
     }
     async function renderMermaidPreview(source) {
         if (!mermaidApi) {
@@ -265,14 +310,10 @@
         }
         clearMermaidError();
         const renderId = `mikuprojectMermaidRender${++mermaidRenderCount}`;
-        mermaidApi.initialize({
-            startOnLoad: false,
-            securityLevel: "strict",
-            theme: "default"
-        });
+        mermaidApi.initialize(getMermaidRenderConfig());
         try {
             const result = await mermaidApi.render(renderId, source);
-            currentMermaidSvg = normalizeSvgForXml(result.svg);
+            currentMermaidSvg = applyMermaidSvgTheme(normalizeSvgForXml(result.svg));
             setMermaidPreviewMarkup(currentMermaidSvg);
             updateMermaidSvgButton();
         }

--- a/src/js/msproject-xml.js
+++ b/src/js/msproject-xml.js
@@ -1566,6 +1566,12 @@
         parsed.setTime(parsed.getTime() + (hours * 60 * 60 * 1000));
         return toIsoLocalString(parsed);
     }
+    function isDateOnlyText(value) {
+        return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value.trim());
+    }
+    function withTimeOnDate(dateText, timeText) {
+        return `${dateText}T${timeText}`;
+    }
     function buildProjectDraftRequest(input) {
         return {
             view_type: "project_draft_request",
@@ -1659,9 +1665,18 @@
             siblings.forEach((task, index) => {
                 const currentPath = [...outlinePath, index + 1];
                 const outlineNumber = currentPath.join(".");
-                const start = task.plannedStart || task.plannedFinish || projectStart;
-                const finish = task.plannedFinish
+                let start = task.plannedStart || task.plannedFinish || projectStart;
+                let finish = task.plannedFinish
                     || (typeof task.plannedDurationHours === "number" ? addHoursToDateTime(start, task.plannedDurationHours) : start);
+                const dateOnlyTaskRange = !task.isMilestone
+                    && isDateOnlyText(start)
+                    && isDateOnlyText(finish)
+                    && task.plannedDuration == null
+                    && typeof task.plannedDurationHours !== "number";
+                if (dateOnlyTaskRange) {
+                    start = withTimeOnDate(start, "09:00:00");
+                    finish = withTimeOnDate(finish, "18:00:00");
+                }
                 const hasChildren = (byParent.get(task.uid) || []).length > 0;
                 orderedTasks.push({
                     uid: task.uid,

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -355,6 +355,28 @@
     }
   }
 
+  function applyMermaidSvgTheme(svgText: string): string {
+    if (!svgText) {
+      return svgText;
+    }
+
+    const styleBlock = [
+      "<style>",
+      ".section0, .section1, .section2, .section3, .section4 { fill: #f7f9ff !important; }",
+      ".task, .task0, .task1, .task2, .task3, .task4, .active, .active0, .active1, .active2, .active3, .done, .done0, .done1, .done2, .done3 { fill: #8f95e8 !important; stroke: #5d63cf !important; }",
+      ".milestone, .milestone0, .milestone1, .milestone2, .milestone3 { fill: #8f95e8 !important; stroke: #5d63cf !important; }",
+      ".grid .tick line, .tick line { stroke: #707b94 !important; }",
+      ".today { stroke: #ff3b30 !important; }",
+      ".taskText, .taskTextOutsideRight, .taskTextOutsideLeft, .sectionTitle, .titleText, text { fill: #1d2740; }",
+      "</style>"
+    ].join("");
+
+    if (svgText.includes(".task0") || svgText.includes(".section0")) {
+      return svgText.replace(/(<svg\b[^>]*>)/i, `$1${styleBlock}`);
+    }
+    return svgText;
+  }
+
   function downloadBlob(blob: Blob, filename: string): void {
     const objectUrl = URL.createObjectURL(blob);
     const link = document.createElement("a");
@@ -364,6 +386,33 @@
     link.click();
     document.body.removeChild(link);
     window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+  }
+
+  function getMermaidRenderConfig(): Record<string, unknown> {
+    return {
+      startOnLoad: false,
+      securityLevel: "strict",
+      theme: "default",
+      themeVariables: {
+        sectionBkgColor: "#f7f9ff",
+        altSectionBkgColor: "#f7f9ff",
+        sectionBkgColor2: "#f7f9ff",
+        sectionBkgColor3: "#f7f9ff",
+        sectionBkgColor4: "#f7f9ff",
+        taskBkgColor: "#8f95e8",
+        taskBorderColor: "#5d63cf",
+        taskTextColor: "#1d2740",
+        activeTaskBkgColor: "#8f95e8",
+        activeTaskBorderColor: "#5d63cf",
+        doneTaskBkgColor: "#8f95e8",
+        doneTaskBorderColor: "#5d63cf",
+        milestoneBkgColor: "#8f95e8",
+        milestoneBorderColor: "#5d63cf",
+        gridColor: "#707b94",
+        lineColor: "#707b94",
+        todayLineColor: "#ff3b30"
+      }
+    };
   }
 
   async function renderMermaidPreview(source: string): Promise<void> {
@@ -377,15 +426,11 @@
 
     clearMermaidError();
     const renderId = `mikuprojectMermaidRender${++mermaidRenderCount}`;
-    mermaidApi.initialize({
-      startOnLoad: false,
-      securityLevel: "strict",
-      theme: "default"
-    });
+    mermaidApi.initialize(getMermaidRenderConfig());
 
     try {
       const result = await mermaidApi.render(renderId, source);
-      currentMermaidSvg = normalizeSvgForXml(result.svg);
+      currentMermaidSvg = applyMermaidSvgTheme(normalizeSvgForXml(result.svg));
       setMermaidPreviewMarkup(currentMermaidSvg);
       updateMermaidSvgButton();
     } catch (error) {

--- a/src/ts/msproject-xml.ts
+++ b/src/ts/msproject-xml.ts
@@ -1622,6 +1622,14 @@
     return toIsoLocalString(parsed);
   }
 
+  function isDateOnlyText(value: string | undefined): boolean {
+    return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value.trim());
+  }
+
+  function withTimeOnDate(dateText: string, timeText: string): string {
+    return `${dateText}T${timeText}`;
+  }
+
   function buildProjectDraftRequest(input: {
     name: string;
     plannedStart?: string;
@@ -1743,9 +1751,18 @@
       siblings.forEach((task, index) => {
         const currentPath = [...outlinePath, index + 1];
         const outlineNumber = currentPath.join(".");
-        const start = task.plannedStart || task.plannedFinish || projectStart;
-        const finish = task.plannedFinish
+        let start = task.plannedStart || task.plannedFinish || projectStart;
+        let finish = task.plannedFinish
           || (typeof task.plannedDurationHours === "number" ? addHoursToDateTime(start, task.plannedDurationHours) : start);
+        const dateOnlyTaskRange = !task.isMilestone
+          && isDateOnlyText(start)
+          && isDateOnlyText(finish)
+          && task.plannedDuration == null
+          && typeof task.plannedDurationHours !== "number";
+        if (dateOnlyTaskRange) {
+          start = withTimeOnDate(start, "09:00:00");
+          finish = withTimeOnDate(finish, "18:00:00");
+        }
         const hasChildren = (byParent.get(task.uid) || []).length > 0;
         orderedTasks.push({
           uid: task.uid,

--- a/tests/mikuproject-main.test.js
+++ b/tests/mikuproject-main.test.js
@@ -356,12 +356,13 @@ describe("mikuproject main", () => {
         view_type: "project_draft_view",
         project: {
           name: "新規基幹刷新",
-          planned_start: "2026-04-01T09:00:00"
+          planned_start: "2026-04-01"
         },
         tasks: [
           { uid: "draft-1", name: "要件定義", parent_uid: null, position: 0, is_summary: true },
-          { uid: "draft-2", name: "ヒアリング", parent_uid: "draft-1", position: 0, planned_finish: "2026-04-01T09:00:00" },
-          { uid: "draft-3", name: "要件確定", parent_uid: "draft-1", position: 1, is_milestone: true, predecessors: ["draft-2"], planned_start: "2026-04-08T18:00:00", planned_finish: "2026-04-08T18:00:00" }
+          { uid: "draft-2", name: "ヒアリング", parent_uid: "draft-1", position: 0, planned_finish: "2026-04-01" },
+          { uid: "draft-3", name: "整理期間", parent_uid: "draft-1", position: 1, planned_start: "2026-04-02", planned_finish: "2026-04-03" },
+          { uid: "draft-4", name: "要件確定", parent_uid: "draft-1", position: 2, is_milestone: true, predecessors: ["draft-2"], planned_start: "2026-04-08T18:00:00", planned_finish: "2026-04-08T18:00:00" }
         ]
       }, null, 2),
       "```"
@@ -372,7 +373,7 @@ describe("mikuproject main", () => {
     await flushAsyncWork();
 
     expect(document.getElementById("summaryProjectName").textContent).toBe("新規基幹刷新");
-    expect(document.getElementById("summaryTaskCount").textContent).toBe("3");
+    expect(document.getElementById("summaryTaskCount").textContent).toBe("4");
     expect(document.getElementById("summaryCalendarCount").textContent).toBe("1");
     expect(document.getElementById("xmlInput").value).toContain("<Name>新規基幹刷新</Name>");
     expect(document.getElementById("xmlInput").value).toContain("<CalendarUID>1</CalendarUID>");
@@ -381,11 +382,14 @@ describe("mikuproject main", () => {
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"ヒアリング\"");
     expect(document.getElementById("modelOutput").value).toContain("\"milestone\": false");
     expect(document.getElementById("modelOutput").value).toContain("\"start\": \"2026-04-01T09:00:00\"");
-    expect(document.getElementById("modelOutput").value).toContain("\"finish\": \"2026-04-01T09:00:00\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"finish\": \"2026-04-01T18:00:00\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"name\": \"整理期間\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"start\": \"2026-04-02T09:00:00\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"finish\": \"2026-04-03T18:00:00\"");
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"要件確定\"");
     expect(document.getElementById("modelOutput").value).toContain("\"milestone\": true");
-    expect(document.getElementById("modelOutput").value).toContain("\"uid\": \"3\"");
-    expect(document.getElementById("modelOutput").value).not.toContain("\"uid\": \"draft-3\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"uid\": \"4\"");
+    expect(document.getElementById("modelOutput").value).not.toContain("\"uid\": \"draft-4\"");
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Standard\"");
   });
 

--- a/tests/mikuproject-project-xlsx.test.js
+++ b/tests/mikuproject-project-xlsx.test.js
@@ -123,7 +123,7 @@ describe("mikuproject project xlsx", () => {
       "Notes"
     ]);
     expect(tasksSheet.rows[3].cells[2].value).toBe("基盤整備");
-    expect(tasksSheet.rows[3].cells[6].value).toBe("2026-03-16");
+    expect(tasksSheet.rows[3].cells[6].value).toBe("2026-03-16 09:00:00");
     expect(tasksSheet.rows[3].cells[2].bold).toBe(true);
     expect(tasksSheet.rows[3].cells[2].fillColor).toBe(EDITABLE_FILL);
     expect(tasksSheet.rows[3].cells[12].fillColor).toBe("#E6F2E0");


### PR DESCRIPTION
## 概要

`project_draft_view` ベースのサンプルデータを更新し、Mermaid / SVG / Excel の見え方が揃うように調整します。あわせて、通常 task の日付だけ指定に対する時刻補完ロジックを強化し、関連 UI とテストも整理します。

## 変更内容

### サンプルデータの更新

- `mikuproject開発` を題材にした `project_draft_view` ベースのサンプルへ更新
- phase / task / milestone を含む構成へ整理
- `架空検討フェーズ【架空】` とその配下 task を含むサンプルを追加
- 既存 XML サンプルも、この sample draft から生成する形へ整理

### `project_draft_view` 取込の改善

- `draft-*` UID を取込時に整数 UID へ再採番
- `is_milestone: true` のときだけ milestone として扱うよう修正
- `planned_finish` のみ指定された task は、同日 `planned_start` を補完
- 通常 task で日付だけ指定された場合は、同日 task だけでなく複数日 task でも
  - `start = 09:00:00`
  - `finish = 18:00:00` へ補完するよう変更

### Mermaid / SVG 表示改善

- Mermaid gantt の task ラベル安全化を維持しつつ、通常 task バーが見えるよう調整
- Mermaid preview と SVG ダウンロードで同じレンダリング設定を使うよう整理
- Mermaid が返す SVG に共通 CSS を注入し、
  - section 背景
  - 通常 task バー
  - milestone
  - grid / today line の見た目を固定
- これにより、`架空検討フェーズ【架空】` 配下の multi-day task が preview / SVG で見えるように変更

### UI の整理

- `新規生成AI連携` の `サンプル` ボタン位置を調整
- `サンプル` ボタン押下時は、`生成AIが返した JSON` のテキストエリアへ sample JSON を入れるよう整理
- `WBS 既定祝日` の read-only 欄を、`lht-text-field-help` から通常の `textarea` へ変更
- `readonly + rows` による `translateY(NaNpx)` エラーを回避

### テスト・ビルド更新

- `tests/mikuproject-main.test.js` を更新
- `tests/mikuproject-project-xlsx.test.js` を更新
- Mermaid / draft import / sample / Project XLSX の期待値を現行挙動へ追随
- 確認結果: `npm run build` 通過、`147 passed / 147`

## 変更ファイル

- `mikuproject-src.html`
- `mikuproject.html`
- `src/ts/main.ts`
- `src/ts/msproject-xml.ts`
- `tests/mikuproject-main.test.js`
- `tests/mikuproject-project-xlsx.test.js`