### PR TITLE
サンプルデータと Mermaid/WBS 表示を改善し、`project_draft_view` の取込補完を強化

### DIFF
--- a/mikuproject.html
+++ b/mikuproject.html
@@ -5536,6 +5536,7 @@ if (!customElements.get("lht-page-menu")) {
                 parent_uid: null,
                 position: 0,
                 is_summary: true,
+                percent_complete: 100,
                 planned_start: "2026-03-16",
                 planned_finish: "2026-03-17"
             },
@@ -5545,6 +5546,7 @@ if (!customElements.get("lht-page-menu")) {
                 parent_uid: "draft-100",
                 position: 0,
                 is_milestone: true,
+                percent_complete: 100,
                 planned_start: "2026-03-16",
                 planned_finish: "2026-03-16"
             },
@@ -5553,6 +5555,7 @@ if (!customElements.get("lht-page-menu")) {
                 name: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）",
                 parent_uid: "draft-100",
                 position: 1,
+                percent_complete: 100,
                 planned_start: "2026-03-16",
                 planned_finish: "2026-03-16"
             },
@@ -5561,6 +5564,7 @@ if (!customElements.get("lht-page-menu")) {
                 name: "round-trip拡張（MS Project XML → 内部JSON形式 → MS Project XML の往復対応）",
                 parent_uid: "draft-100",
                 position: 2,
+                percent_complete: 100,
                 planned_start: "2026-03-17",
                 planned_finish: "2026-03-17"
             },
@@ -5570,6 +5574,7 @@ if (!customElements.get("lht-page-menu")) {
                 parent_uid: null,
                 position: 1,
                 is_summary: true,
+                percent_complete: 25,
                 planned_start: "2026-03-19",
                 planned_finish: "2026-03-25"
             },
@@ -5578,6 +5583,7 @@ if (!customElements.get("lht-page-menu")) {
                 name: "ユーザー操作フローの見直し【架空】",
                 parent_uid: "draft-150",
                 position: 0,
+                percent_complete: 50,
                 planned_start: "2026-03-19",
                 planned_finish: "2026-03-23"
             },
@@ -6576,7 +6582,10 @@ if (!customElements.get("lht-page-menu")) {
   
     */
     function buildSampleXml() {
-        return exportMsProjectXml(importProjectDraftView(SAMPLE_PROJECT_DRAFT_VIEW));
+        const sampleModel = importProjectDraftView(SAMPLE_PROJECT_DRAFT_VIEW);
+        sampleModel.project.currentDate = "2026-03-23T09:00:00";
+        sampleModel.project.statusDate = "2026-03-23T09:00:00";
+        return exportMsProjectXml(sampleModel);
     }
     function textContent(parent, tagName) {
         const element = parent.getElementsByTagName(tagName)[0];
@@ -7151,6 +7160,9 @@ if (!customElements.get("lht-page-menu")) {
             position: typeof task.position === "number" && Number.isFinite(task.position) ? task.position : index,
             isSummary: Boolean(task.is_summary),
             isMilestone: Boolean(task.is_milestone),
+            percentComplete: typeof task.percent_complete === "number" && Number.isFinite(task.percent_complete)
+                ? Math.max(0, Math.min(100, task.percent_complete))
+                : 0,
             plannedDuration: task.planned_duration || undefined,
             plannedDurationHours: typeof task.planned_duration_hours === "number" && Number.isFinite(task.planned_duration_hours)
                 ? task.planned_duration_hours
@@ -7209,7 +7221,7 @@ if (!customElements.get("lht-page-menu")) {
                     duration: task.plannedDuration || (typeof task.plannedDurationHours === "number" ? `PT${task.plannedDurationHours}H` : "PT0H0M0S"),
                     milestone: task.isMilestone,
                     summary: task.isSummary || hasChildren,
-                    percentComplete: 0,
+                    percentComplete: task.percentComplete,
                     predecessors: task.predecessorUids.map((predecessorUid) => ({ predecessorUid })),
                     extendedAttributes: [],
                     baselines: [],

--- a/src/js/msproject-xml.js
+++ b/src/js/msproject-xml.js
@@ -17,6 +17,7 @@
                 parent_uid: null,
                 position: 0,
                 is_summary: true,
+                percent_complete: 100,
                 planned_start: "2026-03-16",
                 planned_finish: "2026-03-17"
             },
@@ -26,6 +27,7 @@
                 parent_uid: "draft-100",
                 position: 0,
                 is_milestone: true,
+                percent_complete: 100,
                 planned_start: "2026-03-16",
                 planned_finish: "2026-03-16"
             },
@@ -34,6 +36,7 @@
                 name: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）",
                 parent_uid: "draft-100",
                 position: 1,
+                percent_complete: 100,
                 planned_start: "2026-03-16",
                 planned_finish: "2026-03-16"
             },
@@ -42,6 +45,7 @@
                 name: "round-trip拡張（MS Project XML → 内部JSON形式 → MS Project XML の往復対応）",
                 parent_uid: "draft-100",
                 position: 2,
+                percent_complete: 100,
                 planned_start: "2026-03-17",
                 planned_finish: "2026-03-17"
             },
@@ -51,6 +55,7 @@
                 parent_uid: null,
                 position: 1,
                 is_summary: true,
+                percent_complete: 25,
                 planned_start: "2026-03-19",
                 planned_finish: "2026-03-25"
             },
@@ -59,6 +64,7 @@
                 name: "ユーザー操作フローの見直し【架空】",
                 parent_uid: "draft-150",
                 position: 0,
+                percent_complete: 50,
                 planned_start: "2026-03-19",
                 planned_finish: "2026-03-23"
             },
@@ -1057,7 +1063,10 @@
   
     */
     function buildSampleXml() {
-        return exportMsProjectXml(importProjectDraftView(SAMPLE_PROJECT_DRAFT_VIEW));
+        const sampleModel = importProjectDraftView(SAMPLE_PROJECT_DRAFT_VIEW);
+        sampleModel.project.currentDate = "2026-03-23T09:00:00";
+        sampleModel.project.statusDate = "2026-03-23T09:00:00";
+        return exportMsProjectXml(sampleModel);
     }
     function textContent(parent, tagName) {
         const element = parent.getElementsByTagName(tagName)[0];
@@ -1632,6 +1641,9 @@
             position: typeof task.position === "number" && Number.isFinite(task.position) ? task.position : index,
             isSummary: Boolean(task.is_summary),
             isMilestone: Boolean(task.is_milestone),
+            percentComplete: typeof task.percent_complete === "number" && Number.isFinite(task.percent_complete)
+                ? Math.max(0, Math.min(100, task.percent_complete))
+                : 0,
             plannedDuration: task.planned_duration || undefined,
             plannedDurationHours: typeof task.planned_duration_hours === "number" && Number.isFinite(task.planned_duration_hours)
                 ? task.planned_duration_hours
@@ -1690,7 +1702,7 @@
                     duration: task.plannedDuration || (typeof task.plannedDurationHours === "number" ? `PT${task.plannedDurationHours}H` : "PT0H0M0S"),
                     milestone: task.isMilestone,
                     summary: task.isSummary || hasChildren,
-                    percentComplete: 0,
+                    percentComplete: task.percentComplete,
                     predecessors: task.predecessorUids.map((predecessorUid) => ({ predecessorUid })),
                     extendedAttributes: [],
                     baselines: [],

--- a/src/ts/msproject-xml.ts
+++ b/src/ts/msproject-xml.ts
@@ -17,6 +17,7 @@
         parent_uid: null,
         position: 0,
         is_summary: true,
+        percent_complete: 100,
         planned_start: "2026-03-16",
         planned_finish: "2026-03-17"
       },
@@ -26,6 +27,7 @@
         parent_uid: "draft-100",
         position: 0,
         is_milestone: true,
+        percent_complete: 100,
         planned_start: "2026-03-16",
         planned_finish: "2026-03-16"
       },
@@ -34,6 +36,7 @@
         name: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）",
         parent_uid: "draft-100",
         position: 1,
+        percent_complete: 100,
         planned_start: "2026-03-16",
         planned_finish: "2026-03-16"
       },
@@ -42,6 +45,7 @@
         name: "round-trip拡張（MS Project XML → 内部JSON形式 → MS Project XML の往復対応）",
         parent_uid: "draft-100",
         position: 2,
+        percent_complete: 100,
         planned_start: "2026-03-17",
         planned_finish: "2026-03-17"
       },
@@ -51,6 +55,7 @@
         parent_uid: null,
         position: 1,
         is_summary: true,
+        percent_complete: 25,
         planned_start: "2026-03-19",
         planned_finish: "2026-03-25"
       },
@@ -59,6 +64,7 @@
         name: "ユーザー操作フローの見直し【架空】",
         parent_uid: "draft-150",
         position: 0,
+        percent_complete: 50,
         planned_start: "2026-03-19",
         planned_finish: "2026-03-23"
       },
@@ -1059,7 +1065,10 @@
   */
 
   function buildSampleXml(): string {
-    return exportMsProjectXml(importProjectDraftView(SAMPLE_PROJECT_DRAFT_VIEW));
+    const sampleModel = importProjectDraftView(SAMPLE_PROJECT_DRAFT_VIEW);
+    sampleModel.project.currentDate = "2026-03-23T09:00:00";
+    sampleModel.project.statusDate = "2026-03-23T09:00:00";
+    return exportMsProjectXml(sampleModel);
   }
 
   function textContent(parent: Element, tagName: string): string {
@@ -1671,6 +1680,7 @@
         position?: number;
         is_summary?: boolean;
         is_milestone?: boolean;
+        percent_complete?: number;
         planned_duration?: string;
         planned_duration_hours?: number;
         planned_start?: string;
@@ -1718,6 +1728,9 @@
       position: typeof task.position === "number" && Number.isFinite(task.position) ? task.position : index,
       isSummary: Boolean(task.is_summary),
       isMilestone: Boolean(task.is_milestone),
+      percentComplete: typeof task.percent_complete === "number" && Number.isFinite(task.percent_complete)
+        ? Math.max(0, Math.min(100, task.percent_complete))
+        : 0,
       plannedDuration: task.planned_duration || undefined,
       plannedDurationHours: typeof task.planned_duration_hours === "number" && Number.isFinite(task.planned_duration_hours)
         ? task.planned_duration_hours
@@ -1776,7 +1789,7 @@
           duration: task.plannedDuration || (typeof task.plannedDurationHours === "number" ? `PT${task.plannedDurationHours}H` : "PT0H0M0S"),
           milestone: task.isMilestone,
           summary: task.isSummary || hasChildren,
-          percentComplete: 0,
+          percentComplete: task.percentComplete,
           predecessors: task.predecessorUids.map((predecessorUid) => ({ predecessorUid })),
           extendedAttributes: [],
           baselines: [],

--- a/tests/mikuproject-main.test.js
+++ b/tests/mikuproject-main.test.js
@@ -359,8 +359,8 @@ describe("mikuproject main", () => {
           planned_start: "2026-04-01"
         },
         tasks: [
-          { uid: "draft-1", name: "要件定義", parent_uid: null, position: 0, is_summary: true },
-          { uid: "draft-2", name: "ヒアリング", parent_uid: "draft-1", position: 0, planned_finish: "2026-04-01" },
+          { uid: "draft-1", name: "要件定義", parent_uid: null, position: 0, is_summary: true, percent_complete: 100 },
+          { uid: "draft-2", name: "ヒアリング", parent_uid: "draft-1", position: 0, percent_complete: 50, planned_finish: "2026-04-01" },
           { uid: "draft-3", name: "整理期間", parent_uid: "draft-1", position: 1, planned_start: "2026-04-02", planned_finish: "2026-04-03" },
           { uid: "draft-4", name: "要件確定", parent_uid: "draft-1", position: 2, is_milestone: true, predecessors: ["draft-2"], planned_start: "2026-04-08T18:00:00", planned_finish: "2026-04-08T18:00:00" }
         ]
@@ -381,6 +381,8 @@ describe("mikuproject main", () => {
     expect(document.getElementById("xmlInput").value).toContain("<UID>3</UID>");
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"ヒアリング\"");
     expect(document.getElementById("modelOutput").value).toContain("\"milestone\": false");
+    expect(document.getElementById("modelOutput").value).toContain("\"percentComplete\": 100");
+    expect(document.getElementById("modelOutput").value).toContain("\"percentComplete\": 50");
     expect(document.getElementById("modelOutput").value).toContain("\"start\": \"2026-04-01T09:00:00\"");
     expect(document.getElementById("modelOutput").value).toContain("\"finish\": \"2026-04-01T18:00:00\"");
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"整理期間\"");
@@ -853,7 +855,7 @@ describe("mikuproject main", () => {
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Resources, Assignments, Calendars");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=3 初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("Name: 初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定） -> 初期実装 Imported From XLSX");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("PercentComplete: 0 -> 77");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("PercentComplete: 100 -> 77");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("反映後の XML は更新済みです");
     expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
     expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);

--- a/tests/mikuproject-project-xlsx.test.js
+++ b/tests/mikuproject-project-xlsx.test.js
@@ -380,7 +380,7 @@ describe("mikuproject project xlsx", () => {
 
     expect(result.changes).toEqual([
       { scope: "tasks", uid: "3", label: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）", field: "Name", before: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）", after: "初期実装 Updated" },
-      { scope: "tasks", uid: "3", label: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）", field: "PercentComplete", before: 0, after: 80 },
+      { scope: "tasks", uid: "3", label: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）", field: "PercentComplete", before: 100, after: 80 },
       { scope: "tasks", uid: "3", label: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）", field: "Notes", before: undefined, after: "Updated Notes" }
     ]);
   });

--- a/tests/mikuproject-wbs-xlsx.test.js
+++ b/tests/mikuproject-wbs-xlsx.test.js
@@ -141,7 +141,7 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.rows[projectInfoHeaderIndex + 5].cells[0].value).toBe("終了日");
     expect(sheet.rows[projectInfoHeaderIndex + 5].cells[2].value).toBe("2026-04-01");
     expect(sheet.rows[projectInfoHeaderIndex + 6].cells[0].value).toBe("現在日");
-    expect(sheet.rows[projectInfoHeaderIndex + 6].cells[2].value).toBe("-");
+    expect(sheet.rows[projectInfoHeaderIndex + 6].cells[2].value).toBe("2026-03-23");
     expect(sheet.rows[projectInfoHeaderIndex + 7].cells[0].value).toBe("祝日");
     expect(sheet.rows[projectInfoHeaderIndex + 7].cells[2].value).toBeGreaterThan(0);
     const summaryHeaderIndex = findRowIndexByCellValue(sheet, "サマリ", 5);
@@ -175,7 +175,7 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.rows[summaryHeaderIndex + 4].cells[8].value).toBe("カレンダ");
     expect(sheet.rows[summaryHeaderIndex + 4].cells[9].value).toBe(1);
     expect(sheet.rows[summaryHeaderIndex + 8].cells[5].value).toBe("基準日");
-    expect(sheet.rows[summaryHeaderIndex + 8].cells[6].value).toBe("-");
+    expect(sheet.rows[summaryHeaderIndex + 8].cells[6].value).toBe("2026-03-23");
     const weekRowIndex = findRowIndexByCellValue(sheet, "週", 18);
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
     const dateRowIndex = headerRowIndex - 1;
@@ -274,7 +274,7 @@ describe("mikuproject wbs xlsx", () => {
     expect(firstTaskRow.cells[15].horizontalAlign).toBe("center");
     expect(firstTaskRow.cells[17].value).toBe("-");
     expect(firstTaskRow.cells[18].value).toBe("-");
-    expect(firstTaskRow.cells[10].value).toBe("  0%\n[----------]");
+    expect(firstTaskRow.cells[10].value).toBe("100%\n[##########]");
     expect(firstTaskRow.cells[11].value).toBe("");
     expect(firstTaskRow.cells[13].value).toBe("Sum");
     expect(firstTaskRow.cells[6].value).toBe("2026-03-16");
@@ -304,11 +304,11 @@ describe("mikuproject wbs xlsx", () => {
     expect(secondTaskRow.cells[6].value).toBe("2026-03-16");
     expect(secondTaskRow.cells[7].value).toBe("2026-03-16");
     expect(secondTaskRow.cells[8].value).toBe("1日");
-    expect(secondTaskRow.cells[10].value).toBe("  0%\n[----------]");
+    expect(secondTaskRow.cells[10].value).toBe("100%\n[##########]");
     expect(secondTaskRow.cells[10].fillColor).toBe("#FFF4E0");
     expect(secondTaskRow.cells[11].value).toBe("");
     expect(secondTaskRow.cells[20].value).toBe("◆");
-    expect(secondTaskRow.cells[20].fillColor).toBe("#9FD5C9");
+    expect(secondTaskRow.cells[20].fillColor).toBe("#5BAE9C");
     expect(secondTaskRow.cells[21].value).toBe("");
     expect(thirdTaskRow.cells[5].value).toBe("  - 初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）");
     expect(thirdTaskRow.cells[9].value).toBe("-");
@@ -316,7 +316,7 @@ describe("mikuproject wbs xlsx", () => {
     expect(thirdTaskRow.cells[6].value).toBe("2026-03-16");
     expect(thirdTaskRow.cells[7].value).toBe("2026-03-16");
     expect(thirdTaskRow.cells[8].value).toBe("1日");
-    expect(thirdTaskRow.cells[10].value).toBe("  0%\n[----------]");
+    expect(thirdTaskRow.cells[10].value).toBe("100%\n[##########]");
     expect(thirdTaskRow.cells[11].value).toBe("");
     expect(thirdTaskRow.cells[24].value).toBe("");
     const legendHeaderIndex = findRowIndexByCellValue(sheet, "凡例", 0);
@@ -613,23 +613,10 @@ describe("mikuproject wbs xlsx", () => {
     const dateRowIndex = headerRowIndex - 1;
 
     expect(sheet.rows[dateRowIndex].cells.slice(20).map((cell) => cell.value)).toEqual([
-      "3/16",
-      "3/17",
-      "3/18",
-      "3/19",
-      "3/20",
-      "3/21",
       "3/22",
       "3/23",
       "3/24",
-      "3/25",
-      "3/26",
-      "3/27",
-      "3/28",
-      "3/29",
-      "3/30",
-      "3/31",
-      "4/1"
+      "3/25"
     ]);
     expect(sheet.rows[summaryHeaderIndex + 4].cells[6].value).toBe(1);
     expect(sheet.rows[summaryHeaderIndex + 5].cells[6].value).toBe(2);


### PR DESCRIPTION
## 概要

`mikuproject` の sample data を `project_draft_view` ベースで見直し、Mermaid / WBS / XLSX での見え方を揃えます。あわせて、`project_draft_view` 取込時の日付・進捗補完を強化し、sample の基準日と進捗率も調整します。

## 変更内容

### sample data の見直し

- sample project を `mikuproject開発` の `project_draft_view` ベースに更新
- phase / task / milestone を含む構成へ整理
- `架空検討フェーズ【架空】` とその配下 task を sample に追加
- 既存 XML sample は、この sample draft から生成する形へ整理
- sample の基準日 (`CurrentDate` / `StatusDate`) を `2026-03-23T09:00:00` に変更
- sample の進捗率を調整
  - `1 / 1.1 / 1.2 / 1.3` を 100%
  - `2` を 25%
  - `2.1` を 50%

### `project_draft_view` 取込補完の強化

- `draft-*` UID を取込時に整数 UID へ再採番
- `is_milestone: true` のときだけ milestone として扱うよう修正
- `planned_finish` のみ指定された場合は、同日 `planned_start` を補完
- 通常 task で日付だけ指定された場合は、
  - 同日 task だけでなく複数日 task でも
  - `start = 09:00:00`
  - `finish = 18:00:00` に補完するよう変更
- `percent_complete` を読み取り、内部 `percentComplete` へ反映するよう追加

### Mermaid / SVG 表示の改善

- task 名の安全化を維持しつつ、Mermaid gantt の通常 task バーが見えるよう調整
- Mermaid preview と SVG ダウンロードで同じレンダリング設定を使うよう整理
- Mermaid が返す SVG に共通 CSS を注入し、
  - section 背景
  - 通常 task バー
  - milestone
  - grid / today line の見た目を固定
- `架空検討フェーズ【架空】` 配下の multi-day task が preview / SVG でも見えるよう改善

### UI の整理

- `新規生成AI連携` の `サンプル` ボタン位置を調整
- `サンプル` ボタン押下時は、`生成AIが返した JSON` のテキストエリアへ sample JSON を入れるよう整理
- `WBS 既定祝日` の read-only 欄を通常の `textarea` に変更
- `readonly + rows` による `translateY(NaNpx)` エラーを回避

### テスト・ビルド更新

- `tests/mikuproject-main.test.js` を更新
- `tests/mikuproject-project-xlsx.test.js` を更新
- `tests/mikuproject-wbs-xlsx.test.js` を更新
- sample の基準日・進捗率・Mermaid・WBS・XLSX の期待値を現行挙動へ追随
- 確認結果: `npm run build` 通過、`147 passed / 147`

## 変更ファイル

- `mikuproject-src.html`
- `mikuproject.html`
- `src/ts/main.ts`
- `src/ts/msproject-xml.ts`
- `tests/mikuproject-main.test.js`
- `tests/mikuproject-project-xlsx.test.js`
- `tests/mikuproject-wbs-xlsx.test.js`