### PR TITLE
生成AI連携 UI の整理と AI プロンプトのクリップボード導線追加

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -19,6 +19,7 @@
 - `main.ts` の summary / validation / preview 描画を別モジュール化し、DOM テストをさらに軽くする
 - `phase_detail_view scoped` の `phase UID / root UID / max depth` 指定を、より選びやすい UI に改善する
 - `task_edit_view` の projection を実装する
+- `.editjson` の import で現状 `project_draft_view` だけを受けている制約を見直し、将来の `task_edit_view` / Patch JSON など他の `view_type` も扱えるようにする
 - 既存 project 向け Patch JSON の schema を具体化する
 - Patch JSON を内部モデルへ適用する処理を実装する
 - Patch JSON import 後の validation と差分要約 UI を実装する

--- a/mikuproject-src.html
+++ b/mikuproject-src.html
@@ -15,6 +15,9 @@
     <symbol id="md-icon-github" viewBox="0 0 16 16">
       <path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.5 7.5 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8 8 0 0 0 16 8c0-4.42-3.58-8-8-8Z"></path>
     </symbol>
+    <symbol id="md-icon-clipboard" viewBox="0 0 16 16">
+      <path d="M6 2.5A1.5 1.5 0 0 1 7.5 1h1A1.5 1.5 0 0 1 10 2.5h1.25A1.75 1.75 0 0 1 13 4.25v8A1.75 1.75 0 0 1 11.25 14h-6.5A1.75 1.75 0 0 1 3 12.25v-8A1.75 1.75 0 0 1 4.75 2.5H6Zm1.5 0h1v-.25h-1v.25Zm-2.75 1.5a.25.25 0 0 0-.25.25v8c0 .138.112.25.25.25h6.5a.25.25 0 0 0 .25-.25v-8a.25.25 0 0 0-.25-.25H10v.25A1.25 1.25 0 0 1 8.75 5.5h-1.5A1.25 1.25 0 0 1 6 4.25V4H4.75Z"></path>
+    </symbol>
   </svg>
   <div class="md-surface-card md-card">
     <header class="ms-hero">
@@ -62,8 +65,10 @@
           <h2 class="md-flow-section__title">
             <span class="md-flow-section__step">1</span>
             <span>Input</span>
+            <lht-help-tooltip label="Input の説明" wide>
+              `MS Project XML`、`XLSX`、`mikuproject_workbook_json (.json)`、生成AI 向け編集用 JSON (`.editjson`)、`CSV` を読み込みます。
+            </lht-help-tooltip>
           </h2>
-          <p class="md-flow-section__text">入力、読込、編集元データの確認をここにまとめます。</p>
         </div>
 
         <div class="md-panel-actions">
@@ -101,27 +106,30 @@
           <input id="importFileInput" type="file" accept=".xml,.xlsx,.json,.editjson,.csv,text/xml,application/xml,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/json,text/csv,text/plain" class="md-hidden" />
         </div>
 
-        <section class="md-note-card md-note-card--accent" aria-label="AI draft generation">
-          <div class="md-note-card__title-row">
-            <h3 class="md-note-card__title">新規生成AI連携</h3>
-            <lht-help-tooltip label="新規生成AI連携の説明" wide>
-              (i) まず生成AIに 生成AIプロンプト を読み込ませます。ファイル取込は画面上部の `Load from file` を使います。生成AIが返す `project_draft_view` は workbook JSON と区別するため当面 `.editjson`、`mikuproject_workbook_json` は `.json` として扱います。<br><br>
-              (ii) その前提で生成AIに `project_draft_view` を作らせます。<br><br>
-              (iii) 返ってきた JSON を、ここでファイル読込または貼り付けで取り込みます。
-            </lht-help-tooltip>
-            <a class="md-inline-link md-inline-link--compact" href="https://raw.githubusercontent.com/igapyon/mikuproject/refs/heads/devel/docs/mikuproject-ai-json-spec.md" target="_blank" rel="noopener noreferrer">生成AIプロンプト</a>
+        <details class="md-note-accordion" aria-label="AI draft generation">
+          <summary class="md-note-accordion__summary">生成AI連携</summary>
+          <div class="md-note-accordion__body">
+            <section class="md-note-card md-note-card--accent">
+              <div class="md-panel-actions md-panel-actions--ai-draft">
+                <button id="copyAiPromptBtn" type="button" class="md-button md-button--tonal md-button--compact-link">
+                  <svg aria-hidden="true" viewBox="0 0 16 16" class="md-button__icon" fill="currentColor">
+                    <use href="#md-icon-clipboard" xlink:href="#md-icon-clipboard"></use>
+                  </svg>
+                  <span>mikuproject 用の生成AIプロンプト</span>
+                </button>
+                <lht-help-tooltip label="新規生成AI連携の説明" wide>
+                  クリップボードにコピーしたプロンプトを用いて生成AIと会話してください。結果として得られた JSON を下のテキストエリアに貼り付けて、<code>貼り付けた JSON を取り込む</code> ボタンをクリックしてください。
+                </lht-help-tooltip>
+                <button id="importProjectDraftBtn" type="button" class="md-button md-button--tonal">貼り付けた JSON を取り込む</button>
+                <button id="loadProjectDraftSampleBtn" type="button" class="md-button md-button--surface">サンプル</button>
+              </div>
+              <template id="aiPromptTemplate">{{AI_PROMPT_TEXT}}</template>
+              <div class="md-form-grid">
+                <lht-text-field-help field-id="projectDraftImportInput" label="生成AIが返した JSON" rows="14" help-text="生成AIが返した `project_draft_view` の JSON テキストを貼り付けます。最後に json フェンスを持つ応答全体でもかまいません。"></lht-text-field-help>
+              </div>
+            </section>
           </div>
-          <p class="md-note-card__text">
-            生成AIとの会話は別途行います。生成AIが返した `project_draft_view` は、上部の `Load from file` から `.editjson` を開くか、JSON テキストを貼り付けてここから取り込みます。
-          </p>
-          <div class="md-panel-actions">
-            <button id="importProjectDraftBtn" type="button" class="md-button md-button--tonal">貼り付けた JSON を取り込む</button>
-            <button id="loadProjectDraftSampleBtn" type="button" class="md-button md-button--surface">サンプル</button>
-          </div>
-          <div class="md-form-grid">
-            <lht-text-field-help field-id="projectDraftImportInput" label="生成AIが返した JSON" rows="14" help-text="生成AIが返した `project_draft_view` の JSON テキストを貼り付けます。最後に json フェンスを持つ応答全体でもかまいません。"></lht-text-field-help>
-          </div>
-        </section>
+        </details>
 
         <details class="md-debug-accordion">
           <summary class="md-debug-accordion__summary">デバッグ情報</summary>
@@ -140,8 +148,10 @@
           <h2 class="md-flow-section__title">
             <span class="md-flow-section__step">2</span>
             <span>Overview</span>
+            <lht-help-tooltip label="Overview の説明" wide>
+              内部モデル、検証結果、Mermaid preview を確認します。取込後の warning と差分要約もここに表示します。
+            </lht-help-tooltip>
           </h2>
-          <p class="md-flow-section__text">内部モデル、要約、検証結果、プレビューをここで確認します。</p>
         </div>
 
         <section class="md-note-card md-note-card--feature">
@@ -231,8 +241,10 @@
           <h2 class="md-flow-section__title">
             <span class="md-flow-section__step">3</span>
             <span>Output</span>
+            <lht-help-tooltip label="Output の説明" wide>
+              `MS Project XML`、`XLSX`、`JSON`、`CSV`、`WBS XLSX`、`Mermaid`、生成AI 向け `.editjson` を保存します。
+            </lht-help-tooltip>
           </h2>
-          <p class="md-flow-section__text">出力設定と生成結果の確認をここにまとめます。</p>
         </div>
 
         <div class="md-output-actions">
@@ -249,33 +261,35 @@
           </div>
         </div>
 
-        <section class="md-note-card md-note-card--accent" aria-label="AI integration exports">
-          <div class="md-note-card__title-row">
-            <h3 class="md-note-card__title">生成AI連携</h3>
+        <details class="md-note-accordion" aria-label="AI integration exports">
+          <summary class="md-note-accordion__summary">生成AI連携</summary>
+          <div class="md-note-accordion__body">
+            <section class="md-note-card md-note-card--accent" aria-label="AI integration exports">
+              <div class="md-panel-actions">
+                <button id="exportAiBundleBtn" type="button" class="md-button md-button--tonal">full bundle</button>
+                <lht-help-tooltip label="生成AI連携の説明" wide>
+                  既存 project を生成AIへ渡すための projection JSON をここから生成します。
+                </lht-help-tooltip>
+                <button id="exportProjectOverviewBtn" type="button" class="md-button md-button--tonal">project_overview_view</button>
+                <button id="exportPhaseDetailFullBtn" type="button" class="md-button md-button--tonal">phase_detail_view full</button>
+              </div>
+              <section class="md-note-card md-note-card--subtle" aria-label="AI scoped phase detail">
+                <h4 class="md-note-card__title">phase_detail_view scoped</h4>
+                <p class="md-note-card__text">
+                  phase の一部だけを生成AIへ渡したい時に使います。
+                </p>
+                <div class="md-form-grid md-form-grid--three">
+                  <lht-text-field-help field-id="phaseDetailUidInput" label="対象 phase UID" rows="1" placeholder="空欄なら先頭 phase" help-text="どの phase を対象にするかを指定します。"></lht-text-field-help>
+                  <lht-text-field-help field-id="phaseDetailRootUidInput" label="部分木の起点 task UID" rows="1" placeholder="空欄なら phase 全体" help-text="phase_detail_view scoped で切り出したい task UID を指定します。まず full を出して UID を確認してください。"></lht-text-field-help>
+                  <lht-text-field-help field-id="phaseDetailMaxDepthInput" label="何階層下まで含めるか" rows="1" placeholder="空欄なら全階層" help-text="起点 task から何階層下まで含めるかを指定します。0 は起点 task のみです。"></lht-text-field-help>
+                </div>
+                <div class="md-panel-actions">
+                  <button id="exportPhaseDetailBtn" type="button" class="md-button md-button--tonal">phase_detail_view scoped</button>
+                </div>
+              </section>
+            </section>
           </div>
-          <p class="md-note-card__text">
-            既存 project を生成AIへ渡すための projection JSON をここから生成します。
-          </p>
-          <div class="md-panel-actions">
-            <button id="exportAiBundleBtn" type="button" class="md-button md-button--tonal">full bundle</button>
-            <button id="exportProjectOverviewBtn" type="button" class="md-button md-button--tonal">project_overview_view</button>
-            <button id="exportPhaseDetailFullBtn" type="button" class="md-button md-button--tonal">phase_detail_view full</button>
-          </div>
-          <section class="md-note-card md-note-card--subtle" aria-label="AI scoped phase detail">
-            <h4 class="md-note-card__title">phase_detail_view scoped</h4>
-            <p class="md-note-card__text">
-              phase の一部だけを生成AIへ渡したい時に使います。
-            </p>
-            <div class="md-form-grid md-form-grid--three">
-              <lht-text-field-help field-id="phaseDetailUidInput" label="対象 phase UID" rows="1" placeholder="空欄なら先頭 phase" help-text="どの phase を対象にするかを指定します。"></lht-text-field-help>
-              <lht-text-field-help field-id="phaseDetailRootUidInput" label="部分木の起点 task UID" rows="1" placeholder="空欄なら phase 全体" help-text="phase_detail_view scoped で切り出したい task UID を指定します。まず full を出して UID を確認してください。"></lht-text-field-help>
-              <lht-text-field-help field-id="phaseDetailMaxDepthInput" label="何階層下まで含めるか" rows="1" placeholder="空欄なら全階層" help-text="起点 task から何階層下まで含めるかを指定します。0 は起点 task のみです。"></lht-text-field-help>
-            </div>
-            <div class="md-panel-actions">
-              <button id="exportPhaseDetailBtn" type="button" class="md-button md-button--tonal">phase_detail_view scoped</button>
-            </div>
-          </section>
-        </section>
+        </details>
 
         <section class="ms-settings-card" aria-label="Output settings">
           <details class="ms-settings-accordion">

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -1242,8 +1242,6 @@ lht-index-card-link {
 .md-flow-section__header {
   display: grid;
   gap: 8px;
-  padding-bottom: 8px;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
 }
 
 .md-flow-section__title {
@@ -1378,6 +1376,24 @@ lht-index-card-link {
   align-items: center;
 }
 
+.md-panel-actions--ai-draft {
+  margin-bottom: 20px;
+}
+
+.md-button--compact-link {
+  gap: 0.38rem;
+  min-height: 2.2rem;
+  padding: 0.28rem 0.88rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.md-button__icon {
+  width: 0.82rem;
+  height: 0.82rem;
+  flex: 0 0 auto;
+}
+
 .md-output-actions {
   display: grid;
   gap: 12px;
@@ -1407,7 +1423,7 @@ lht-index-card-link {
 }
 
 .md-panel-actions + .md-form-grid {
-  margin-top: 12px;
+  margin-top: 24px;
 }
 
 .md-panel-actions + .md-note-card {
@@ -1422,6 +1438,7 @@ lht-index-card-link {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 0.44rem;
   min-height: 2.55rem;
   border-radius: 999px;
   padding: 0.38rem 1.02rem;
@@ -1431,8 +1448,19 @@ lht-index-card-link {
   font: inherit;
   font-weight: 600;
   font-size: 0.9rem;
+  line-height: 1.2;
   cursor: pointer;
+  text-decoration: none;
   transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+}
+
+.md-button:link,
+.md-button:visited,
+.md-button:hover,
+.md-button:focus-visible,
+.md-button:active {
+  color: #102a43;
+  text-decoration: none;
 }
 
 .md-button:hover {
@@ -1461,9 +1489,11 @@ lht-index-card-link {
   border: 1px solid var(--md-project-border);
   border-radius: 12px;
   background: rgba(230, 240, 255, 0.72);
-  padding: 14px 16px;
+  padding: 11px 14px;
   color: #102a43;
-  font-weight: 600;
+  font-size: 0.94rem;
+  font-weight: 500;
+  line-height: 1.45;
 }
 
 .md-save-state {
@@ -1626,6 +1656,34 @@ lht-index-card-link {
   font-weight: 700;
 }
 
+.md-pill-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.42rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(103, 80, 164, 0.22);
+  background: linear-gradient(180deg, #f6f1fc 0%, #eee7f8 100%);
+  color: #4f378b;
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1.2;
+  text-decoration: none;
+  transition: background 0.16s ease, border-color 0.16s ease, color 0.16s ease;
+}
+
+.md-pill-link:hover,
+.md-pill-link:focus-visible {
+  background: linear-gradient(180deg, #efe7fa 0%, #e6dcf5 100%);
+  border-color: rgba(103, 80, 164, 0.32);
+  color: #3f315f;
+  text-decoration: none;
+}
+
+.md-pill-link--compact {
+  margin-left: auto;
+}
+
 md-outlined-text-field.md-outlined-field {
   --md-outlined-text-field-outline-color: #bdb7c8;
   --md-outlined-field-outline-color: #bdb7c8;
@@ -1748,6 +1806,49 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 
 .md-debug-accordion__body .md-form-grid + .md-form-grid {
   margin-top: 16px;
+}
+
+.md-note-accordion {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.72);
+  overflow: clip;
+}
+
+.md-note-accordion__summary {
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+  padding: 14px 18px;
+  font-size: 0.94rem;
+  font-weight: 700;
+  color: #102a43;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.md-note-accordion__summary::-webkit-details-marker {
+  display: none;
+}
+
+.md-note-accordion__summary::before {
+  content: "▸";
+  font-size: 0.9rem;
+  color: #52606d;
+  transition: transform 160ms ease;
+}
+
+.md-note-accordion[open] .md-note-accordion__summary::before {
+  transform: rotate(90deg);
+}
+
+.md-note-accordion__body {
+  padding: 0 18px 18px;
+}
+
+.md-note-accordion__body > .md-note-card {
+  margin-top: 0;
 }
 
 .ms-settings-card {
@@ -2051,6 +2152,9 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
     <symbol id="md-icon-github" viewBox="0 0 16 16">
       <path d="M8 0C3.58 0 0 3.58 0 8a8 8 0 0 0 5.47 7.59c.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.5-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.5 7.5 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8 8 0 0 0 16 8c0-4.42-3.58-8-8-8Z"></path>
     </symbol>
+    <symbol id="md-icon-clipboard" viewBox="0 0 16 16">
+      <path d="M6 2.5A1.5 1.5 0 0 1 7.5 1h1A1.5 1.5 0 0 1 10 2.5h1.25A1.75 1.75 0 0 1 13 4.25v8A1.75 1.75 0 0 1 11.25 14h-6.5A1.75 1.75 0 0 1 3 12.25v-8A1.75 1.75 0 0 1 4.75 2.5H6Zm1.5 0h1v-.25h-1v.25Zm-2.75 1.5a.25.25 0 0 0-.25.25v8c0 .138.112.25.25.25h6.5a.25.25 0 0 0 .25-.25v-8a.25.25 0 0 0-.25-.25H10v.25A1.25 1.25 0 0 1 8.75 5.5h-1.5A1.25 1.25 0 0 1 6 4.25V4H4.75Z"></path>
+    </symbol>
   </svg>
   <div class="md-surface-card md-card">
     <header class="ms-hero">
@@ -2098,8 +2202,10 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
           <h2 class="md-flow-section__title">
             <span class="md-flow-section__step">1</span>
             <span>Input</span>
+            <lht-help-tooltip label="Input の説明" wide>
+              `MS Project XML`、`XLSX`、`mikuproject_workbook_json (.json)`、生成AI 向け編集用 JSON (`.editjson`)、`CSV` を読み込みます。
+            </lht-help-tooltip>
           </h2>
-          <p class="md-flow-section__text">入力、読込、編集元データの確認をここにまとめます。</p>
         </div>
 
         <div class="md-panel-actions">
@@ -2137,27 +2243,398 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
           <input id="importFileInput" type="file" accept=".xml,.xlsx,.json,.editjson,.csv,text/xml,application/xml,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/json,text/csv,text/plain" class="md-hidden" />
         </div>
 
-        <section class="md-note-card md-note-card--accent" aria-label="AI draft generation">
-          <div class="md-note-card__title-row">
-            <h3 class="md-note-card__title">新規生成AI連携</h3>
-            <lht-help-tooltip label="新規生成AI連携の説明" wide>
-              (i) まず生成AIに 生成AIプロンプト を読み込ませます。ファイル取込は画面上部の `Load from file` を使います。生成AIが返す `project_draft_view` は workbook JSON と区別するため当面 `.editjson`、`mikuproject_workbook_json` は `.json` として扱います。<br><br>
-              (ii) その前提で生成AIに `project_draft_view` を作らせます。<br><br>
-              (iii) 返ってきた JSON を、ここでファイル読込または貼り付けで取り込みます。
-            </lht-help-tooltip>
-            <a class="md-inline-link md-inline-link--compact" href="https://raw.githubusercontent.com/igapyon/mikuproject/refs/heads/devel/docs/mikuproject-ai-json-spec.md" target="_blank" rel="noopener noreferrer">生成AIプロンプト</a>
+        <details class="md-note-accordion" aria-label="AI draft generation">
+          <summary class="md-note-accordion__summary">生成AI連携</summary>
+          <div class="md-note-accordion__body">
+            <section class="md-note-card md-note-card--accent">
+              <div class="md-panel-actions md-panel-actions--ai-draft">
+                <button id="copyAiPromptBtn" type="button" class="md-button md-button--tonal md-button--compact-link">
+                  <svg aria-hidden="true" viewBox="0 0 16 16" class="md-button__icon" fill="currentColor">
+                    <use href="#md-icon-clipboard" xlink:href="#md-icon-clipboard"></use>
+                  </svg>
+                  <span>mikuproject 用の生成AIプロンプト</span>
+                </button>
+                <lht-help-tooltip label="新規生成AI連携の説明" wide>
+                  クリップボードにコピーしたプロンプトを用いて生成AIと会話してください。結果として得られた JSON を下のテキストエリアに貼り付けて、<code>貼り付けた JSON を取り込む</code> ボタンをクリックしてください。
+                </lht-help-tooltip>
+                <button id="importProjectDraftBtn" type="button" class="md-button md-button--tonal">貼り付けた JSON を取り込む</button>
+                <button id="loadProjectDraftSampleBtn" type="button" class="md-button md-button--surface">サンプル</button>
+              </div>
+              <template id="aiPromptTemplate"># mikuproject AI JSON Spec
+
+あなたはこれから `mikuproject` とやりとりしながら、プロジェクトの内容を理解し、必要に応じて変更提案を返していこうとしています。
+
+`mikuproject` は `MS Project XML` を取り扱うツールです。
+
+`mikuproject` と生成AIの間のやり取りは、XML ではなく JSON ベースで行います。
+
+現時点の実装状況:
+- 実装済み: `project_overview_view` の export
+- 実装済み: `phase_detail_view` の export
+- 実装済み: `project_draft_view` の import
+- 未実装: `task_edit_view`
+- 未実装: Patch JSON の import / 適用
+- `project_draft_request` は補助的な構想・helper であり、現行 UI の主機能ではありません
+
+前提:
+- AI へ渡される入力は用途別 projection JSON です
+- AI は説明文を返してよいです
+- 既存編集向けの Patch JSON は将来案として設計中です
+- `MS Project XML` は保存と互換のための外部形式ですが、AI は直接扱いません
+- workbook JSON と AI 向け編集用 JSON を混同しないため、当面 `project_draft_view` などの編集用 JSON には `.editjson` 拡張子を推奨します
+
+重要方針:
+- 全体 JSON の再出力は禁止です
+- 不明な値を推測して補完してはいけません
+- 未指定項目は変更しない前提です
+- 与えられた projection と rules の範囲を超えて変更してはいけません
+- 業務意味が不明な場合、断定的な再設計は避けてください
+- 業務意味が不明な変更は候補案として扱ってください
+
+projection JSON の代表例:
+- `project_overview_view`: プロジェクト全体の構造、粒度、主要節目を把握するための要約ビュー
+- `phase_detail_view`: 特定フェーズの task 群、主要 milestone、依存の要点を把握するための詳細ビュー
+- `task_edit_view`: 個別 task を安全に編集するための作業ビュー。現時点では未実装です
+- `project_draft_request`: 全く新規の project 草案を AI に生成させるための入力。現時点では設計メモ寄りです
+- `project_draft_view`: 新規 project 草案の全量出力。現時点では import 済みです
+
+ファイル拡張子の運用:
+- `mikuproject_workbook_json` は `.json` を推奨します
+- `project_draft_view` は `.editjson` を推奨します
+- `.editjson` は、将来 `task_edit_view` や Patch JSON などの AI 向け編集用 JSON 群にも拡張できる広めの拡張子として扱います
+- 拡張子は判別補助であり、必要に応じて中身の `view_type` / `format` でも判定します
+
+`phase_detail_view` は、安全な変更候補の抽出や、次に必要な `task_edit_view` の特定にも使えます。
+`phase_detail_view` には、phase 全体をそのまま渡す `full` モードと、対象を絞る `scoped` モードの両方がありえます。
+必要に応じて、`root_uid` と `max_depth` で対象範囲を絞って渡してよいです。
+
+新規生成モードでは、既存 project の編集は行わず、全く新しい project の草案だけを返します。
+
+### `project_overview_view` の例
+
+```json
+{
+  "project": {
+    "name": "新基幹システム導入",
+    "planned_start": "2026-04-01",
+    "planned_finish": "2026-12-31"
+  },
+  "summary": {
+    "task_count": 128,
+    "milestone_count": 12,
+    "max_outline_level": 4
+  },
+  "phases": [
+    {
+      "uid": "100",
+      "name": "要件定義",
+      "wbs": "1",
+      "task_count": 18,
+      "milestone_count": 2,
+      "planned_start": "2026-04-01",
+      "planned_finish": "2026-05-15"
+    }
+  ]
+}
+```
+
+### `phase_detail_view` の例
+
+```json
+{
+  "project": {
+    "name": "新基幹システム導入"
+  },
+  "phase": {
+    "uid": "100",
+    "name": "要件定義",
+    "wbs": "1",
+    "planned_start": "2026-04-01",
+    "planned_finish": "2026-05-15"
+  },
+  "scope": {
+    "mode": "full",
+    "root_uid": null,
+    "max_depth": null
+  },
+  "tasks": [
+    {
+      "uid": "110",
+      "name": "現状業務整理",
+      "parent_uid": "100",
+      "position": 0,
+      "planned_duration": "PT40H",
+      "planned_duration_hours": 40,
+      "planned_start": "2026-04-01",
+      "planned_finish": "2026-04-05"
+    }
+  ],
+  "milestones": [
+    {
+      "uid": "190",
+      "name": "要件定義完了",
+      "date": "2026-05-15"
+    }
+  ]
+}
+```
+
+`phase_detail_view` の範囲指定:
+- `mode = "full"` の場合は、phase 全体を対象にします
+- `mode = "scoped"` の場合は、`root_uid` と `max_depth` で対象範囲を絞れます
+- `root_uid` を指定すると、その task を起点にした subtree を対象にできます
+- `max_depth` を指定すると、`root_uid` から何階層下まで含めるかを制御できます
+- `mode = "full"` では `root_uid = null` かつ `max_depth = null` です
+
+### `task_edit_view` の例
+
+これは将来の安全編集用 projection 案であり、現時点では `mikuproject` 本体に未実装です。
+
+```json
+{
+  "project": {
+    "name": "新基幹システム導入"
+  },
+  "phase": {
+    "uid": "100",
+    "name": "要件定義"
+  },
+  "target_task": {
+    "uid": "120",
+    "name": "要件ヒアリング",
+    "parent_uid": "100",
+    "position": 1,
+    "planned_duration": "PT80H",
+    "planned_duration_hours": 80,
+    "planned_start": "2026-04-06",
+    "planned_finish": "2026-04-15"
+  },
+  "predecessors": [
+    {
+      "task_uid": "110",
+      "name": "現状業務整理",
+      "type": "FS",
+      "lag": "PT0H",
+      "lag_hours": 0
+    }
+  ],
+  "successors": [
+    {
+      "task_uid": "130",
+      "name": "要件確定",
+      "type": "FS",
+      "lag": "PT0H",
+      "lag_hours": 0
+    }
+  ],
+  "rules": {
+    "allow_patch_ops": ["update_task", "move_task", "link_tasks", "unlink_tasks"],
+    "allowed_edit_fields": ["name", "planned_start", "planned_finish", "planned_duration", "planned_duration_hours"],
+    "forbid_completed_task_changes": true
+  }
+}
+```
+
+### `project_draft_request` の例
+
+これは新規生成プロンプト組み立て用の入力案です。現時点では主に設計用で、UI の主導線にはまだ載せていません。
+
+```json
+{
+  "view_type": "project_draft_request",
+  "project": {
+    "name": "新規基幹刷新",
+    "planned_start": "2026-04-01"
+  },
+  "requirements": {
+    "goal": "社内基幹システム刷新",
+    "team_count": 2,
+    "must_have_phases": ["要件定義", "設計", "実装", "テスト", "移行"],
+    "must_have_milestones": ["要件確定", "本番移行"]
+  }
+}
+```
+
+### `project_draft_view` の例
+
+```json
+{
+  "view_type": "project_draft_view",
+  "project": {
+    "name": "新規基幹刷新",
+    "planned_start": "2026-04-01"
+  },
+  "tasks": [
+    {
+      "uid": "draft-1",
+      "name": "要件定義",
+      "parent_uid": null,
+      "position": 0,
+      "is_summary": true
+    }
+  ]
+}
+```
+
+phase の定義:
+- 当面、phase は top-level summary task を指します
+- ルート直下の summary task を phase とみなします
+- ここでいう summary task は `is_summary = true` 相当の task です
+- `UID=0` の project summary task は phase に含めません
+
+UID:
+- `uid` は常に string です
+- `parent_uid`, `from_uid`, `to_uid`, `task_uid` も常に string です
+
+日付・期間:
+- 当面、WBS 理解用 projection は計画ベースです
+- 曖昧な `start` / `finish` は使わず、意味名を分けます
+- 例:
+  - `planned_start`
+  - `planned_finish`
+  - `planned_duration`
+  - `planned_duration_hours`
+  - `actual_start`
+  - `actual_finish`
+- duration は元表現と補助数値を併記することがあります
+- 例:
+  - `planned_duration: "PT40H"`
+  - `planned_duration_hours: 40`
+- 両方がある場合、理解や比較には `*_hours` を補助的に使ってよいです
+
+依存関係:
+- dependency は単なる前後順ではなく意味的な関係です
+- 少なくとも次を見ます
+  - 相手 task の `uid`
+  - 相手 task の `name`
+  - `type`
+  - `lag`
+  - `lag_hours`
+- `type` は少なくとも次を扱います
+  - `FS`
+  - `SS`
+  - `FF`
+  - `SF`
+- `predecessors` だけでなく `successors` も見てください
+- `lag` は負値を取りうることがあります
+
+rules:
+- 各 projection には `rules` が含まれることがあります
+- `rules` は参考情報ではなく、AI が返してよい Patch の契約です
+- `allow_patch_ops` にない操作は返してはいけません
+- `allowed_edit_fields` にない field は更新してはいけません
+- `forbid_*` が true の条件は必ず守ってください
+
+### `rules` の例
+
+```json
+{
+  "allow_patch_ops": ["update_task", "move_task", "link_tasks", "unlink_tasks"],
+  "allowed_edit_fields": [
+    "name",
+    "planned_start",
+    "planned_finish",
+    "planned_duration",
+    "planned_duration_hours"
+  ],
+  "forbid_completed_task_changes": true,
+  "forbid_summary_task_direct_edit": true,
+  "forbid_delete_task": true
+}
+```
+
+Patch JSON の原則:
+- Patch JSON は `operations` 配列を持つオブジェクトです
+- task の field 更新は `update_task` を使います
+- 親子や順序の変更は `move_task` を使います
+- 依存関係の追加や解除は `link_tasks` / `unlink_tasks` を使います
+
+新規生成モードの原則:
+- `project_draft_request` に対する返答は `project_draft_view` です
+- このとき `Patch JSON` は返しません
+- draft は正本ではなく草案です
+- draft 内の `uid` は `"draft-1"` のような仮 UID でよいです
+- `percent_complete` を含めてよいです
+- task が通常 task で、`planned_start` / `planned_finish` が日付だけの場合、`mikuproject` 側では勤務時間帯を補完して扱うことがあります
+- 同日 task の date-only 指定は、通常 task なら `09:00:00` 開始 / `18:00:00` 終了へ補完されることがあります
+- 複数日 task の date-only 指定でも、通常 task なら開始日は `09:00:00`、終了日は `18:00:00` を補完して扱うことがあります
+- `planned_finish` だけが与えられた通常 task は、まず同日の `planned_start` を補完したうえで、上記の勤務時間帯補完を適用することがあります
+- `is_milestone: true` の task には、この勤務時間帯補完を適用しません
+
+Patch の例:
+```json
+{
+  "operations": [
+    {
+      "op": "update_task",
+      "uid": "101",
+      "fields": {
+        "name": "修正タスク"
+      }
+    }
+  ]
+}
+```
+
+順序変更の例:
+```json
+{
+  "operations": [
+    {
+      "op": "move_task",
+      "uid": "120",
+      "new_parent_uid": "100",
+      "new_index": 2
+    }
+  ]
+}
+```
+
+依存追加の例:
+```json
+{
+  "operations": [
+    {
+      "op": "link_tasks",
+      "from_uid": "110",
+      "to_uid": "120",
+      "type": "FS",
+      "lag": "PT0H",
+      "lag_hours": 0
+    }
+  ]
+}
+```
+
+変更不要の例:
+```json
+{
+  "operations": []
+}
+```
+
+出力ルール:
+- 対話インタフェースでは、説明文を返してよいです
+- 変更理由や不確実性を簡潔に説明してよいです
+- ただし、最終的な機械処理対象 JSON は必ず最後に 1 個の `json` コードフェンスで囲って返してください
+- 既存編集モードでは、その最後の `json` コードフェンス内は `Patch JSON` です
+- 新規生成モードでは、その最後の `json` コードフェンス内は `project_draft_view` です
+- `mikuproject` が処理対象にするのは、その最後の `json` コードフェンス内の JSON のみです
+- 不明な場合は変更を最小にしてください
+- 変更不要なら最後の `json` コードフェンスで空の `operations` を返してください
+- 与えられていない task や field を勝手に推測しないでください
+
+改善候補:
+- 将来的には `suggest_only` のような提案専用モードを追加する余地があります
+- 現時点の spec は task / phase / dependency を優先しており、resource や工数配分の扱いは今後の検討対象です
+- phase 定義は当面 `top-level summary task` 固定ですが、将来的にはより柔軟な定義へ拡張する余地があります
+</template>
+              <div class="md-form-grid">
+                <lht-text-field-help field-id="projectDraftImportInput" label="生成AIが返した JSON" rows="14" help-text="生成AIが返した `project_draft_view` の JSON テキストを貼り付けます。最後に json フェンスを持つ応答全体でもかまいません。"></lht-text-field-help>
+              </div>
+            </section>
           </div>
-          <p class="md-note-card__text">
-            生成AIとの会話は別途行います。生成AIが返した `project_draft_view` は、上部の `Load from file` から `.editjson` を開くか、JSON テキストを貼り付けてここから取り込みます。
-          </p>
-          <div class="md-panel-actions">
-            <button id="importProjectDraftBtn" type="button" class="md-button md-button--tonal">貼り付けた JSON を取り込む</button>
-            <button id="loadProjectDraftSampleBtn" type="button" class="md-button md-button--surface">サンプル</button>
-          </div>
-          <div class="md-form-grid">
-            <lht-text-field-help field-id="projectDraftImportInput" label="生成AIが返した JSON" rows="14" help-text="生成AIが返した `project_draft_view` の JSON テキストを貼り付けます。最後に json フェンスを持つ応答全体でもかまいません。"></lht-text-field-help>
-          </div>
-        </section>
+        </details>
 
         <details class="md-debug-accordion">
           <summary class="md-debug-accordion__summary">デバッグ情報</summary>
@@ -2176,8 +2653,10 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
           <h2 class="md-flow-section__title">
             <span class="md-flow-section__step">2</span>
             <span>Overview</span>
+            <lht-help-tooltip label="Overview の説明" wide>
+              内部モデル、検証結果、Mermaid preview を確認します。取込後の warning と差分要約もここに表示します。
+            </lht-help-tooltip>
           </h2>
-          <p class="md-flow-section__text">内部モデル、要約、検証結果、プレビューをここで確認します。</p>
         </div>
 
         <section class="md-note-card md-note-card--feature">
@@ -2267,8 +2746,10 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
           <h2 class="md-flow-section__title">
             <span class="md-flow-section__step">3</span>
             <span>Output</span>
+            <lht-help-tooltip label="Output の説明" wide>
+              `MS Project XML`、`XLSX`、`JSON`、`CSV`、`WBS XLSX`、`Mermaid`、生成AI 向け `.editjson` を保存します。
+            </lht-help-tooltip>
           </h2>
-          <p class="md-flow-section__text">出力設定と生成結果の確認をここにまとめます。</p>
         </div>
 
         <div class="md-output-actions">
@@ -2285,33 +2766,35 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
           </div>
         </div>
 
-        <section class="md-note-card md-note-card--accent" aria-label="AI integration exports">
-          <div class="md-note-card__title-row">
-            <h3 class="md-note-card__title">生成AI連携</h3>
+        <details class="md-note-accordion" aria-label="AI integration exports">
+          <summary class="md-note-accordion__summary">生成AI連携</summary>
+          <div class="md-note-accordion__body">
+            <section class="md-note-card md-note-card--accent" aria-label="AI integration exports">
+              <div class="md-panel-actions">
+                <button id="exportAiBundleBtn" type="button" class="md-button md-button--tonal">full bundle</button>
+                <lht-help-tooltip label="生成AI連携の説明" wide>
+                  既存 project を生成AIへ渡すための projection JSON をここから生成します。
+                </lht-help-tooltip>
+                <button id="exportProjectOverviewBtn" type="button" class="md-button md-button--tonal">project_overview_view</button>
+                <button id="exportPhaseDetailFullBtn" type="button" class="md-button md-button--tonal">phase_detail_view full</button>
+              </div>
+              <section class="md-note-card md-note-card--subtle" aria-label="AI scoped phase detail">
+                <h4 class="md-note-card__title">phase_detail_view scoped</h4>
+                <p class="md-note-card__text">
+                  phase の一部だけを生成AIへ渡したい時に使います。
+                </p>
+                <div class="md-form-grid md-form-grid--three">
+                  <lht-text-field-help field-id="phaseDetailUidInput" label="対象 phase UID" rows="1" placeholder="空欄なら先頭 phase" help-text="どの phase を対象にするかを指定します。"></lht-text-field-help>
+                  <lht-text-field-help field-id="phaseDetailRootUidInput" label="部分木の起点 task UID" rows="1" placeholder="空欄なら phase 全体" help-text="phase_detail_view scoped で切り出したい task UID を指定します。まず full を出して UID を確認してください。"></lht-text-field-help>
+                  <lht-text-field-help field-id="phaseDetailMaxDepthInput" label="何階層下まで含めるか" rows="1" placeholder="空欄なら全階層" help-text="起点 task から何階層下まで含めるかを指定します。0 は起点 task のみです。"></lht-text-field-help>
+                </div>
+                <div class="md-panel-actions">
+                  <button id="exportPhaseDetailBtn" type="button" class="md-button md-button--tonal">phase_detail_view scoped</button>
+                </div>
+              </section>
+            </section>
           </div>
-          <p class="md-note-card__text">
-            既存 project を生成AIへ渡すための projection JSON をここから生成します。
-          </p>
-          <div class="md-panel-actions">
-            <button id="exportAiBundleBtn" type="button" class="md-button md-button--tonal">full bundle</button>
-            <button id="exportProjectOverviewBtn" type="button" class="md-button md-button--tonal">project_overview_view</button>
-            <button id="exportPhaseDetailFullBtn" type="button" class="md-button md-button--tonal">phase_detail_view full</button>
-          </div>
-          <section class="md-note-card md-note-card--subtle" aria-label="AI scoped phase detail">
-            <h4 class="md-note-card__title">phase_detail_view scoped</h4>
-            <p class="md-note-card__text">
-              phase の一部だけを生成AIへ渡したい時に使います。
-            </p>
-            <div class="md-form-grid md-form-grid--three">
-              <lht-text-field-help field-id="phaseDetailUidInput" label="対象 phase UID" rows="1" placeholder="空欄なら先頭 phase" help-text="どの phase を対象にするかを指定します。"></lht-text-field-help>
-              <lht-text-field-help field-id="phaseDetailRootUidInput" label="部分木の起点 task UID" rows="1" placeholder="空欄なら phase 全体" help-text="phase_detail_view scoped で切り出したい task UID を指定します。まず full を出して UID を確認してください。"></lht-text-field-help>
-              <lht-text-field-help field-id="phaseDetailMaxDepthInput" label="何階層下まで含めるか" rows="1" placeholder="空欄なら全階層" help-text="起点 task から何階層下まで含めるかを指定します。0 は起点 task のみです。"></lht-text-field-help>
-            </div>
-            <div class="md-panel-actions">
-              <button id="exportPhaseDetailBtn" type="button" class="md-button md-button--tonal">phase_detail_view scoped</button>
-            </div>
-          </section>
-        </section>
+        </details>
 
         <section class="ms-settings-card" aria-label="Output settings">
           <details class="ms-settings-accordion">
@@ -14303,6 +14786,40 @@ globalThis["mermaid"] = globalThis.__esbuild_esm_mermaid_nm["mermaid"].default;
             toast.show(message, 2200);
         }
     }
+    function getAiPromptText() {
+        var _a;
+        const template = document.getElementById("aiPromptTemplate");
+        if (!template) {
+            return "";
+        }
+        return (((_a = template.content) === null || _a === void 0 ? void 0 : _a.textContent) || template.textContent || "").trim();
+    }
+    async function copyTextToClipboard(text) {
+        if (typeof navigator !== "undefined" &&
+            navigator.clipboard &&
+            typeof navigator.clipboard.writeText === "function") {
+            await navigator.clipboard.writeText(text);
+            return;
+        }
+        const textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.setAttribute("readonly", "readonly");
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+    }
+    async function copyAiPrompt() {
+        const promptText = getAiPromptText();
+        if (!promptText) {
+            throw new Error("生成AIプロンプトが見つかりません");
+        }
+        await copyTextToClipboard(promptText);
+        showToast("生成AIプロンプトをクリップボードにコピーしました");
+        setStatus("生成AIプロンプトをクリップボードにコピーしました");
+    }
     function setMermaidError(message) {
         const errorNode = getElement("mermaidSvgError");
         errorNode.textContent = message;
@@ -15333,6 +15850,14 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             }
         });
         getElement("loadProjectDraftSampleBtn").addEventListener("click", loadProjectDraftSample);
+        getElement("copyAiPromptBtn").addEventListener("click", async () => {
+            try {
+                await copyAiPrompt();
+            }
+            catch (error) {
+                setStatus(error instanceof Error ? error.message : "生成AIプロンプトのコピーに失敗しました");
+            }
+        });
         getElement("importProjectDraftBtn").addEventListener("click", async () => {
             try {
                 await importProjectDraftFromText();

--- a/scripts/build-project.mjs
+++ b/scripts/build-project.mjs
@@ -103,7 +103,9 @@ function transpileTypeScript(target, tsModule) {
 }
 
 function applyTemplateValues(source) {
-  return source.replaceAll("{{BUILD_DATE}}", formatBuildDate(new Date()));
+  return source
+    .replaceAll("{{BUILD_DATE}}", formatBuildDate(new Date()))
+    .replaceAll("{{AI_PROMPT_TEXT}}", escapeHtml(loadAiPromptText()));
 }
 
 function formatBuildDate(date) {
@@ -111,4 +113,16 @@ function formatBuildDate(date) {
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const day = String(date.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
+}
+
+function loadAiPromptText() {
+  const promptPath = path.resolve(ROOT, "docs/mikuproject-ai-json-spec.md");
+  return fs.readFileSync(promptPath, "utf8");
+}
+
+function escapeHtml(text) {
+  return text
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
 }

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -181,8 +181,6 @@
 .md-flow-section__header {
   display: grid;
   gap: 8px;
-  padding-bottom: 8px;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
 }
 
 .md-flow-section__title {
@@ -317,6 +315,24 @@
   align-items: center;
 }
 
+.md-panel-actions--ai-draft {
+  margin-bottom: 20px;
+}
+
+.md-button--compact-link {
+  gap: 0.38rem;
+  min-height: 2.2rem;
+  padding: 0.28rem 0.88rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+}
+
+.md-button__icon {
+  width: 0.82rem;
+  height: 0.82rem;
+  flex: 0 0 auto;
+}
+
 .md-output-actions {
   display: grid;
   gap: 12px;
@@ -346,7 +362,7 @@
 }
 
 .md-panel-actions + .md-form-grid {
-  margin-top: 12px;
+  margin-top: 24px;
 }
 
 .md-panel-actions + .md-note-card {
@@ -361,6 +377,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 0.44rem;
   min-height: 2.55rem;
   border-radius: 999px;
   padding: 0.38rem 1.02rem;
@@ -370,8 +387,19 @@
   font: inherit;
   font-weight: 600;
   font-size: 0.9rem;
+  line-height: 1.2;
   cursor: pointer;
+  text-decoration: none;
   transition: background 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+}
+
+.md-button:link,
+.md-button:visited,
+.md-button:hover,
+.md-button:focus-visible,
+.md-button:active {
+  color: #102a43;
+  text-decoration: none;
 }
 
 .md-button:hover {
@@ -400,9 +428,11 @@
   border: 1px solid var(--md-project-border);
   border-radius: 12px;
   background: rgba(230, 240, 255, 0.72);
-  padding: 14px 16px;
+  padding: 11px 14px;
   color: #102a43;
-  font-weight: 600;
+  font-size: 0.94rem;
+  font-weight: 500;
+  line-height: 1.45;
 }
 
 .md-save-state {
@@ -565,6 +595,34 @@
   font-weight: 700;
 }
 
+.md-pill-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.42rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid rgba(103, 80, 164, 0.22);
+  background: linear-gradient(180deg, #f6f1fc 0%, #eee7f8 100%);
+  color: #4f378b;
+  font-size: 0.82rem;
+  font-weight: 700;
+  line-height: 1.2;
+  text-decoration: none;
+  transition: background 0.16s ease, border-color 0.16s ease, color 0.16s ease;
+}
+
+.md-pill-link:hover,
+.md-pill-link:focus-visible {
+  background: linear-gradient(180deg, #efe7fa 0%, #e6dcf5 100%);
+  border-color: rgba(103, 80, 164, 0.32);
+  color: #3f315f;
+  text-decoration: none;
+}
+
+.md-pill-link--compact {
+  margin-left: auto;
+}
+
 md-outlined-text-field.md-outlined-field {
   --md-outlined-text-field-outline-color: #bdb7c8;
   --md-outlined-field-outline-color: #bdb7c8;
@@ -687,6 +745,49 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 
 .md-debug-accordion__body .md-form-grid + .md-form-grid {
   margin-top: 16px;
+}
+
+.md-note-accordion {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.72);
+  overflow: clip;
+}
+
+.md-note-accordion__summary {
+  list-style: none;
+  cursor: pointer;
+  user-select: none;
+  padding: 14px 18px;
+  font-size: 0.94rem;
+  font-weight: 700;
+  color: #102a43;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.md-note-accordion__summary::-webkit-details-marker {
+  display: none;
+}
+
+.md-note-accordion__summary::before {
+  content: "▸";
+  font-size: 0.9rem;
+  color: #52606d;
+  transition: transform 160ms ease;
+}
+
+.md-note-accordion[open] .md-note-accordion__summary::before {
+  transform: rotate(90deg);
+}
+
+.md-note-accordion__body {
+  padding: 0 18px 18px;
+}
+
+.md-note-accordion__body > .md-note-card {
+  margin-top: 0;
 }
 
 .ms-settings-card {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -215,6 +215,40 @@
             toast.show(message, 2200);
         }
     }
+    function getAiPromptText() {
+        var _a;
+        const template = document.getElementById("aiPromptTemplate");
+        if (!template) {
+            return "";
+        }
+        return (((_a = template.content) === null || _a === void 0 ? void 0 : _a.textContent) || template.textContent || "").trim();
+    }
+    async function copyTextToClipboard(text) {
+        if (typeof navigator !== "undefined" &&
+            navigator.clipboard &&
+            typeof navigator.clipboard.writeText === "function") {
+            await navigator.clipboard.writeText(text);
+            return;
+        }
+        const textarea = document.createElement("textarea");
+        textarea.value = text;
+        textarea.setAttribute("readonly", "readonly");
+        textarea.style.position = "fixed";
+        textarea.style.opacity = "0";
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand("copy");
+        document.body.removeChild(textarea);
+    }
+    async function copyAiPrompt() {
+        const promptText = getAiPromptText();
+        if (!promptText) {
+            throw new Error("生成AIプロンプトが見つかりません");
+        }
+        await copyTextToClipboard(promptText);
+        showToast("生成AIプロンプトをクリップボードにコピーしました");
+        setStatus("生成AIプロンプトをクリップボードにコピーしました");
+    }
     function setMermaidError(message) {
         const errorNode = getElement("mermaidSvgError");
         errorNode.textContent = message;
@@ -1245,6 +1279,14 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             }
         });
         getElement("loadProjectDraftSampleBtn").addEventListener("click", loadProjectDraftSample);
+        getElement("copyAiPromptBtn").addEventListener("click", async () => {
+            try {
+                await copyAiPrompt();
+            }
+            catch (error) {
+                setStatus(error instanceof Error ? error.message : "生成AIプロンプトのコピーに失敗しました");
+            }
+        });
         getElement("importProjectDraftBtn").addEventListener("click", async () => {
             try {
                 await importProjectDraftFromText();

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -345,6 +345,45 @@
     }
   }
 
+  function getAiPromptText(): string {
+    const template = document.getElementById("aiPromptTemplate") as HTMLTemplateElement | null;
+    if (!template) {
+      return "";
+    }
+    return (template.content?.textContent || template.textContent || "").trim();
+  }
+
+  async function copyTextToClipboard(text: string): Promise<void> {
+    if (
+      typeof navigator !== "undefined" &&
+      navigator.clipboard &&
+      typeof navigator.clipboard.writeText === "function"
+    ) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "readonly");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+    document.execCommand("copy");
+    document.body.removeChild(textarea);
+  }
+
+  async function copyAiPrompt(): Promise<void> {
+    const promptText = getAiPromptText();
+    if (!promptText) {
+      throw new Error("生成AIプロンプトが見つかりません");
+    }
+    await copyTextToClipboard(promptText);
+    showToast("生成AIプロンプトをクリップボードにコピーしました");
+    setStatus("生成AIプロンプトをクリップボードにコピーしました");
+  }
+
   function setMermaidError(message: string): void {
     const errorNode = getElement<HTMLElement>("mermaidSvgError");
     errorNode.textContent = message;
@@ -1489,6 +1528,13 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
       }
     });
     getElement<HTMLButtonElement>("loadProjectDraftSampleBtn").addEventListener("click", loadProjectDraftSample);
+    getElement<HTMLButtonElement>("copyAiPromptBtn").addEventListener("click", async () => {
+      try {
+        await copyAiPrompt();
+      } catch (error) {
+        setStatus(error instanceof Error ? error.message : "生成AIプロンプトのコピーに失敗しました");
+      }
+    });
     getElement<HTMLButtonElement>("importProjectDraftBtn").addEventListener("click", async () => {
       try {
         await importProjectDraftFromText();

--- a/tests/mikuproject-main.test.js
+++ b/tests/mikuproject-main.test.js
@@ -95,6 +95,15 @@ function mountDom() {
       </button>
     </div>
     <section id="tabPanelInput" class="md-flow-section md-tab-panel" data-tab-panel="input">
+      <div class="md-flow-section__header">
+        <h2 class="md-flow-section__title">
+          <span class="md-flow-section__step">1</span>
+          <span>Input</span>
+          <lht-help-tooltip label="Input の説明" wide>
+            <p>MS Project XML、XLSX、mikuproject_workbook_json (.json)、生成AI 向け編集用 JSON (.editjson)、CSV を読み込みます。</p>
+          </lht-help-tooltip>
+        </h2>
+      </div>
       <span class="md-button-with-help">
         <button id="importFileBtnWithHelp" type="button">Load from file help host</button>
         <span class="md-button-help-anchor">
@@ -109,9 +118,39 @@ function mountDom() {
           <textarea id="xmlInput"></textarea>
         </div>
       </details>
+      <details class="md-note-accordion">
+        <summary class="md-note-accordion__summary">新規生成AI連携</summary>
+        <div class="md-note-accordion__body">
+          <section class="md-note-card md-note-card--accent">
+            <div class="md-panel-actions">
+              <button id="copyAiPromptBtnPane" type="button">mikuproject 用の生成AIプロンプト</button>
+              <button id="importProjectDraftBtn" type="button">貼り付けた JSON を取り込む</button>
+              <lht-help-tooltip label="新規生成AI連携の説明" wide>
+                <p>(i) まず生成AIに 生成AIプロンプト を読み込ませます。</p>
+              </lht-help-tooltip>
+              <button id="loadProjectDraftSampleBtn" type="button">サンプル</button>
+            </div>
+            <template id="aiPromptTemplate"># mikuproject AI JSON Spec
+
+あなたはこれから mikuproject とやりとりします。</template>
+            <div class="md-form-grid">
+              <textarea id="projectDraftImportInput"></textarea>
+            </div>
+          </section>
+        </div>
+      </details>
       <div id="xmlSaveState" class="md-save-state md-save-state--dirty">XML 保存状態: 未保存</div>
     </section>
     <section id="tabPanelTransform" class="md-flow-section md-tab-panel" data-tab-panel="transform" hidden>
+      <div class="md-flow-section__header">
+        <h2 class="md-flow-section__title">
+          <span class="md-flow-section__step">2</span>
+          <span>Overview</span>
+          <lht-help-tooltip label="Overview の説明" wide>
+            <p>内部モデル、検証結果、Mermaid preview を確認します。取込後の warning と差分要約もここに表示します。</p>
+          </lht-help-tooltip>
+        </h2>
+      </div>
       <div id="summaryProjectName"></div>
       <div id="summaryTaskCount"></div>
       <div id="summaryResourceCount"></div>
@@ -144,6 +183,15 @@ function mountDom() {
       </div>
     </section>
     <section id="tabPanelOutput" class="md-flow-section md-tab-panel" data-tab-panel="output" hidden>
+      <div class="md-flow-section__header">
+        <h2 class="md-flow-section__title">
+          <span class="md-flow-section__step">3</span>
+          <span>Output</span>
+          <lht-help-tooltip label="Output の説明" wide>
+            <p>MS Project XML、XLSX、JSON、CSV、WBS XLSX、Mermaid、生成AI 向け .editjson を保存します。</p>
+          </lht-help-tooltip>
+        </h2>
+      </div>
       <details class="md-debug-accordion">
         <summary class="md-debug-accordion__summary">設定</summary>
         <div class="md-debug-accordion__body">
@@ -163,7 +211,6 @@ function mountDom() {
       <details class="md-debug-accordion">
         <summary class="md-debug-accordion__summary">デバッグ情報</summary>
         <div class="md-debug-accordion__body">
-          <textarea id="projectDraftImportInput"></textarea>
           <textarea id="workbookJsonOutput"></textarea>
           <textarea id="aiBundleOutput"></textarea>
           <textarea id="projectOverviewOutput"></textarea>
@@ -178,6 +225,10 @@ function mountDom() {
   `;
   const toast = document.getElementById("toast");
   toast.show = vi.fn();
+  const copyButton = document.getElementById("copyAiPromptBtnPane");
+  if (copyButton) {
+    copyButton.id = "copyAiPromptBtn";
+  }
 }
 
 function bootPage() {
@@ -237,6 +288,17 @@ describe("mikuproject main", () => {
       configurable: true
     });
     HTMLAnchorElement.prototype.click = vi.fn();
+    const clipboard = {
+      writeText: vi.fn(async () => {})
+    };
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      value: clipboard,
+      configurable: true
+    });
+    Object.defineProperty(window.navigator, "clipboard", {
+      value: clipboard,
+      configurable: true
+    });
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-16T23:12:00+09:00"));
   });
@@ -248,15 +310,22 @@ describe("mikuproject main", () => {
     expect(document.getElementById("statusMessage").textContent).toContain("サンプル XML");
     expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 未保存");
     expect(document.querySelector('lht-help-tooltip[label="Load from file の説明"]')).not.toBeNull();
+    expect(document.querySelector('lht-help-tooltip[label="Input の説明"]')).not.toBeNull();
+    expect(document.querySelector('lht-help-tooltip[label="Overview の説明"]')).not.toBeNull();
+    expect(document.querySelector('lht-help-tooltip[label="Output の説明"]')).not.toBeNull();
     expect(document.body.textContent).toContain("取込結果");
     expect(document.body.textContent).toContain("検証メッセージ");
     expect(document.body.textContent).toContain("取込 warning");
     expect(document.body.textContent).toContain("差分要約");
     expect(document.body.textContent).toContain("差分反映・warning・検証結果を確認します");
     expect(document.body.textContent).not.toContain("Workbook JSON");
+    expect(document.body.textContent).not.toContain("入力、読込、編集元データの確認をここにまとめます。");
+    expect(document.body.textContent).not.toContain("内部モデル、要約、検証結果、プレビューをここで確認します。");
+    expect(document.body.textContent).not.toContain("出力設定と生成結果の確認をここにまとめます。");
     expect(document.body.textContent).toContain("デバッグ情報");
     expect(document.querySelector(".md-debug-accordion")?.hasAttribute("open")).toBe(false);
     expect(document.querySelectorAll(".md-debug-accordion")[1]?.hasAttribute("open")).toBe(false);
+    expect(document.querySelector(".md-note-accordion")?.hasAttribute("open")).toBe(false);
     expect(document.body.textContent).toContain("WBS XLSX の祝日指定");
     expect(document.body.textContent).toContain("設定");
     expect(document.querySelectorAll(".md-debug-accordion")[2]?.hasAttribute("open")).toBe(false);
@@ -427,6 +496,17 @@ describe("mikuproject main", () => {
     expect(draftText).toContain("\"name\": \"mikuproject開発\"");
     expect(draftText).toContain("架空検討フェーズ【架空】");
     expect(document.getElementById("statusMessage").textContent).toContain("サンプル project_draft_view");
+  });
+
+  it("copies ai prompt to clipboard", async () => {
+    bootPage();
+
+    document.getElementById("copyAiPromptBtn").click();
+    await flushAsyncWork();
+
+    expect(globalThis.navigator.clipboard.writeText.mock.calls.length).toBeGreaterThan(0);
+    expect(globalThis.navigator.clipboard.writeText.mock.calls.at(-1)[0]).toContain("# mikuproject AI JSON Spec");
+    expect(document.getElementById("statusMessage").textContent).toContain("生成AIプロンプトをクリップボードにコピーしました");
   });
 
   it("parses xml into internal model summary", () => {


### PR DESCRIPTION
## 概要

生成AI連携まわりの UI を整理し、`project_draft_view` を扱う導線を分かりやすくしました。 あわせて、`mikuproject` 用の生成AIプロンプトをクリップボードへコピーできるようにし、関連する説明やアコーディオン構成、余白を調整しています。

## 変更内容

- `Input` 側の生成AI連携 UI を整理
  - セクション名を `新規生成AI連携` から `生成AI連携` に変更
  - デフォルトで閉じるアコーディオンに変更
  - `(i)` の位置をタイトル行から操作ボタン付近へ移動
  - ボタン列と JSON テキストエリアの間に専用余白を追加
- `mikuproject 用の生成AIプロンプト` を外部リンクからコピー用ボタンへ変更
  - `docs/mikuproject-ai-json-spec.md` の内容をビルド時に埋め込み
  - ボタンクリックでクリップボードへコピーする処理を追加
  - クリップボード用途を示すアイコンを追加
- `Output` 側の生成AI連携 UI を整理
  - `生成AI連携` セクションをデフォルトで閉じるアコーディオンに変更
  - 説明文を本文から `(i)` に移動
  - `(i)` を `full bundle` ボタンの右へ移動
- 補助的な UI 調整
  - `Input / Overview / Output` の説明文整理
  - ステータスメッセージの文字サイズ・太さ調整
  - ボタン配置や余白の微調整
- ドキュメント更新
  - `docs/TODO.md` に、現状 `.editjson` import は `project_draft_view` のみであり、将来は他の `view_type` にも対応する予定があることを追記

## 主な対象

- `mikuproject-src.html`
- `mikuproject.html`
- `src/css/app.css`
- `src/ts/main.ts`
- `src/js/main.js`
- `scripts/build-project.mjs`
- `docs/TODO.md`
- `tests/mikuproject-main.test.js`