### PR TITLE
XLSX Import 実運用対応と WBS / 生成AI連携 UI の整理

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -16,6 +16,13 @@
 - `local-data/` に置くべきでない生成物や一時ファイルがないか見直す
 - `npm test` を `scripts/run-tests.mjs` ベースへ切り替えるか検討する
 - `main.test.js` に残っている `xlsx import` の file input wiring を、UI 配線確認と import 結果確認へさらに分離する
+- `XLSX Import` の実地回帰観点を明文化し、少なくとも次を継続確認する
+  - export した `.xlsx` をそのまま import できる
+  - Excel で 1 セル変更した `.xlsx` を import できる
+  - 同じファイル名で保存し直した `.xlsx` を連続 import できる
+  - 空 editable セルを埋めた変更を import できる
+  - `Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes` など主要 editable 列が戻る
+  - `Milestone / Summary / Critical` など表示専用列は戻らない
 - `main.ts` の summary / validation / preview 描画を別モジュール化し、DOM テストをさらに軽くする
 - `phase_detail_view scoped` の `phase UID / root UID / max depth` 指定を、より選びやすい UI に改善する
 - `task_edit_view` の projection を実装する

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -211,6 +211,30 @@ import 時の扱いも `XLSX Import` と完全に揃える。
 
 `mikuproject_workbook_json` の import も、この表と同じ反映対象列・キー・部分更新ルールを使う。
 
+`Tasks` シートの header ごとの扱いは次のとおり。
+
+| Tasks Header | 扱い |
+| --- | --- |
+| `UID` | 表示のみ |
+| `ID` | 表示のみ |
+| `Name` | import 可 |
+| `OutlineLevel` | 表示のみ |
+| `OutlineNumber` | 表示のみ |
+| `WBS` | 表示のみ |
+| `Start` | import 可 |
+| `Finish` | import 可 |
+| `Duration` | 表示のみ |
+| `PercentComplete` | import 可 |
+| `PercentWorkComplete` | import 可 |
+| `Milestone` | 表示のみ |
+| `Summary` | 表示のみ |
+| `Critical` | 表示のみ |
+| `CalendarUID` | 表示のみ |
+| `Predecessors` | 表示のみ |
+| `Notes` | import 可 |
+
+`Resources` と `Assignments` が 0 件の workbook では、どの列が import 対象か分かるように、editable 列だけ着色されたダミー行を 1 行出してよい。これは表示補助であり、`UID` 等のキーが空なので import 時には無視される。
+
 ### Calendar 編集方針
 
 `Calendars / Exceptions` は、業務上は重要だが壊しやすい領域でもあるため、当面は `mikuproject` の画面上で直接編集しない方針とする。

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -5034,11 +5034,22 @@ if (!customElements.get("lht-page-menu")) {
             const entries = this.unpackEntries(bytes);
             return parseWorkbookEntries(entries);
         }
+        async importWorkbookAsync(bytes) {
+            const entries = await this.unpackEntriesAsync(bytes);
+            return parseWorkbookEntries(entries);
+        }
         listEntries(bytes) {
             return Object.keys(this.unpackEntries(bytes)).sort();
         }
+        async listEntriesAsync(bytes) {
+            const entries = await this.unpackEntriesAsync(bytes);
+            return Object.keys(entries).sort();
+        }
         unpackEntries(bytes) {
             return unpackZip(bytes);
+        }
+        async unpackEntriesAsync(bytes) {
+            return unpackZipAsync(bytes);
         }
         createWorkbookEntries(workbook) {
             const styleBook = createStyleBook(workbook);
@@ -5552,9 +5563,11 @@ if (!customElements.get("lht-page-menu")) {
         const workbookXml = decodeRequiredEntry(entries, "xl/workbook.xml");
         const workbookRelsXml = decodeRequiredEntry(entries, "xl/_rels/workbook.xml.rels");
         const stylesXml = entries["xl/styles.xml"] ? decodeUtf8(entries["xl/styles.xml"]) : null;
+        const sharedStringsXml = entries["xl/sharedStrings.xml"] ? decodeUtf8(entries["xl/sharedStrings.xml"]) : null;
         const workbookDocument = parseXmlDocument(workbookXml);
         const relationshipsDocument = parseXmlDocument(workbookRelsXml);
         const styleBook = parseStylesXml(stylesXml);
+        const sharedStrings = parseSharedStringsXml(sharedStringsXml);
         const relationshipMap = new Map();
         const relationshipElements = Array.from(relationshipsDocument.getElementsByTagNameNS("http://schemas.openxmlformats.org/package/2006/relationships", "Relationship"));
         for (const relationshipElement of relationshipElements) {
@@ -5578,14 +5591,14 @@ if (!customElements.get("lht-page-menu")) {
                     throw new Error(`Worksheet relationship target is missing for sheet: ${name}`);
                 }
                 const worksheetXml = decodeRequiredEntry(entries, target);
-                return parseWorksheetXml(name, worksheetXml, styleBook);
+                return parseWorksheetXml(name, worksheetXml, styleBook, sharedStrings);
             })
         };
     }
     function normalizeWorkbookTarget(target) {
         return target.startsWith("xl/") ? target : `xl/${target.replace(/^\.\//, "")}`;
     }
-    function parseWorksheetXml(name, xmlText, styleBook) {
+    function parseWorksheetXml(name, xmlText, styleBook, sharedStrings) {
         const document = parseXmlDocument(xmlText);
         const rowElements = Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "row"));
         return {
@@ -5595,7 +5608,7 @@ if (!customElements.get("lht-page-menu")) {
             mergedRanges: parseWorksheetMergedRanges(document),
             rows: rowElements.map((rowElement) => ({
                 height: parseOptionalNumber(rowElement.getAttribute("ht")),
-                cells: parseWorksheetRowCells(rowElement, styleBook)
+                cells: parseWorksheetRowCells(rowElement, styleBook, sharedStrings)
             }))
         };
     }
@@ -5643,7 +5656,7 @@ if (!customElements.get("lht-page-menu")) {
             colSplit
         };
     }
-    function parseWorksheetRowCells(rowElement, styleBook) {
+    function parseWorksheetRowCells(rowElement, styleBook, sharedStrings) {
         const cells = [];
         const cellElements = Array.from(rowElement.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "c")).filter((element) => element.parentElement === rowElement);
         for (const cellElement of cellElements) {
@@ -5652,11 +5665,11 @@ if (!customElements.get("lht-page-menu")) {
             while (cells.length < columnIndex) {
                 cells.push({});
             }
-            cells.push(parseWorksheetCell(cellElement, styleBook));
+            cells.push(parseWorksheetCell(cellElement, styleBook, sharedStrings));
         }
         return cells;
     }
-    function parseWorksheetCell(cellElement, styleBook) {
+    function parseWorksheetCell(cellElement, styleBook, sharedStrings) {
         const type = cellElement.getAttribute("t") || "";
         const styleIndex = Number(cellElement.getAttribute("s") || "0");
         const formulaElement = findDirectChild(cellElement, "f");
@@ -5666,6 +5679,10 @@ if (!customElements.get("lht-page-menu")) {
         if (type === "inlineStr") {
             const textElement = inlineStringElement ? findDirectChild(inlineStringElement, "t") : null;
             value = textElement ? (textElement.textContent || "") : "";
+        }
+        else if (type === "s") {
+            const sharedStringIndex = Number((valueElement === null || valueElement === void 0 ? void 0 : valueElement.textContent) || "0");
+            value = Number.isFinite(sharedStringIndex) ? (sharedStrings[sharedStringIndex] || "") : "";
         }
         else if (type === "b") {
             value = (valueElement === null || valueElement === void 0 ? void 0 : valueElement.textContent) === "1";
@@ -5710,6 +5727,27 @@ if (!customElements.get("lht-page-menu")) {
             cell.value = value;
         }
         return cell;
+    }
+    function parseSharedStringsXml(xmlText) {
+        if (!xmlText) {
+            return [];
+        }
+        const document = parseXmlDocument(xmlText);
+        const stringItems = Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "si"));
+        return stringItems.map((item) => extractSharedStringText(item));
+    }
+    function extractSharedStringText(itemElement) {
+        const directText = findDirectChild(itemElement, "t");
+        if (directText) {
+            return directText.textContent || "";
+        }
+        const richTextRuns = Array.from(itemElement.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "r"));
+        if (richTextRuns.length === 0) {
+            return "";
+        }
+        return richTextRuns
+            .map((run) => { var _a; return ((_a = findDirectChild(run, "t")) === null || _a === void 0 ? void 0 : _a.textContent) || ""; })
+            .join("");
     }
     function parseStylesXml(xmlText) {
         if (!xmlText) {
@@ -5966,6 +6004,68 @@ if (!customElements.get("lht-page-menu")) {
             pointer += 46 + fileNameLength + extraLength + commentLength;
         }
         return entries;
+    }
+    async function unpackZipAsync(bytes) {
+        const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+        const endOffset = findEndOfCentralDirectoryOffset(bytes);
+        const totalEntries = view.getUint16(endOffset + 10, true);
+        const centralDirectoryOffset = view.getUint32(endOffset + 16, true);
+        const entries = {};
+        let pointer = centralDirectoryOffset;
+        for (let index = 0; index < totalEntries; index += 1) {
+            if (view.getUint32(pointer, true) !== 0x02014b50) {
+                throw new Error("Invalid ZIP central directory header");
+            }
+            const compressionMethod = view.getUint16(pointer + 10, true);
+            const compressedSize = view.getUint32(pointer + 20, true);
+            const uncompressedSize = view.getUint32(pointer + 24, true);
+            const fileNameLength = view.getUint16(pointer + 28, true);
+            const extraLength = view.getUint16(pointer + 30, true);
+            const commentLength = view.getUint16(pointer + 32, true);
+            const localHeaderOffset = view.getUint32(pointer + 42, true);
+            const fileName = decodeUtf8(bytes.subarray(pointer + 46, pointer + 46 + fileNameLength));
+            const localView = new DataView(bytes.buffer, bytes.byteOffset + localHeaderOffset, bytes.byteLength - localHeaderOffset);
+            if (localView.getUint32(0, true) !== 0x04034b50) {
+                throw new Error(`Invalid ZIP local header for entry: ${fileName}`);
+            }
+            const localFileNameLength = localView.getUint16(26, true);
+            const localExtraLength = localView.getUint16(28, true);
+            const dataOffset = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+            const data = bytes.slice(dataOffset, dataOffset + compressedSize);
+            if (compressionMethod === 0) {
+                if (compressedSize !== uncompressedSize) {
+                    throw new Error(`Stored ZIP entry size mismatch: ${fileName}`);
+                }
+                entries[fileName] = data;
+            }
+            else if (compressionMethod === 8) {
+                entries[fileName] = await inflateDeflateRaw(data, uncompressedSize, fileName);
+            }
+            else {
+                throw new Error(`Unsupported ZIP compression method for entry ${fileName}: ${compressionMethod}`);
+            }
+            pointer += 46 + fileNameLength + extraLength + commentLength;
+        }
+        return entries;
+    }
+    async function inflateDeflateRaw(compressed, expectedSize, fileName) {
+        var _a;
+        if (typeof DecompressionStream !== "function") {
+            throw new Error(`ZIP deflate compression is not supported in this runtime: ${fileName}`);
+        }
+        const sourceStream = typeof Blob === "function" && typeof ((_a = Blob.prototype) === null || _a === void 0 ? void 0 : _a.stream) === "function"
+            ? new Blob([compressed]).stream()
+            : new Response(compressed).body;
+        if (!sourceStream) {
+            throw new Error(`ZIP deflate stream source is not available in this runtime: ${fileName}`);
+        }
+        const decompressedStream = sourceStream.pipeThrough(new DecompressionStream("deflate-raw"));
+        const buffer = await new Response(decompressedStream).arrayBuffer();
+        const inflated = new Uint8Array(buffer);
+        if (inflated.byteLength !== expectedSize) {
+            throw new Error(`Deflated ZIP entry size mismatch: ${fileName}`);
+        }
+        return inflated;
     }
     function findEndOfCentralDirectoryOffset(bytes) {
         for (let index = bytes.byteLength - 22; index >= 0; index -= 1) {
@@ -9766,6 +9866,43 @@ if (!customElements.get("lht-page-menu")) {
         };
     }
     function buildResourcesSheet(model) {
+        const resourceRows = model.resources.length > 0
+            ? model.resources.map((resource, index) => ({
+                cells: [
+                    countCell(resource.uid, index),
+                    countCell(resource.id, index),
+                    editableCell(entityNameCell(resource.name, index)),
+                    countCell(resource.type, index),
+                    textCell(resource.initials, index),
+                    editableCell(textCell(resource.group, index)),
+                    editableCell(countCell(resource.maxUnits, index)),
+                    referenceCell(resource.calendarUID, index),
+                    textCell(resource.standardRate, index),
+                    textCell(resource.overtimeRate, index),
+                    countCell(resource.costPerUse, index),
+                    workCell(resource.work, index),
+                    workCell(resource.actualWork, index),
+                    workCell(resource.remainingWork, index)
+                ]
+            }))
+            : [{
+                    cells: [
+                        countCell(undefined, 0),
+                        countCell(undefined, 0),
+                        editableCell(entityNameCell(undefined, 0)),
+                        countCell(undefined, 0),
+                        textCell(undefined, 0),
+                        editableCell(textCell(undefined, 0)),
+                        editableCell(countCell(undefined, 0)),
+                        referenceCell(undefined, 0),
+                        textCell(undefined, 0),
+                        textCell(undefined, 0),
+                        countCell(undefined, 0),
+                        workCell(undefined, 0),
+                        workCell(undefined, 0),
+                        workCell(undefined, 0)
+                    ]
+                }];
         return {
             name: "Resources",
             columns: [
@@ -9779,30 +9916,46 @@ if (!customElements.get("lht-page-menu")) {
                 sectionTitleRow("Resources", 14, SHEET_THEMES.resources.section),
                 sectionTitleRow("Resource List", 14, SHEET_THEMES.resources.section),
                 headerRow([...SHEET_HEADERS.Resources], SHEET_THEMES.resources.header),
-                ...model.resources.map((resource, index) => ({
-                    cells: [
-                        countCell(resource.uid, index),
-                        countCell(resource.id, index),
-                        editableCell(entityNameCell(resource.name, index)),
-                        countCell(resource.type, index),
-                        textCell(resource.initials, index),
-                        editableCell(textCell(resource.group, index)),
-                        editableCell(countCell(resource.maxUnits, index)),
-                        referenceCell(resource.calendarUID, index),
-                        textCell(resource.standardRate, index),
-                        textCell(resource.overtimeRate, index),
-                        countCell(resource.costPerUse, index),
-                        workCell(resource.work, index),
-                        workCell(resource.actualWork, index),
-                        workCell(resource.remainingWork, index)
-                    ]
-                }))
+                ...resourceRows
             ]
         };
     }
     function buildAssignmentsSheet(model) {
         const taskNameByUid = new Map(model.tasks.map((task) => [task.uid, task.name]));
         const resourceNameByUid = new Map(model.resources.map((resource) => [resource.uid, resource.name]));
+        const assignmentRows = model.assignments.length > 0
+            ? model.assignments.map((assignment, index) => ({
+                cells: [
+                    countCell(assignment.uid, index),
+                    referenceCell(assignment.taskUid, index),
+                    entityNameCell(taskNameByUid.get(assignment.taskUid), index),
+                    referenceCell(assignment.resourceUid, index),
+                    entityNameCell(resourceNameByUid.get(assignment.resourceUid), index),
+                    dateTimeCell(assignment.start, index),
+                    dateTimeCell(assignment.finish, index),
+                    editableCell(countCell(assignment.units, index)),
+                    editableCell(workCell(assignment.work, index)),
+                    workCell(assignment.actualWork, index),
+                    workCell(assignment.remainingWork, index),
+                    editableCell(percentCell(assignment.percentWorkComplete, index))
+                ]
+            }))
+            : [{
+                    cells: [
+                        countCell(undefined, 0),
+                        referenceCell(undefined, 0),
+                        entityNameCell(undefined, 0),
+                        referenceCell(undefined, 0),
+                        entityNameCell(undefined, 0),
+                        dateTimeCell(undefined, 0),
+                        dateTimeCell(undefined, 0),
+                        editableCell(countCell(undefined, 0)),
+                        editableCell(workCell(undefined, 0)),
+                        workCell(undefined, 0),
+                        workCell(undefined, 0),
+                        editableCell(percentCell(undefined, 0))
+                    ]
+                }];
         return {
             name: "Assignments",
             columns: [
@@ -9815,22 +9968,7 @@ if (!customElements.get("lht-page-menu")) {
                 sectionTitleRow("Assignments", 12, SHEET_THEMES.assignments.section),
                 sectionTitleRow("Assignment List", 12, SHEET_THEMES.assignments.section),
                 headerRow([...SHEET_HEADERS.Assignments], SHEET_THEMES.assignments.header),
-                ...model.assignments.map((assignment, index) => ({
-                    cells: [
-                        countCell(assignment.uid, index),
-                        referenceCell(assignment.taskUid, index),
-                        entityNameCell(taskNameByUid.get(assignment.taskUid), index),
-                        referenceCell(assignment.resourceUid, index),
-                        entityNameCell(resourceNameByUid.get(assignment.resourceUid), index),
-                        dateTimeCell(assignment.start, index),
-                        dateTimeCell(assignment.finish, index),
-                        editableCell(countCell(assignment.units, index)),
-                        editableCell(workCell(assignment.work, index)),
-                        workCell(assignment.actualWork, index),
-                        workCell(assignment.remainingWork, index),
-                        editableCell(percentCell(assignment.percentWorkComplete, index))
-                    ]
-                }))
+                ...assignmentRows
             ]
         };
     }
@@ -10063,11 +10201,9 @@ if (!customElements.get("lht-page-menu")) {
         });
     }
     function editableCell(cellLike) {
-        if (cellLike.value === undefined) {
-            return cellLike;
-        }
         return {
             ...cellLike,
+            border: cellLike.border || "thin",
             fillColor: EDITABLE_FILL
         };
     }
@@ -10943,7 +11079,7 @@ if (!customElements.get("lht-page-menu")) {
     function projectInfoRows(project, calendarNameByUid, holidayCount, columnCount, startColumnIndex, startRowNumber) {
         const scheduleMode = project.scheduleFromStart ? "開始基準" : "終了基準";
         const items = [
-            { label: "題名", value: truncateWbsReference(project.title || "-", 18) || "-", fillColor: SUMMARY_ASSIGNMENT_FILL },
+            { label: "プロジェクト名", value: truncateWbsReference(project.name || "-", 18) || "-", fillColor: SUMMARY_ASSIGNMENT_FILL },
             { label: "カレンダ", value: formatCalendarLabel(project.calendarUID, calendarNameByUid), fillColor: SUMMARY_ASSIGNMENT_FILL },
             { label: "基準", value: scheduleMode, fillColor: SUMMARY_ASSIGNMENT_FILL },
             { label: "開始日", value: formatWbsDate(project.startDate), fillColor: SUMMARY_SCHEDULE_FILL },
@@ -15685,7 +15821,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         const baseModel = ensureCurrentModel();
         const bytes = new Uint8Array(await file.arrayBuffer());
         const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
-        const workbook = codec.importWorkbook(bytes);
+        const workbook = typeof codec.importWorkbookAsync === "function"
+            ? await codec.importWorkbookAsync(bytes)
+            : codec.importWorkbook(bytes);
         const result = mikuprojectProjectXlsx.importProjectWorkbookDetailed(workbook, baseModel);
         currentModel = result.model;
         const issues = mikuprojectXml.validateProjectModel(currentModel);
@@ -15809,8 +15947,16 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     }
     function bindEvents() {
         getElement("loadSampleBtn").addEventListener("click", loadSample);
+        getElement("importFileInput").addEventListener("click", (event) => {
+            const input = event.target;
+            if (input) {
+                input.value = "";
+            }
+        });
         getElement("importFileBtn").addEventListener("click", () => {
-            getElement("importFileInput").click();
+            const input = getElement("importFileInput");
+            input.value = "";
+            input.click();
         });
         getElement("downloadMermaidSvgBtn").addEventListener("click", () => {
             void downloadCurrentMermaidSvg().catch((error) => {
@@ -15925,10 +16071,14 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         getElement("importFileInput").addEventListener("change", async (event) => {
             const input = event.target;
             const file = (input === null || input === void 0 ? void 0 : input.files) && input.files[0];
+            if (file) {
+                setStatus(`${file.name} を読み込んでいます...`);
+            }
             try {
                 await importFromFile(file);
             }
             catch (error) {
+                console.error("[mikuproject] file import failed", error);
                 setStatus(error instanceof Error ? error.message : "ファイル読込に失敗しました");
             }
             finally {

--- a/src/js/excel-io.js
+++ b/src/js/excel-io.js
@@ -23,11 +23,22 @@
             const entries = this.unpackEntries(bytes);
             return parseWorkbookEntries(entries);
         }
+        async importWorkbookAsync(bytes) {
+            const entries = await this.unpackEntriesAsync(bytes);
+            return parseWorkbookEntries(entries);
+        }
         listEntries(bytes) {
             return Object.keys(this.unpackEntries(bytes)).sort();
         }
+        async listEntriesAsync(bytes) {
+            const entries = await this.unpackEntriesAsync(bytes);
+            return Object.keys(entries).sort();
+        }
         unpackEntries(bytes) {
             return unpackZip(bytes);
+        }
+        async unpackEntriesAsync(bytes) {
+            return unpackZipAsync(bytes);
         }
         createWorkbookEntries(workbook) {
             const styleBook = createStyleBook(workbook);
@@ -541,9 +552,11 @@
         const workbookXml = decodeRequiredEntry(entries, "xl/workbook.xml");
         const workbookRelsXml = decodeRequiredEntry(entries, "xl/_rels/workbook.xml.rels");
         const stylesXml = entries["xl/styles.xml"] ? decodeUtf8(entries["xl/styles.xml"]) : null;
+        const sharedStringsXml = entries["xl/sharedStrings.xml"] ? decodeUtf8(entries["xl/sharedStrings.xml"]) : null;
         const workbookDocument = parseXmlDocument(workbookXml);
         const relationshipsDocument = parseXmlDocument(workbookRelsXml);
         const styleBook = parseStylesXml(stylesXml);
+        const sharedStrings = parseSharedStringsXml(sharedStringsXml);
         const relationshipMap = new Map();
         const relationshipElements = Array.from(relationshipsDocument.getElementsByTagNameNS("http://schemas.openxmlformats.org/package/2006/relationships", "Relationship"));
         for (const relationshipElement of relationshipElements) {
@@ -567,14 +580,14 @@
                     throw new Error(`Worksheet relationship target is missing for sheet: ${name}`);
                 }
                 const worksheetXml = decodeRequiredEntry(entries, target);
-                return parseWorksheetXml(name, worksheetXml, styleBook);
+                return parseWorksheetXml(name, worksheetXml, styleBook, sharedStrings);
             })
         };
     }
     function normalizeWorkbookTarget(target) {
         return target.startsWith("xl/") ? target : `xl/${target.replace(/^\.\//, "")}`;
     }
-    function parseWorksheetXml(name, xmlText, styleBook) {
+    function parseWorksheetXml(name, xmlText, styleBook, sharedStrings) {
         const document = parseXmlDocument(xmlText);
         const rowElements = Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "row"));
         return {
@@ -584,7 +597,7 @@
             mergedRanges: parseWorksheetMergedRanges(document),
             rows: rowElements.map((rowElement) => ({
                 height: parseOptionalNumber(rowElement.getAttribute("ht")),
-                cells: parseWorksheetRowCells(rowElement, styleBook)
+                cells: parseWorksheetRowCells(rowElement, styleBook, sharedStrings)
             }))
         };
     }
@@ -632,7 +645,7 @@
             colSplit
         };
     }
-    function parseWorksheetRowCells(rowElement, styleBook) {
+    function parseWorksheetRowCells(rowElement, styleBook, sharedStrings) {
         const cells = [];
         const cellElements = Array.from(rowElement.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "c")).filter((element) => element.parentElement === rowElement);
         for (const cellElement of cellElements) {
@@ -641,11 +654,11 @@
             while (cells.length < columnIndex) {
                 cells.push({});
             }
-            cells.push(parseWorksheetCell(cellElement, styleBook));
+            cells.push(parseWorksheetCell(cellElement, styleBook, sharedStrings));
         }
         return cells;
     }
-    function parseWorksheetCell(cellElement, styleBook) {
+    function parseWorksheetCell(cellElement, styleBook, sharedStrings) {
         const type = cellElement.getAttribute("t") || "";
         const styleIndex = Number(cellElement.getAttribute("s") || "0");
         const formulaElement = findDirectChild(cellElement, "f");
@@ -655,6 +668,10 @@
         if (type === "inlineStr") {
             const textElement = inlineStringElement ? findDirectChild(inlineStringElement, "t") : null;
             value = textElement ? (textElement.textContent || "") : "";
+        }
+        else if (type === "s") {
+            const sharedStringIndex = Number((valueElement === null || valueElement === void 0 ? void 0 : valueElement.textContent) || "0");
+            value = Number.isFinite(sharedStringIndex) ? (sharedStrings[sharedStringIndex] || "") : "";
         }
         else if (type === "b") {
             value = (valueElement === null || valueElement === void 0 ? void 0 : valueElement.textContent) === "1";
@@ -699,6 +716,27 @@
             cell.value = value;
         }
         return cell;
+    }
+    function parseSharedStringsXml(xmlText) {
+        if (!xmlText) {
+            return [];
+        }
+        const document = parseXmlDocument(xmlText);
+        const stringItems = Array.from(document.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "si"));
+        return stringItems.map((item) => extractSharedStringText(item));
+    }
+    function extractSharedStringText(itemElement) {
+        const directText = findDirectChild(itemElement, "t");
+        if (directText) {
+            return directText.textContent || "";
+        }
+        const richTextRuns = Array.from(itemElement.getElementsByTagNameNS("http://schemas.openxmlformats.org/spreadsheetml/2006/main", "r"));
+        if (richTextRuns.length === 0) {
+            return "";
+        }
+        return richTextRuns
+            .map((run) => { var _a; return ((_a = findDirectChild(run, "t")) === null || _a === void 0 ? void 0 : _a.textContent) || ""; })
+            .join("");
     }
     function parseStylesXml(xmlText) {
         if (!xmlText) {
@@ -955,6 +993,68 @@
             pointer += 46 + fileNameLength + extraLength + commentLength;
         }
         return entries;
+    }
+    async function unpackZipAsync(bytes) {
+        const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+        const endOffset = findEndOfCentralDirectoryOffset(bytes);
+        const totalEntries = view.getUint16(endOffset + 10, true);
+        const centralDirectoryOffset = view.getUint32(endOffset + 16, true);
+        const entries = {};
+        let pointer = centralDirectoryOffset;
+        for (let index = 0; index < totalEntries; index += 1) {
+            if (view.getUint32(pointer, true) !== 0x02014b50) {
+                throw new Error("Invalid ZIP central directory header");
+            }
+            const compressionMethod = view.getUint16(pointer + 10, true);
+            const compressedSize = view.getUint32(pointer + 20, true);
+            const uncompressedSize = view.getUint32(pointer + 24, true);
+            const fileNameLength = view.getUint16(pointer + 28, true);
+            const extraLength = view.getUint16(pointer + 30, true);
+            const commentLength = view.getUint16(pointer + 32, true);
+            const localHeaderOffset = view.getUint32(pointer + 42, true);
+            const fileName = decodeUtf8(bytes.subarray(pointer + 46, pointer + 46 + fileNameLength));
+            const localView = new DataView(bytes.buffer, bytes.byteOffset + localHeaderOffset, bytes.byteLength - localHeaderOffset);
+            if (localView.getUint32(0, true) !== 0x04034b50) {
+                throw new Error(`Invalid ZIP local header for entry: ${fileName}`);
+            }
+            const localFileNameLength = localView.getUint16(26, true);
+            const localExtraLength = localView.getUint16(28, true);
+            const dataOffset = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+            const data = bytes.slice(dataOffset, dataOffset + compressedSize);
+            if (compressionMethod === 0) {
+                if (compressedSize !== uncompressedSize) {
+                    throw new Error(`Stored ZIP entry size mismatch: ${fileName}`);
+                }
+                entries[fileName] = data;
+            }
+            else if (compressionMethod === 8) {
+                entries[fileName] = await inflateDeflateRaw(data, uncompressedSize, fileName);
+            }
+            else {
+                throw new Error(`Unsupported ZIP compression method for entry ${fileName}: ${compressionMethod}`);
+            }
+            pointer += 46 + fileNameLength + extraLength + commentLength;
+        }
+        return entries;
+    }
+    async function inflateDeflateRaw(compressed, expectedSize, fileName) {
+        var _a;
+        if (typeof DecompressionStream !== "function") {
+            throw new Error(`ZIP deflate compression is not supported in this runtime: ${fileName}`);
+        }
+        const sourceStream = typeof Blob === "function" && typeof ((_a = Blob.prototype) === null || _a === void 0 ? void 0 : _a.stream) === "function"
+            ? new Blob([compressed]).stream()
+            : new Response(compressed).body;
+        if (!sourceStream) {
+            throw new Error(`ZIP deflate stream source is not available in this runtime: ${fileName}`);
+        }
+        const decompressedStream = sourceStream.pipeThrough(new DecompressionStream("deflate-raw"));
+        const buffer = await new Response(decompressedStream).arrayBuffer();
+        const inflated = new Uint8Array(buffer);
+        if (inflated.byteLength !== expectedSize) {
+            throw new Error(`Deflated ZIP entry size mismatch: ${fileName}`);
+        }
+        return inflated;
     }
     function findEndOfCentralDirectoryOffset(bytes) {
         for (let index = bytes.byteLength - 22; index >= 0; index -= 1) {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1114,7 +1114,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         const baseModel = ensureCurrentModel();
         const bytes = new Uint8Array(await file.arrayBuffer());
         const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
-        const workbook = codec.importWorkbook(bytes);
+        const workbook = typeof codec.importWorkbookAsync === "function"
+            ? await codec.importWorkbookAsync(bytes)
+            : codec.importWorkbook(bytes);
         const result = mikuprojectProjectXlsx.importProjectWorkbookDetailed(workbook, baseModel);
         currentModel = result.model;
         const issues = mikuprojectXml.validateProjectModel(currentModel);
@@ -1238,8 +1240,16 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     }
     function bindEvents() {
         getElement("loadSampleBtn").addEventListener("click", loadSample);
+        getElement("importFileInput").addEventListener("click", (event) => {
+            const input = event.target;
+            if (input) {
+                input.value = "";
+            }
+        });
         getElement("importFileBtn").addEventListener("click", () => {
-            getElement("importFileInput").click();
+            const input = getElement("importFileInput");
+            input.value = "";
+            input.click();
         });
         getElement("downloadMermaidSvgBtn").addEventListener("click", () => {
             void downloadCurrentMermaidSvg().catch((error) => {
@@ -1354,10 +1364,14 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         getElement("importFileInput").addEventListener("change", async (event) => {
             const input = event.target;
             const file = (input === null || input === void 0 ? void 0 : input.files) && input.files[0];
+            if (file) {
+                setStatus(`${file.name} を読み込んでいます...`);
+            }
             try {
                 await importFromFile(file);
             }
             catch (error) {
+                console.error("[mikuproject] file import failed", error);
                 setStatus(error instanceof Error ? error.message : "ファイル読込に失敗しました");
             }
             finally {

--- a/src/js/project-xlsx.js
+++ b/src/js/project-xlsx.js
@@ -146,6 +146,43 @@
         };
     }
     function buildResourcesSheet(model) {
+        const resourceRows = model.resources.length > 0
+            ? model.resources.map((resource, index) => ({
+                cells: [
+                    countCell(resource.uid, index),
+                    countCell(resource.id, index),
+                    editableCell(entityNameCell(resource.name, index)),
+                    countCell(resource.type, index),
+                    textCell(resource.initials, index),
+                    editableCell(textCell(resource.group, index)),
+                    editableCell(countCell(resource.maxUnits, index)),
+                    referenceCell(resource.calendarUID, index),
+                    textCell(resource.standardRate, index),
+                    textCell(resource.overtimeRate, index),
+                    countCell(resource.costPerUse, index),
+                    workCell(resource.work, index),
+                    workCell(resource.actualWork, index),
+                    workCell(resource.remainingWork, index)
+                ]
+            }))
+            : [{
+                    cells: [
+                        countCell(undefined, 0),
+                        countCell(undefined, 0),
+                        editableCell(entityNameCell(undefined, 0)),
+                        countCell(undefined, 0),
+                        textCell(undefined, 0),
+                        editableCell(textCell(undefined, 0)),
+                        editableCell(countCell(undefined, 0)),
+                        referenceCell(undefined, 0),
+                        textCell(undefined, 0),
+                        textCell(undefined, 0),
+                        countCell(undefined, 0),
+                        workCell(undefined, 0),
+                        workCell(undefined, 0),
+                        workCell(undefined, 0)
+                    ]
+                }];
         return {
             name: "Resources",
             columns: [
@@ -159,30 +196,46 @@
                 sectionTitleRow("Resources", 14, SHEET_THEMES.resources.section),
                 sectionTitleRow("Resource List", 14, SHEET_THEMES.resources.section),
                 headerRow([...SHEET_HEADERS.Resources], SHEET_THEMES.resources.header),
-                ...model.resources.map((resource, index) => ({
-                    cells: [
-                        countCell(resource.uid, index),
-                        countCell(resource.id, index),
-                        editableCell(entityNameCell(resource.name, index)),
-                        countCell(resource.type, index),
-                        textCell(resource.initials, index),
-                        editableCell(textCell(resource.group, index)),
-                        editableCell(countCell(resource.maxUnits, index)),
-                        referenceCell(resource.calendarUID, index),
-                        textCell(resource.standardRate, index),
-                        textCell(resource.overtimeRate, index),
-                        countCell(resource.costPerUse, index),
-                        workCell(resource.work, index),
-                        workCell(resource.actualWork, index),
-                        workCell(resource.remainingWork, index)
-                    ]
-                }))
+                ...resourceRows
             ]
         };
     }
     function buildAssignmentsSheet(model) {
         const taskNameByUid = new Map(model.tasks.map((task) => [task.uid, task.name]));
         const resourceNameByUid = new Map(model.resources.map((resource) => [resource.uid, resource.name]));
+        const assignmentRows = model.assignments.length > 0
+            ? model.assignments.map((assignment, index) => ({
+                cells: [
+                    countCell(assignment.uid, index),
+                    referenceCell(assignment.taskUid, index),
+                    entityNameCell(taskNameByUid.get(assignment.taskUid), index),
+                    referenceCell(assignment.resourceUid, index),
+                    entityNameCell(resourceNameByUid.get(assignment.resourceUid), index),
+                    dateTimeCell(assignment.start, index),
+                    dateTimeCell(assignment.finish, index),
+                    editableCell(countCell(assignment.units, index)),
+                    editableCell(workCell(assignment.work, index)),
+                    workCell(assignment.actualWork, index),
+                    workCell(assignment.remainingWork, index),
+                    editableCell(percentCell(assignment.percentWorkComplete, index))
+                ]
+            }))
+            : [{
+                    cells: [
+                        countCell(undefined, 0),
+                        referenceCell(undefined, 0),
+                        entityNameCell(undefined, 0),
+                        referenceCell(undefined, 0),
+                        entityNameCell(undefined, 0),
+                        dateTimeCell(undefined, 0),
+                        dateTimeCell(undefined, 0),
+                        editableCell(countCell(undefined, 0)),
+                        editableCell(workCell(undefined, 0)),
+                        workCell(undefined, 0),
+                        workCell(undefined, 0),
+                        editableCell(percentCell(undefined, 0))
+                    ]
+                }];
         return {
             name: "Assignments",
             columns: [
@@ -195,22 +248,7 @@
                 sectionTitleRow("Assignments", 12, SHEET_THEMES.assignments.section),
                 sectionTitleRow("Assignment List", 12, SHEET_THEMES.assignments.section),
                 headerRow([...SHEET_HEADERS.Assignments], SHEET_THEMES.assignments.header),
-                ...model.assignments.map((assignment, index) => ({
-                    cells: [
-                        countCell(assignment.uid, index),
-                        referenceCell(assignment.taskUid, index),
-                        entityNameCell(taskNameByUid.get(assignment.taskUid), index),
-                        referenceCell(assignment.resourceUid, index),
-                        entityNameCell(resourceNameByUid.get(assignment.resourceUid), index),
-                        dateTimeCell(assignment.start, index),
-                        dateTimeCell(assignment.finish, index),
-                        editableCell(countCell(assignment.units, index)),
-                        editableCell(workCell(assignment.work, index)),
-                        workCell(assignment.actualWork, index),
-                        workCell(assignment.remainingWork, index),
-                        editableCell(percentCell(assignment.percentWorkComplete, index))
-                    ]
-                }))
+                ...assignmentRows
             ]
         };
     }
@@ -443,11 +481,9 @@
         });
     }
     function editableCell(cellLike) {
-        if (cellLike.value === undefined) {
-            return cellLike;
-        }
         return {
             ...cellLike,
+            border: cellLike.border || "thin",
             fillColor: EDITABLE_FILL
         };
     }

--- a/src/js/wbs-xlsx.js
+++ b/src/js/wbs-xlsx.js
@@ -311,7 +311,7 @@
     function projectInfoRows(project, calendarNameByUid, holidayCount, columnCount, startColumnIndex, startRowNumber) {
         const scheduleMode = project.scheduleFromStart ? "開始基準" : "終了基準";
         const items = [
-            { label: "題名", value: truncateWbsReference(project.title || "-", 18) || "-", fillColor: SUMMARY_ASSIGNMENT_FILL },
+            { label: "プロジェクト名", value: truncateWbsReference(project.name || "-", 18) || "-", fillColor: SUMMARY_ASSIGNMENT_FILL },
             { label: "カレンダ", value: formatCalendarLabel(project.calendarUID, calendarNameByUid), fillColor: SUMMARY_ASSIGNMENT_FILL },
             { label: "基準", value: scheduleMode, fillColor: SUMMARY_ASSIGNMENT_FILL },
             { label: "開始日", value: formatWbsDate(project.startDate), fillColor: SUMMARY_SCHEDULE_FILL },

--- a/src/ts/excel-io.ts
+++ b/src/ts/excel-io.ts
@@ -106,12 +106,26 @@
       return parseWorkbookEntries(entries);
     }
 
+    async importWorkbookAsync(bytes: Uint8Array): Promise<XlsxWorkbookModel> {
+      const entries = await this.unpackEntriesAsync(bytes);
+      return parseWorkbookEntries(entries);
+    }
+
     listEntries(bytes: Uint8Array): string[] {
       return Object.keys(this.unpackEntries(bytes)).sort();
     }
 
+    async listEntriesAsync(bytes: Uint8Array): Promise<string[]> {
+      const entries = await this.unpackEntriesAsync(bytes);
+      return Object.keys(entries).sort();
+    }
+
     unpackEntries(bytes: Uint8Array): Record<string, Uint8Array> {
       return unpackZip(bytes);
+    }
+
+    async unpackEntriesAsync(bytes: Uint8Array): Promise<Record<string, Uint8Array>> {
+      return unpackZipAsync(bytes);
     }
 
     private createWorkbookEntries(workbook: XlsxWorkbookModel): ZipEntry[] {
@@ -697,9 +711,11 @@
     const workbookXml = decodeRequiredEntry(entries, "xl/workbook.xml");
     const workbookRelsXml = decodeRequiredEntry(entries, "xl/_rels/workbook.xml.rels");
     const stylesXml = entries["xl/styles.xml"] ? decodeUtf8(entries["xl/styles.xml"]) : null;
+    const sharedStringsXml = entries["xl/sharedStrings.xml"] ? decodeUtf8(entries["xl/sharedStrings.xml"]) : null;
     const workbookDocument = parseXmlDocument(workbookXml);
     const relationshipsDocument = parseXmlDocument(workbookRelsXml);
     const styleBook = parseStylesXml(stylesXml);
+    const sharedStrings = parseSharedStringsXml(sharedStringsXml);
     const relationshipMap = new Map<string, string>();
     const relationshipElements = Array.from(relationshipsDocument.getElementsByTagNameNS(
       "http://schemas.openxmlformats.org/package/2006/relationships",
@@ -735,7 +751,7 @@
           throw new Error(`Worksheet relationship target is missing for sheet: ${name}`);
         }
         const worksheetXml = decodeRequiredEntry(entries, target);
-        return parseWorksheetXml(name, worksheetXml, styleBook);
+        return parseWorksheetXml(name, worksheetXml, styleBook, sharedStrings);
       })
     };
   }
@@ -744,7 +760,12 @@
     return target.startsWith("xl/") ? target : `xl/${target.replace(/^\.\//, "")}`;
   }
 
-  function parseWorksheetXml(name: string, xmlText: string, styleBook: StyleDescriptor[]): XlsxSheetModel {
+  function parseWorksheetXml(
+    name: string,
+    xmlText: string,
+    styleBook: StyleDescriptor[],
+    sharedStrings: string[]
+  ): XlsxSheetModel {
     const document = parseXmlDocument(xmlText);
     const rowElements = Array.from(document.getElementsByTagNameNS(
       "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
@@ -758,7 +779,7 @@
       mergedRanges: parseWorksheetMergedRanges(document),
       rows: rowElements.map((rowElement) => ({
         height: parseOptionalNumber(rowElement.getAttribute("ht")),
-        cells: parseWorksheetRowCells(rowElement, styleBook)
+        cells: parseWorksheetRowCells(rowElement, styleBook, sharedStrings)
       }))
     };
   }
@@ -819,7 +840,11 @@
     };
   }
 
-  function parseWorksheetRowCells(rowElement: Element, styleBook: StyleDescriptor[]): XlsxCellModel[] {
+  function parseWorksheetRowCells(
+    rowElement: Element,
+    styleBook: StyleDescriptor[],
+    sharedStrings: string[]
+  ): XlsxCellModel[] {
     const cells: XlsxCellModel[] = [];
     const cellElements = Array.from(rowElement.getElementsByTagNameNS(
       "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
@@ -832,13 +857,17 @@
       while (cells.length < columnIndex) {
         cells.push({});
       }
-      cells.push(parseWorksheetCell(cellElement, styleBook));
+      cells.push(parseWorksheetCell(cellElement, styleBook, sharedStrings));
     }
 
     return cells;
   }
 
-  function parseWorksheetCell(cellElement: Element, styleBook: StyleDescriptor[]): XlsxCellModel {
+  function parseWorksheetCell(
+    cellElement: Element,
+    styleBook: StyleDescriptor[],
+    sharedStrings: string[]
+  ): XlsxCellModel {
     const type = cellElement.getAttribute("t") || "";
     const styleIndex = Number(cellElement.getAttribute("s") || "0");
     const formulaElement = findDirectChild(cellElement, "f");
@@ -849,6 +878,9 @@
     if (type === "inlineStr") {
       const textElement = inlineStringElement ? findDirectChild(inlineStringElement, "t") : null;
       value = textElement ? (textElement.textContent || "") : "";
+    } else if (type === "s") {
+      const sharedStringIndex = Number(valueElement?.textContent || "0");
+      value = Number.isFinite(sharedStringIndex) ? (sharedStrings[sharedStringIndex] || "") : "";
     } else if (type === "b") {
       value = valueElement?.textContent === "1";
     } else if (type === "str") {
@@ -891,6 +923,35 @@
       cell.value = value;
     }
     return cell;
+  }
+
+  function parseSharedStringsXml(xmlText: string | null): string[] {
+    if (!xmlText) {
+      return [];
+    }
+    const document = parseXmlDocument(xmlText);
+    const stringItems = Array.from(document.getElementsByTagNameNS(
+      "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+      "si"
+    ));
+    return stringItems.map((item) => extractSharedStringText(item));
+  }
+
+  function extractSharedStringText(itemElement: Element): string {
+    const directText = findDirectChild(itemElement, "t");
+    if (directText) {
+      return directText.textContent || "";
+    }
+    const richTextRuns = Array.from(itemElement.getElementsByTagNameNS(
+      "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+      "r"
+    ));
+    if (richTextRuns.length === 0) {
+      return "";
+    }
+    return richTextRuns
+      .map((run) => findDirectChild(run, "t")?.textContent || "")
+      .join("");
   }
 
   function parseStylesXml(xmlText: string | null): StyleDescriptor[] {
@@ -1185,6 +1246,75 @@
     }
 
     return entries;
+  }
+
+  async function unpackZipAsync(bytes: Uint8Array): Promise<Record<string, Uint8Array>> {
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    const endOffset = findEndOfCentralDirectoryOffset(bytes);
+    const totalEntries = view.getUint16(endOffset + 10, true);
+    const centralDirectoryOffset = view.getUint32(endOffset + 16, true);
+    const entries: Record<string, Uint8Array> = {};
+    let pointer = centralDirectoryOffset;
+
+    for (let index = 0; index < totalEntries; index += 1) {
+      if (view.getUint32(pointer, true) !== 0x02014b50) {
+        throw new Error("Invalid ZIP central directory header");
+      }
+
+      const compressionMethod = view.getUint16(pointer + 10, true);
+      const compressedSize = view.getUint32(pointer + 20, true);
+      const uncompressedSize = view.getUint32(pointer + 24, true);
+      const fileNameLength = view.getUint16(pointer + 28, true);
+      const extraLength = view.getUint16(pointer + 30, true);
+      const commentLength = view.getUint16(pointer + 32, true);
+      const localHeaderOffset = view.getUint32(pointer + 42, true);
+      const fileName = decodeUtf8(bytes.subarray(pointer + 46, pointer + 46 + fileNameLength));
+      const localView = new DataView(bytes.buffer, bytes.byteOffset + localHeaderOffset, bytes.byteLength - localHeaderOffset);
+      if (localView.getUint32(0, true) !== 0x04034b50) {
+        throw new Error(`Invalid ZIP local header for entry: ${fileName}`);
+      }
+      const localFileNameLength = localView.getUint16(26, true);
+      const localExtraLength = localView.getUint16(28, true);
+      const dataOffset = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+      const data = bytes.slice(dataOffset, dataOffset + compressedSize);
+
+      if (compressionMethod === 0) {
+        if (compressedSize !== uncompressedSize) {
+          throw new Error(`Stored ZIP entry size mismatch: ${fileName}`);
+        }
+        entries[fileName] = data;
+      } else if (compressionMethod === 8) {
+        entries[fileName] = await inflateDeflateRaw(data, uncompressedSize, fileName);
+      } else {
+        throw new Error(`Unsupported ZIP compression method for entry ${fileName}: ${compressionMethod}`);
+      }
+      pointer += 46 + fileNameLength + extraLength + commentLength;
+    }
+
+    return entries;
+  }
+
+  async function inflateDeflateRaw(
+    compressed: Uint8Array,
+    expectedSize: number,
+    fileName: string
+  ): Promise<Uint8Array> {
+    if (typeof DecompressionStream !== "function") {
+      throw new Error(`ZIP deflate compression is not supported in this runtime: ${fileName}`);
+    }
+    const sourceStream = typeof Blob === "function" && typeof Blob.prototype?.stream === "function"
+      ? new Blob([compressed]).stream()
+      : new Response(compressed).body;
+    if (!sourceStream) {
+      throw new Error(`ZIP deflate stream source is not available in this runtime: ${fileName}`);
+    }
+    const decompressedStream = sourceStream.pipeThrough(new DecompressionStream("deflate-raw"));
+    const buffer = await new Response(decompressedStream).arrayBuffer();
+    const inflated = new Uint8Array(buffer);
+    if (inflated.byteLength !== expectedSize) {
+      throw new Error(`Deflated ZIP entry size mismatch: ${fileName}`);
+    }
+    return inflated;
   }
 
   function findEndOfCentralDirectoryOffset(bytes: Uint8Array): number {

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -45,6 +45,7 @@
       XlsxWorkbookCodec: new () => {
         exportWorkbook: (workbook: unknown) => Uint8Array;
         importWorkbook: (bytes: Uint8Array) => unknown;
+        importWorkbookAsync?: (bytes: Uint8Array) => Promise<unknown>;
       };
     };
   }).__mikuprojectExcelIo;
@@ -1358,7 +1359,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     const baseModel = ensureCurrentModel();
     const bytes = new Uint8Array(await file.arrayBuffer());
     const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
-    const workbook = codec.importWorkbook(bytes);
+    const workbook = typeof codec.importWorkbookAsync === "function"
+      ? await codec.importWorkbookAsync(bytes)
+      : codec.importWorkbook(bytes);
     const result = mikuprojectProjectXlsx.importProjectWorkbookDetailed(workbook, baseModel);
     currentModel = result.model;
     const issues = mikuprojectXml.validateProjectModel(currentModel);
@@ -1491,8 +1494,16 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
 
   function bindEvents(): void {
     getElement<HTMLButtonElement>("loadSampleBtn").addEventListener("click", loadSample);
+    getElement<HTMLInputElement>("importFileInput").addEventListener("click", (event) => {
+      const input = event.target as HTMLInputElement | null;
+      if (input) {
+        input.value = "";
+      }
+    });
     getElement<HTMLButtonElement>("importFileBtn").addEventListener("click", () => {
-      getElement<HTMLInputElement>("importFileInput").click();
+      const input = getElement<HTMLInputElement>("importFileInput");
+      input.value = "";
+      input.click();
     });
     getElement<HTMLButtonElement>("downloadMermaidSvgBtn").addEventListener("click", () => {
       void downloadCurrentMermaidSvg().catch((error) => {
@@ -1594,9 +1605,13 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     getElement<HTMLInputElement>("importFileInput").addEventListener("change", async (event) => {
       const input = event.target as HTMLInputElement | null;
       const file = input?.files && input.files[0];
+      if (file) {
+        setStatus(`${file.name} を読み込んでいます...`);
+      }
       try {
         await importFromFile(file);
       } catch (error) {
+        console.error("[mikuproject] file import failed", error);
         setStatus(error instanceof Error ? error.message : "ファイル読込に失敗しました");
       } finally {
         if (input) {

--- a/src/ts/project-xlsx.ts
+++ b/src/ts/project-xlsx.ts
@@ -211,6 +211,44 @@
   }
 
   function buildResourcesSheet(model: ProjectModel) {
+    const resourceRows = model.resources.length > 0
+      ? model.resources.map((resource, index) => ({
+        cells: [
+          countCell(resource.uid, index),
+          countCell(resource.id, index),
+          editableCell(entityNameCell(resource.name, index)),
+          countCell(resource.type, index),
+          textCell(resource.initials, index),
+          editableCell(textCell(resource.group, index)),
+          editableCell(countCell(resource.maxUnits, index)),
+          referenceCell(resource.calendarUID, index),
+          textCell(resource.standardRate, index),
+          textCell(resource.overtimeRate, index),
+          countCell(resource.costPerUse, index),
+          workCell(resource.work, index),
+          workCell(resource.actualWork, index),
+          workCell(resource.remainingWork, index)
+        ]
+      }))
+      : [{
+        cells: [
+          countCell(undefined, 0),
+          countCell(undefined, 0),
+          editableCell(entityNameCell(undefined, 0)),
+          countCell(undefined, 0),
+          textCell(undefined, 0),
+          editableCell(textCell(undefined, 0)),
+          editableCell(countCell(undefined, 0)),
+          referenceCell(undefined, 0),
+          textCell(undefined, 0),
+          textCell(undefined, 0),
+          countCell(undefined, 0),
+          workCell(undefined, 0),
+          workCell(undefined, 0),
+          workCell(undefined, 0)
+        ]
+      }];
+
     return {
       name: "Resources",
       columns: [
@@ -224,24 +262,7 @@
         sectionTitleRow("Resources", 14, SHEET_THEMES.resources.section),
         sectionTitleRow("Resource List", 14, SHEET_THEMES.resources.section),
         headerRow([...SHEET_HEADERS.Resources], SHEET_THEMES.resources.header),
-        ...model.resources.map((resource, index) => ({
-          cells: [
-            countCell(resource.uid, index),
-            countCell(resource.id, index),
-            editableCell(entityNameCell(resource.name, index)),
-            countCell(resource.type, index),
-            textCell(resource.initials, index),
-            editableCell(textCell(resource.group, index)),
-            editableCell(countCell(resource.maxUnits, index)),
-            referenceCell(resource.calendarUID, index),
-            textCell(resource.standardRate, index),
-            textCell(resource.overtimeRate, index),
-            countCell(resource.costPerUse, index),
-            workCell(resource.work, index),
-            workCell(resource.actualWork, index),
-            workCell(resource.remainingWork, index)
-          ]
-        }))
+        ...resourceRows
       ]
     };
   }
@@ -249,6 +270,39 @@
   function buildAssignmentsSheet(model: ProjectModel) {
     const taskNameByUid = new Map(model.tasks.map((task) => [task.uid, task.name]));
     const resourceNameByUid = new Map(model.resources.map((resource) => [resource.uid, resource.name]));
+    const assignmentRows = model.assignments.length > 0
+      ? model.assignments.map((assignment, index) => ({
+        cells: [
+          countCell(assignment.uid, index),
+          referenceCell(assignment.taskUid, index),
+          entityNameCell(taskNameByUid.get(assignment.taskUid), index),
+          referenceCell(assignment.resourceUid, index),
+          entityNameCell(resourceNameByUid.get(assignment.resourceUid), index),
+          dateTimeCell(assignment.start, index),
+          dateTimeCell(assignment.finish, index),
+          editableCell(countCell(assignment.units, index)),
+          editableCell(workCell(assignment.work, index)),
+          workCell(assignment.actualWork, index),
+          workCell(assignment.remainingWork, index),
+          editableCell(percentCell(assignment.percentWorkComplete, index))
+        ]
+      }))
+      : [{
+        cells: [
+          countCell(undefined, 0),
+          referenceCell(undefined, 0),
+          entityNameCell(undefined, 0),
+          referenceCell(undefined, 0),
+          entityNameCell(undefined, 0),
+          dateTimeCell(undefined, 0),
+          dateTimeCell(undefined, 0),
+          editableCell(countCell(undefined, 0)),
+          editableCell(workCell(undefined, 0)),
+          workCell(undefined, 0),
+          workCell(undefined, 0),
+          editableCell(percentCell(undefined, 0))
+        ]
+      }];
 
     return {
       name: "Assignments",
@@ -262,22 +316,7 @@
         sectionTitleRow("Assignments", 12, SHEET_THEMES.assignments.section),
         sectionTitleRow("Assignment List", 12, SHEET_THEMES.assignments.section),
         headerRow([...SHEET_HEADERS.Assignments], SHEET_THEMES.assignments.header),
-        ...model.assignments.map((assignment, index) => ({
-          cells: [
-            countCell(assignment.uid, index),
-            referenceCell(assignment.taskUid, index),
-            entityNameCell(taskNameByUid.get(assignment.taskUid), index),
-            referenceCell(assignment.resourceUid, index),
-            entityNameCell(resourceNameByUid.get(assignment.resourceUid), index),
-            dateTimeCell(assignment.start, index),
-            dateTimeCell(assignment.finish, index),
-            editableCell(countCell(assignment.units, index)),
-            editableCell(workCell(assignment.work, index)),
-            workCell(assignment.actualWork, index),
-            workCell(assignment.remainingWork, index),
-            editableCell(percentCell(assignment.percentWorkComplete, index))
-          ]
-        }))
+        ...assignmentRows
       ]
     };
   }
@@ -532,11 +571,9 @@
   }
 
   function editableCell(cellLike: XlsxCellLike): XlsxCellLike {
-    if (cellLike.value === undefined) {
-      return cellLike;
-    }
     return {
       ...cellLike,
+      border: cellLike.border || "thin",
       fillColor: EDITABLE_FILL
     };
   }

--- a/src/ts/wbs-xlsx.ts
+++ b/src/ts/wbs-xlsx.ts
@@ -435,7 +435,7 @@
   ) {
     const scheduleMode = project.scheduleFromStart ? "開始基準" : "終了基準";
     const items: Array<{ label: string; value: string | number; fillColor: string }> = [
-      { label: "題名", value: truncateWbsReference(project.title || "-", 18) || "-", fillColor: SUMMARY_ASSIGNMENT_FILL },
+      { label: "プロジェクト名", value: truncateWbsReference(project.name || "-", 18) || "-", fillColor: SUMMARY_ASSIGNMENT_FILL },
       { label: "カレンダ", value: formatCalendarLabel(project.calendarUID, calendarNameByUid), fillColor: SUMMARY_ASSIGNMENT_FILL },
       { label: "基準", value: scheduleMode, fillColor: SUMMARY_ASSIGNMENT_FILL },
       { label: "開始日", value: formatWbsDate(project.startDate), fillColor: SUMMARY_SCHEDULE_FILL },

--- a/tests/mikuproject-excel-io.test.js
+++ b/tests/mikuproject-excel-io.test.js
@@ -3,6 +3,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { deflateRawSync } from "node:zlib";
 
 import { describe, expect, it } from "vitest";
 
@@ -25,6 +26,70 @@ function bootExcelIoModule() {
 
 function decodeUtf8(bytes) {
   return new TextDecoder().decode(bytes);
+}
+
+function encodeUtf8(text) {
+  return new TextEncoder().encode(text);
+}
+
+function buildDeflatedZipWithSingleEntry(name, text) {
+  const nameBytes = encodeUtf8(name);
+  const rawData = encodeUtf8(text);
+  const compressedData = new Uint8Array(deflateRawSync(rawData));
+
+  const localHeader = new Uint8Array(30 + nameBytes.length);
+  const localView = new DataView(localHeader.buffer);
+  localView.setUint32(0, 0x04034b50, true);
+  localView.setUint16(4, 20, true);
+  localView.setUint16(6, 0, true);
+  localView.setUint16(8, 8, true);
+  localView.setUint32(14, 0, true);
+  localView.setUint32(18, compressedData.byteLength, true);
+  localView.setUint32(22, rawData.byteLength, true);
+  localView.setUint16(26, nameBytes.length, true);
+  localView.setUint16(28, 0, true);
+  localHeader.set(nameBytes, 30);
+
+  const centralHeader = new Uint8Array(46 + nameBytes.length);
+  const centralView = new DataView(centralHeader.buffer);
+  centralView.setUint32(0, 0x02014b50, true);
+  centralView.setUint16(4, 20, true);
+  centralView.setUint16(6, 20, true);
+  centralView.setUint16(8, 0, true);
+  centralView.setUint16(10, 8, true);
+  centralView.setUint32(16, 0, true);
+  centralView.setUint32(20, compressedData.byteLength, true);
+  centralView.setUint32(24, rawData.byteLength, true);
+  centralView.setUint16(28, nameBytes.length, true);
+  centralView.setUint16(30, 0, true);
+  centralView.setUint16(32, 0, true);
+  centralView.setUint16(34, 0, true);
+  centralView.setUint16(36, 0, true);
+  centralView.setUint32(38, 0, true);
+  centralView.setUint32(42, 0, true);
+  centralHeader.set(nameBytes, 46);
+
+  const end = new Uint8Array(22);
+  const endView = new DataView(end.buffer);
+  endView.setUint32(0, 0x06054b50, true);
+  endView.setUint16(4, 0, true);
+  endView.setUint16(6, 0, true);
+  endView.setUint16(8, 1, true);
+  endView.setUint16(10, 1, true);
+  endView.setUint32(12, centralHeader.byteLength, true);
+  endView.setUint32(16, localHeader.byteLength + compressedData.byteLength, true);
+  endView.setUint16(20, 0, true);
+
+  const bytes = new Uint8Array(localHeader.byteLength + compressedData.byteLength + centralHeader.byteLength + end.byteLength);
+  let offset = 0;
+  bytes.set(localHeader, offset);
+  offset += localHeader.byteLength;
+  bytes.set(compressedData, offset);
+  offset += compressedData.byteLength;
+  bytes.set(centralHeader, offset);
+  offset += centralHeader.byteLength;
+  bytes.set(end, offset);
+  return bytes;
 }
 
 describe("mikuproject excel io", () => {
@@ -563,5 +628,16 @@ describe("mikuproject excel io", () => {
 
     expect(worksheetXml).toContain("<mergeCells");
     expect(worksheetXml).toContain('ref="A1:B1"');
+  });
+
+  it("can asynchronously unpack a deflated zip entry", async () => {
+    const excelIo = bootExcelIoModule();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const bytes = buildDeflatedZipWithSingleEntry("[Content_Types].xml", "<Types></Types>");
+
+    const entries = await codec.unpackEntriesAsync(bytes);
+
+    expect(Object.keys(entries)).toEqual(["[Content_Types].xml"]);
+    expect(decodeUtf8(entries["[Content_Types].xml"])).toBe("<Types></Types>");
   });
 });

--- a/tests/mikuproject-main.test.js
+++ b/tests/mikuproject-main.test.js
@@ -275,6 +275,7 @@ async function flushAsyncWork() {
   await Promise.resolve();
 }
 
+
 describe("mikuproject main", () => {
   beforeEach(() => {
     document.body.innerHTML = "";
@@ -980,6 +981,21 @@ describe("mikuproject main", () => {
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("反映後の XML は更新済みです");
     expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
     expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
+  });
+
+  it("clears file input value before reselecting the same file", () => {
+    bootPage();
+
+    const importInput = document.getElementById("importFileInput");
+    Object.defineProperty(importInput, "value", {
+      configurable: true,
+      writable: true,
+      value: "same-file.xlsx"
+    });
+
+    importInput.dispatchEvent(new Event("click"));
+
+    expect(importInput.value).toBe("");
   });
 
   it("imports workbook json edits back into the current model and xml", async () => {

--- a/tests/mikuproject-project-xlsx.test.js
+++ b/tests/mikuproject-project-xlsx.test.js
@@ -82,9 +82,9 @@ describe("mikuproject project xlsx", () => {
     expect(workbook.sheets[0].rows[3].cells[0].value).toBe("Name");
     expect(workbook.sheets[0].rows[3].cells[1].value).toBe("mikuproject開発");
     expect(workbook.sheets[0].rows[3].cells[1].fillColor).toBe(EDITABLE_FILL);
-    expect(workbook.sheets[0].rows[4].cells[1].fillColor).toBe("#FAF6FF");
-    expect(workbook.sheets[0].rows[5].cells[1].fillColor).toBe("#FAF6FF");
-    expect(workbook.sheets[0].rows[6].cells[1].fillColor).toBe("#FAF6FF");
+    expect(workbook.sheets[0].rows[4].cells[1].fillColor).toBe(EDITABLE_FILL);
+    expect(workbook.sheets[0].rows[5].cells[1].fillColor).toBe(EDITABLE_FILL);
+    expect(workbook.sheets[0].rows[6].cells[1].fillColor).toBe(EDITABLE_FILL);
     expect(workbook.sheets[0].rows[7].cells[1].value).toBe("2026-03-16");
     expect(workbook.sheets[0].rows[11].cells[0].value).toBe("Settings");
     expect(workbook.sheets[0].rows[12].cells[1].fillColor).toBe(EDITABLE_FILL);
@@ -137,7 +137,8 @@ describe("mikuproject project xlsx", () => {
     expect(tasksSheet.rows[5].cells[15].value).toBe("");
     expect(tasksSheet.rows[5].cells[15].fillColor).toBe("#EEF7F4");
     expect(tasksSheet.rows[5].cells[16].value).toBeUndefined();
-    expect(tasksSheet.rows[5].cells[16].fillColor).toBeUndefined();
+    expect(tasksSheet.rows[5].cells[16].fillColor).toBe(EDITABLE_FILL);
+    expect(tasksSheet.rows[5].cells[16].border).toBe("thin");
 
     expect(resourcesSheet.mergedRanges).toEqual([]);
     expect(resourcesSheet.rows[0].cells[0].value).toBe("Resources");
@@ -160,7 +161,12 @@ describe("mikuproject project xlsx", () => {
       "ActualWork",
       "RemainingWork"
     ]);
-    expect(resourcesSheet.rows).toHaveLength(3);
+    expect(resourcesSheet.rows).toHaveLength(4);
+    expect(resourcesSheet.rows[3].cells[0].value).toBeUndefined();
+    expect(resourcesSheet.rows[3].cells[2].fillColor).toBe(EDITABLE_FILL);
+    expect(resourcesSheet.rows[3].cells[5].fillColor).toBe(EDITABLE_FILL);
+    expect(resourcesSheet.rows[3].cells[6].fillColor).toBe(EDITABLE_FILL);
+    expect(resourcesSheet.rows[3].cells[2].border).toBe("thin");
 
     expect(assignmentsSheet.mergedRanges).toEqual([]);
     expect(assignmentsSheet.rows[0].cells[0].value).toBe("Assignments");
@@ -181,7 +187,12 @@ describe("mikuproject project xlsx", () => {
       "RemainingWork",
       "PercentWorkComplete"
     ]);
-    expect(assignmentsSheet.rows).toHaveLength(3);
+    expect(assignmentsSheet.rows).toHaveLength(4);
+    expect(assignmentsSheet.rows[3].cells[0].value).toBeUndefined();
+    expect(assignmentsSheet.rows[3].cells[7].fillColor).toBe(EDITABLE_FILL);
+    expect(assignmentsSheet.rows[3].cells[8].fillColor).toBe(EDITABLE_FILL);
+    expect(assignmentsSheet.rows[3].cells[11].fillColor).toBe(EDITABLE_FILL);
+    expect(assignmentsSheet.rows[3].cells[7].border).toBe("thin");
 
     expect(calendarsSheet.mergedRanges).toEqual([]);
     expect(calendarsSheet.rows[0].cells[0].value).toBe("Calendars");
@@ -509,7 +520,7 @@ describe("mikuproject project xlsx", () => {
   it("reports assignment percent work complete import changes", () => {
     const { projectXlsx, model, workbook } = buildSampleWorkbook((nextWorkbook) => {
       const assignmentsSheet = nextWorkbook.sheets.find((sheet) => sheet.name === "Assignments");
-      expect(assignmentsSheet.rows).toHaveLength(3);
+      expect(assignmentsSheet.rows).toHaveLength(4);
     });
 
     const result = projectXlsx.importProjectWorkbookDetailed(workbook, model);

--- a/tests/mikuproject-wbs-xlsx.test.js
+++ b/tests/mikuproject-wbs-xlsx.test.js
@@ -130,8 +130,8 @@ describe("mikuproject wbs xlsx", () => {
     const projectInfoHeaderIndex = findRowIndexByCellValue(sheet, "プロジェクト", 0);
     expect(projectInfoHeaderIndex).toBe(2);
     expect(sheet.rows[projectInfoHeaderIndex].cells[0].fontSize).toBe(14);
-    expect(sheet.rows[projectInfoHeaderIndex + 1].cells[0].value).toBe("題名");
-    expect(sheet.rows[projectInfoHeaderIndex + 1].cells[2].value).toBe("-");
+    expect(sheet.rows[projectInfoHeaderIndex + 1].cells[0].value).toBe("プロジェクト名");
+    expect(sheet.rows[projectInfoHeaderIndex + 1].cells[2].value).toBe("mikuproject開発");
     expect(sheet.rows[projectInfoHeaderIndex + 2].cells[0].value).toBe("カレンダ");
     expect(sheet.rows[projectInfoHeaderIndex + 2].cells[2].value).toBe("1 Standard");
     expect(sheet.rows[projectInfoHeaderIndex + 3].cells[0].value).toBe("基準");
@@ -710,7 +710,7 @@ describe("mikuproject wbs xlsx", () => {
     const { xml, wbsXlsx } = bootModules();
     const model = xml.importMsProjectXml(xml.SAMPLE_XML);
 
-    model.project.title = "Sample Project Title Very Long";
+    model.project.name = "Sample Project Name Very Long";
     model.calendars[0].name = "Standard Calendar Very Long";
     model.tasks[2].predecessors = [{ predecessorUid: "1", type: 1, lag: "0" }];
 
@@ -721,6 +721,7 @@ describe("mikuproject wbs xlsx", () => {
     const secondTaskRow = sheet.rows[headerRowIndex + 3];
     const thirdTaskRow = sheet.rows[headerRowIndex + 4];
 
+    expect(sheet.rows[projectInfoHeaderIndex + 1].cells[0].value).toBe("プロジェクト名");
     expect(sheet.rows[projectInfoHeaderIndex + 1].cells[2].value).toBe("Sample Project ...");
     expect(secondTaskRow.cells[15].value).toBe("-");
     expect(secondTaskRow.cells[16].value).toBe("1 Standa...");


### PR DESCRIPTION
## 概要

この変更では、`XLSX Import` の実運用寄りの不具合修正と、`WBS XLSX` および生成AI連携まわりの UI 整理を行っています。 この会話で確認できた範囲では、特に Excel で保存し直した `.xlsx` の再取込、`Notes` の取込、`WBS XLSX` の project 情報表示、生成AI連携 UI の導線改善が含まれます。

## 変更内容

- `XLSX Import` の実運用対応
  - Excel が保存した `deflate` 圧縮の `.xlsx` を読めるように修正
  - `sharedStrings` を読むようにして、`Notes` など文字列セルの取込を改善
  - 同じファイル名を保存し直した `.xlsx` を再選択しやすいように、file input の値リセットを追加
  - 読込中ステータスと失敗時の `console.error` を追加
- `Project XLSX` の editable 表示改善
  - 空の editable セルでも罫線と editable 色が分かるように調整
  - `Resources` / `Assignments` が 0 件でも、どこが反映対象か分かるようにダミー行を追加
- `WBS XLSX` の表示調整
  - `タスク詳細` が `Tasks.Notes` を参照する前提で確認を進めた
  - project 情報ブロックの先頭項目を `project.title` ではなく `project.name` 参照に変更
  - ラベルを `題名` ではなく `プロジェクト名` に変更
- 生成AI連携 UI の整理
  - `Input` / `Overview` / `Output` の説明文を縮小し、`(i)` tooltip に整理
  - `生成AI連携` をアコーディオン化し、デフォルトで閉じるように変更
  - `mikuproject 用の生成AIプロンプト` を外部リンクではなくクリップボードコピーのボタンに変更
  - AI 連携ボタン列とテキストエリアの余白や配置を調整
- ドキュメント更新
  - `docs/TODO.md` に、`.editjson` import が現状 `project_draft_view` のみ対応であることを追記
  - `docs/TODO.md` に、`XLSX Import` の実地回帰観点を追記
  - `docs/spec.md` に `Tasks` シートの `import 可 / 表示のみ` の整理を追記