### PR TITLE
WBS XLSX レイアウト調整と Excel 保存 `.xlsx` 再取込対応の改善

### DIFF
--- a/mikuproject.html
+++ b/mikuproject.html
@@ -10791,6 +10791,8 @@ if (!customElements.get("lht-page-menu")) {
     const WEEK_START_BAND_FILL = "#E3EEF9";
     const MONTH_BOUNDARY_WEEK_FILL = "#D6E7F8";
     const MONTH_START_HEADER_FILL = "#DCEAF7";
+    const SATURDAY_HEADER_FILL = "#8EA9DB";
+    const SUNDAY_HEADER_FILL = "#E6B8AF";
     const TODAY_BAND_FILL = "#FFE6A7";
     const TODAY_ACTIVE_BAND_FILL = "#F3C96B";
     const TODAY_PROGRESS_BAND_FILL = "#D89A2B";
@@ -10802,6 +10804,7 @@ if (!customElements.get("lht-page-menu")) {
     const PROGRESS_COLUMN_FILL = "#FCF8FB";
     const REFERENCE_COLUMN_FILL = "#F8FBFB";
     const WBS_LAYOUT = createWbsSheetLayoutHelper();
+    const pxWidth = (pixels) => Math.round((pixels / 7) * 100) / 100;
     function collectWbsHolidayDates(model) {
         const holidaySet = new Set();
         for (const calendar of model.calendars) {
@@ -10904,19 +10907,17 @@ if (!customElements.get("lht-page-menu")) {
         const dividerColumnIndex = fixedHeaders.length + 1;
         const dateBandStartColumnIndex = dividerColumnIndex;
         const totalColumns = fixedHeaders.length + 1 + dateBand.length;
-        const rows = [
-            sheetTitleRow("WBS", totalColumns),
-            emptyRow(totalColumns, 22)
-        ];
+        const rows = [];
         const mergedRanges = [];
         const projectInfoBlock = projectInfoRows(model.project, calendarNameByUid, holidaySet.size, totalColumns, 0, rows.length + 1);
-        overlayRows(rows, 2, projectInfoBlock.rows, totalColumns);
+        overlayRows(rows, 0, projectInfoBlock.rows, totalColumns);
+        const exportTimestampRow = rows[1] || (rows[1] = emptyRow(totalColumns));
+        exportTimestampRow.cells[9] = {
+            value: formatWbsExportTimestamp(new Date()),
+            horizontalAlign: "left",
+            verticalAlign: "center"
+        };
         mergedRanges.push(...projectInfoBlock.mergedRanges);
-        const summaryBlock = displaySummaryRows(dateBand.length, countBusinessDays(dateBand, holidaySet, nonWorkingDayTypes), model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns, 5, 3, options.displayDaysBeforeBaseDate, options.displayDaysAfterBaseDate, options.useBusinessDaysForDisplayRange, options.useBusinessDaysForProgressBand);
-        overlayRows(rows, 2, summaryBlock.rows, totalColumns);
-        mergedRanges.push(...summaryBlock.mergedRanges);
-        const weekBandRanges = buildWeekBandRanges(dateBand, dateBandStartColumnIndex, rows.length + 1);
-        rows.push(weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length));
         rows.push(dateBandHeaderRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet, nonWorkingDayTypes));
         rows.push(weekdayHeaderRow(fixedHeaders, dateBand, model.project.currentDate, holidaySet, nonWorkingDayTypes));
         rows.push(...model.tasks.map((task) => ({
@@ -10948,16 +10949,20 @@ if (!customElements.get("lht-page-menu")) {
         rows.push(emptyRow(totalColumns, 28));
         const legendBlock = legendRows(totalColumns, rows.length + 1);
         rows.push(...legendBlock.rows);
-        mergedRanges.push(...weekBandRanges.map((item) => item.range), ...legendBlock.mergedRanges);
+        mergedRanges.push(...legendBlock.mergedRanges);
+        rows.push(emptyRow(totalColumns, 28));
+        const summaryBlock = displaySummaryRows(dateBand.length, countBusinessDays(dateBand, holidaySet, nonWorkingDayTypes), model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns, 0, rows.length + 1, options.displayDaysBeforeBaseDate, options.displayDaysAfterBaseDate, options.useBusinessDaysForDisplayRange, options.useBusinessDaysForProgressBand);
+        rows.push(...summaryBlock.rows);
+        mergedRanges.push(...summaryBlock.mergedRanges);
         return {
             sheets: [
                 {
                     name: "WBS",
                     columns: [
-                        { width: 8 }, { width: 8 }, { width: 12 }, { width: 10 }, { width: 10 }, { width: 42 },
-                        { width: 20 }, { width: 18 }, { width: 12 }, { width: 28 }, { width: 14 },
+                        { width: pxWidth(45) }, { width: pxWidth(45) }, { width: pxWidth(65) }, { width: pxWidth(60) }, { width: pxWidth(45) }, { width: 42 },
+                        { width: pxWidth(85) }, { width: pxWidth(85) }, { width: pxWidth(65) }, { width: 28 }, { width: 14 },
                         { width: 18, hidden: true }, { width: 12, hidden: true }, { width: 12, hidden: true }, { width: 12, hidden: true },
-                        { width: 16 }, { width: 12, hidden: true }, { width: 20, hidden: true }, { width: 18, hidden: true }, { width: 3 },
+                        { width: pxWidth(85) }, { width: 12, hidden: true }, { width: 20, hidden: true }, { width: 18, hidden: true }, { width: 3 },
                         ...dateBand.map(() => ({ width: 6 }))
                     ],
                     mergedRanges,
@@ -11077,11 +11082,9 @@ if (!customElements.get("lht-page-menu")) {
         };
     }
     function projectInfoRows(project, calendarNameByUid, holidayCount, columnCount, startColumnIndex, startRowNumber) {
-        const scheduleMode = project.scheduleFromStart ? "開始基準" : "終了基準";
         const items = [
             { label: "プロジェクト名", value: truncateWbsReference(project.name || "-", 18) || "-", fillColor: SUMMARY_ASSIGNMENT_FILL },
             { label: "カレンダ", value: formatCalendarLabel(project.calendarUID, calendarNameByUid), fillColor: SUMMARY_ASSIGNMENT_FILL },
-            { label: "基準", value: scheduleMode, fillColor: SUMMARY_ASSIGNMENT_FILL },
             { label: "開始日", value: formatWbsDate(project.startDate), fillColor: SUMMARY_SCHEDULE_FILL },
             { label: "終了日", value: formatWbsDate(project.finishDate), fillColor: SUMMARY_SCHEDULE_FILL },
             { label: "現在日", value: formatWbsDate(project.currentDate), fillColor: SUMMARY_SCHEDULE_FILL },
@@ -11089,17 +11092,17 @@ if (!customElements.get("lht-page-menu")) {
         ];
         return {
             mergedRanges: [
-                WBS_LAYOUT.range(WBS_LAYOUT.reference(startRowNumber, startColumnIndex), WBS_LAYOUT.reference(startRowNumber, startColumnIndex + 3)),
+                WBS_LAYOUT.range(WBS_LAYOUT.reference(startRowNumber, startColumnIndex), WBS_LAYOUT.reference(startRowNumber, startColumnIndex + 4)),
                 ...items.map((_, index) => {
                     const rowNumber = startRowNumber + index + 1;
                     return [
                         WBS_LAYOUT.range(WBS_LAYOUT.reference(rowNumber, startColumnIndex), WBS_LAYOUT.reference(rowNumber, startColumnIndex + 1)),
-                        WBS_LAYOUT.range(WBS_LAYOUT.reference(rowNumber, startColumnIndex + 2), WBS_LAYOUT.reference(rowNumber, startColumnIndex + 3))
+                        WBS_LAYOUT.range(WBS_LAYOUT.reference(rowNumber, startColumnIndex + 2), WBS_LAYOUT.reference(rowNumber, startColumnIndex + 4))
                     ];
                 }).flat()
             ],
             rows: [
-                projectBlockHeaderRow(columnCount, startColumnIndex, "プロジェクト"),
+                projectBlockHeaderRow(columnCount, startColumnIndex, "プロジェクト情報"),
                 ...items.map((item) => projectPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor))
             ]
         };
@@ -11196,15 +11199,18 @@ if (!customElements.get("lht-page-menu")) {
         for (const item of scheduleItems) {
             blockRows.push(summaryPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor));
         }
-        for (let index = 0; index < countItems.length; index += 1) {
-            const rowIndex = 1 + index;
-            while (blockRows.length <= rowIndex) {
-                blockRows.push(emptyRow(columnCount, 22));
-            }
-            overlaySummaryPair(blockRows[rowIndex], startColumnIndex + 3, countItems[index].label, countItems[index].value, countItems[index].fillColor);
+        for (const item of countItems) {
+            blockRows.push(summaryPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor));
+        }
+        const mergedRanges = [
+            WBS_LAYOUT.range(WBS_LAYOUT.reference(startRowNumber, startColumnIndex), WBS_LAYOUT.reference(startRowNumber, startColumnIndex + 2))
+        ];
+        for (let index = 1; index < blockRows.length; index += 1) {
+            const rowNumber = startRowNumber + index;
+            mergedRanges.push(WBS_LAYOUT.range(WBS_LAYOUT.reference(rowNumber, startColumnIndex + 1), WBS_LAYOUT.reference(rowNumber, startColumnIndex + 2)));
         }
         return {
-            mergedRanges: [WBS_LAYOUT.range(WBS_LAYOUT.reference(startRowNumber, startColumnIndex), WBS_LAYOUT.reference(startRowNumber, startColumnIndex + 1))],
+            mergedRanges,
             rows: blockRows
         };
     }
@@ -11223,6 +11229,11 @@ if (!customElements.get("lht-page-menu")) {
             border: "thin",
             fillColor: HEADER_ID_FILL
         };
+        cells[startColumnIndex + 2] = {
+            value: "",
+            border: "thin",
+            fillColor: HEADER_ID_FILL
+        };
         return { height: 24, cells };
     }
     function projectBlockHeaderRow(columnCount, startColumnIndex, title) {
@@ -11235,7 +11246,7 @@ if (!customElements.get("lht-page-menu")) {
             fontSize: 14,
             fillColor: HEADER_ID_FILL
         };
-        for (let offset = 1; offset < 4; offset += 1) {
+        for (let offset = 1; offset < 5; offset += 1) {
             cells[startColumnIndex + offset] = {
                 value: "",
                 border: "thin",
@@ -11270,12 +11281,22 @@ if (!customElements.get("lht-page-menu")) {
             border: "thin",
             fillColor
         };
+        cells[startColumnIndex + 4] = {
+            value: "",
+            border: "thin",
+            fillColor
+        };
         return { height: 22, cells };
     }
     function summaryPairRow(columnCount, startColumnIndex, label, value, fillColor) {
         const cells = Array.from({ length: columnCount }, () => ({}));
         cells[startColumnIndex] = summaryStatCell(label, fillColor, false);
         cells[startColumnIndex + 1] = summaryStatCell(value, fillColor, true);
+        cells[startColumnIndex + 2] = {
+            value: "",
+            border: "thin",
+            fillColor
+        };
         return { height: 22, cells };
     }
     function overlaySummaryPair(row, startColumnIndex, label, value, fillColor) {
@@ -11293,6 +11314,11 @@ if (!customElements.get("lht-page-menu")) {
             fillColor
         };
         cells[startColumnIndex + 1] = {
+            value: "",
+            border: "thin",
+            fillColor
+        };
+        cells[startColumnIndex + 2] = {
             value: "",
             border: "thin",
             fillColor
@@ -11510,6 +11536,14 @@ if (!customElements.get("lht-page-menu")) {
     function formatWbsDate(value) {
         return value ? value.slice(0, 10) : "-";
     }
+    function formatWbsExportTimestamp(value) {
+        const year = value.getFullYear();
+        const month = String(value.getMonth() + 1).padStart(2, "0");
+        const day = String(value.getDate()).padStart(2, "0");
+        const hours = String(value.getHours()).padStart(2, "0");
+        const minutes = String(value.getMinutes()).padStart(2, "0");
+        return `出力日時 ${year}-${month}-${day} ${hours}:${minutes}`;
+    }
     function dateNumberCell(day, currentDate, holidaySet, nonWorkingDayTypes) {
         const isToday = isSameDay(day, currentDate);
         const isWeekendDay = isWeeklyNonWorkingDay(day, nonWorkingDayTypes);
@@ -11531,13 +11565,16 @@ if (!customElements.get("lht-page-menu")) {
         const isHoliday = holidaySet.has(day);
         const weekStart = isWeekStart(day);
         const monthStart = isMonthStart(day);
+        const target = parseDateOnly(day);
+        const dayType = target ? (target.getDay() === 0 ? 1 : target.getDay() + 1) : 0;
+        const weekendHeaderFill = dayType === 7 ? SATURDAY_HEADER_FILL : (dayType === 1 ? SUNDAY_HEADER_FILL : WEEKEND_BAND_FILL);
         return {
             value: formatWeekdayValue(day),
             bold: true,
             border: "thin",
             horizontalAlign: "center",
             verticalAlign: "center",
-            fillColor: isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : (monthStart ? MONTH_START_HEADER_FILL : (weekStart ? WEEK_START_BAND_FILL : HEADER_FILL))))
+            fillColor: isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? weekendHeaderFill : (isToday ? TODAY_BAND_FILL : (monthStart ? MONTH_START_HEADER_FILL : (weekStart ? WEEK_START_BAND_FILL : HEADER_FILL))))
         };
     }
     function dateBandCell(task, day, currentDate, holidaySet, nonWorkingDayTypes, useBusinessDaysForProgressBand) {

--- a/src/js/wbs-xlsx.js
+++ b/src/js/wbs-xlsx.js
@@ -23,6 +23,8 @@
     const WEEK_START_BAND_FILL = "#E3EEF9";
     const MONTH_BOUNDARY_WEEK_FILL = "#D6E7F8";
     const MONTH_START_HEADER_FILL = "#DCEAF7";
+    const SATURDAY_HEADER_FILL = "#8EA9DB";
+    const SUNDAY_HEADER_FILL = "#E6B8AF";
     const TODAY_BAND_FILL = "#FFE6A7";
     const TODAY_ACTIVE_BAND_FILL = "#F3C96B";
     const TODAY_PROGRESS_BAND_FILL = "#D89A2B";
@@ -34,6 +36,7 @@
     const PROGRESS_COLUMN_FILL = "#FCF8FB";
     const REFERENCE_COLUMN_FILL = "#F8FBFB";
     const WBS_LAYOUT = createWbsSheetLayoutHelper();
+    const pxWidth = (pixels) => Math.round((pixels / 7) * 100) / 100;
     function collectWbsHolidayDates(model) {
         const holidaySet = new Set();
         for (const calendar of model.calendars) {
@@ -136,19 +139,17 @@
         const dividerColumnIndex = fixedHeaders.length + 1;
         const dateBandStartColumnIndex = dividerColumnIndex;
         const totalColumns = fixedHeaders.length + 1 + dateBand.length;
-        const rows = [
-            sheetTitleRow("WBS", totalColumns),
-            emptyRow(totalColumns, 22)
-        ];
+        const rows = [];
         const mergedRanges = [];
         const projectInfoBlock = projectInfoRows(model.project, calendarNameByUid, holidaySet.size, totalColumns, 0, rows.length + 1);
-        overlayRows(rows, 2, projectInfoBlock.rows, totalColumns);
+        overlayRows(rows, 0, projectInfoBlock.rows, totalColumns);
+        const exportTimestampRow = rows[1] || (rows[1] = emptyRow(totalColumns));
+        exportTimestampRow.cells[9] = {
+            value: formatWbsExportTimestamp(new Date()),
+            horizontalAlign: "left",
+            verticalAlign: "center"
+        };
         mergedRanges.push(...projectInfoBlock.mergedRanges);
-        const summaryBlock = displaySummaryRows(dateBand.length, countBusinessDays(dateBand, holidaySet, nonWorkingDayTypes), model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns, 5, 3, options.displayDaysBeforeBaseDate, options.displayDaysAfterBaseDate, options.useBusinessDaysForDisplayRange, options.useBusinessDaysForProgressBand);
-        overlayRows(rows, 2, summaryBlock.rows, totalColumns);
-        mergedRanges.push(...summaryBlock.mergedRanges);
-        const weekBandRanges = buildWeekBandRanges(dateBand, dateBandStartColumnIndex, rows.length + 1);
-        rows.push(weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length));
         rows.push(dateBandHeaderRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet, nonWorkingDayTypes));
         rows.push(weekdayHeaderRow(fixedHeaders, dateBand, model.project.currentDate, holidaySet, nonWorkingDayTypes));
         rows.push(...model.tasks.map((task) => ({
@@ -180,16 +181,20 @@
         rows.push(emptyRow(totalColumns, 28));
         const legendBlock = legendRows(totalColumns, rows.length + 1);
         rows.push(...legendBlock.rows);
-        mergedRanges.push(...weekBandRanges.map((item) => item.range), ...legendBlock.mergedRanges);
+        mergedRanges.push(...legendBlock.mergedRanges);
+        rows.push(emptyRow(totalColumns, 28));
+        const summaryBlock = displaySummaryRows(dateBand.length, countBusinessDays(dateBand, holidaySet, nonWorkingDayTypes), model.project.currentDate, model.tasks.length, model.resources.length, model.assignments.length, model.calendars.length, totalColumns, 0, rows.length + 1, options.displayDaysBeforeBaseDate, options.displayDaysAfterBaseDate, options.useBusinessDaysForDisplayRange, options.useBusinessDaysForProgressBand);
+        rows.push(...summaryBlock.rows);
+        mergedRanges.push(...summaryBlock.mergedRanges);
         return {
             sheets: [
                 {
                     name: "WBS",
                     columns: [
-                        { width: 8 }, { width: 8 }, { width: 12 }, { width: 10 }, { width: 10 }, { width: 42 },
-                        { width: 20 }, { width: 18 }, { width: 12 }, { width: 28 }, { width: 14 },
+                        { width: pxWidth(45) }, { width: pxWidth(45) }, { width: pxWidth(65) }, { width: pxWidth(60) }, { width: pxWidth(45) }, { width: 42 },
+                        { width: pxWidth(85) }, { width: pxWidth(85) }, { width: pxWidth(65) }, { width: 28 }, { width: 14 },
                         { width: 18, hidden: true }, { width: 12, hidden: true }, { width: 12, hidden: true }, { width: 12, hidden: true },
-                        { width: 16 }, { width: 12, hidden: true }, { width: 20, hidden: true }, { width: 18, hidden: true }, { width: 3 },
+                        { width: pxWidth(85) }, { width: 12, hidden: true }, { width: 20, hidden: true }, { width: 18, hidden: true }, { width: 3 },
                         ...dateBand.map(() => ({ width: 6 }))
                     ],
                     mergedRanges,
@@ -309,11 +314,9 @@
         };
     }
     function projectInfoRows(project, calendarNameByUid, holidayCount, columnCount, startColumnIndex, startRowNumber) {
-        const scheduleMode = project.scheduleFromStart ? "開始基準" : "終了基準";
         const items = [
             { label: "プロジェクト名", value: truncateWbsReference(project.name || "-", 18) || "-", fillColor: SUMMARY_ASSIGNMENT_FILL },
             { label: "カレンダ", value: formatCalendarLabel(project.calendarUID, calendarNameByUid), fillColor: SUMMARY_ASSIGNMENT_FILL },
-            { label: "基準", value: scheduleMode, fillColor: SUMMARY_ASSIGNMENT_FILL },
             { label: "開始日", value: formatWbsDate(project.startDate), fillColor: SUMMARY_SCHEDULE_FILL },
             { label: "終了日", value: formatWbsDate(project.finishDate), fillColor: SUMMARY_SCHEDULE_FILL },
             { label: "現在日", value: formatWbsDate(project.currentDate), fillColor: SUMMARY_SCHEDULE_FILL },
@@ -321,17 +324,17 @@
         ];
         return {
             mergedRanges: [
-                WBS_LAYOUT.range(WBS_LAYOUT.reference(startRowNumber, startColumnIndex), WBS_LAYOUT.reference(startRowNumber, startColumnIndex + 3)),
+                WBS_LAYOUT.range(WBS_LAYOUT.reference(startRowNumber, startColumnIndex), WBS_LAYOUT.reference(startRowNumber, startColumnIndex + 4)),
                 ...items.map((_, index) => {
                     const rowNumber = startRowNumber + index + 1;
                     return [
                         WBS_LAYOUT.range(WBS_LAYOUT.reference(rowNumber, startColumnIndex), WBS_LAYOUT.reference(rowNumber, startColumnIndex + 1)),
-                        WBS_LAYOUT.range(WBS_LAYOUT.reference(rowNumber, startColumnIndex + 2), WBS_LAYOUT.reference(rowNumber, startColumnIndex + 3))
+                        WBS_LAYOUT.range(WBS_LAYOUT.reference(rowNumber, startColumnIndex + 2), WBS_LAYOUT.reference(rowNumber, startColumnIndex + 4))
                     ];
                 }).flat()
             ],
             rows: [
-                projectBlockHeaderRow(columnCount, startColumnIndex, "プロジェクト"),
+                projectBlockHeaderRow(columnCount, startColumnIndex, "プロジェクト情報"),
                 ...items.map((item) => projectPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor))
             ]
         };
@@ -428,15 +431,18 @@
         for (const item of scheduleItems) {
             blockRows.push(summaryPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor));
         }
-        for (let index = 0; index < countItems.length; index += 1) {
-            const rowIndex = 1 + index;
-            while (blockRows.length <= rowIndex) {
-                blockRows.push(emptyRow(columnCount, 22));
-            }
-            overlaySummaryPair(blockRows[rowIndex], startColumnIndex + 3, countItems[index].label, countItems[index].value, countItems[index].fillColor);
+        for (const item of countItems) {
+            blockRows.push(summaryPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor));
+        }
+        const mergedRanges = [
+            WBS_LAYOUT.range(WBS_LAYOUT.reference(startRowNumber, startColumnIndex), WBS_LAYOUT.reference(startRowNumber, startColumnIndex + 2))
+        ];
+        for (let index = 1; index < blockRows.length; index += 1) {
+            const rowNumber = startRowNumber + index;
+            mergedRanges.push(WBS_LAYOUT.range(WBS_LAYOUT.reference(rowNumber, startColumnIndex + 1), WBS_LAYOUT.reference(rowNumber, startColumnIndex + 2)));
         }
         return {
-            mergedRanges: [WBS_LAYOUT.range(WBS_LAYOUT.reference(startRowNumber, startColumnIndex), WBS_LAYOUT.reference(startRowNumber, startColumnIndex + 1))],
+            mergedRanges,
             rows: blockRows
         };
     }
@@ -455,6 +461,11 @@
             border: "thin",
             fillColor: HEADER_ID_FILL
         };
+        cells[startColumnIndex + 2] = {
+            value: "",
+            border: "thin",
+            fillColor: HEADER_ID_FILL
+        };
         return { height: 24, cells };
     }
     function projectBlockHeaderRow(columnCount, startColumnIndex, title) {
@@ -467,7 +478,7 @@
             fontSize: 14,
             fillColor: HEADER_ID_FILL
         };
-        for (let offset = 1; offset < 4; offset += 1) {
+        for (let offset = 1; offset < 5; offset += 1) {
             cells[startColumnIndex + offset] = {
                 value: "",
                 border: "thin",
@@ -502,12 +513,22 @@
             border: "thin",
             fillColor
         };
+        cells[startColumnIndex + 4] = {
+            value: "",
+            border: "thin",
+            fillColor
+        };
         return { height: 22, cells };
     }
     function summaryPairRow(columnCount, startColumnIndex, label, value, fillColor) {
         const cells = Array.from({ length: columnCount }, () => ({}));
         cells[startColumnIndex] = summaryStatCell(label, fillColor, false);
         cells[startColumnIndex + 1] = summaryStatCell(value, fillColor, true);
+        cells[startColumnIndex + 2] = {
+            value: "",
+            border: "thin",
+            fillColor
+        };
         return { height: 22, cells };
     }
     function overlaySummaryPair(row, startColumnIndex, label, value, fillColor) {
@@ -525,6 +546,11 @@
             fillColor
         };
         cells[startColumnIndex + 1] = {
+            value: "",
+            border: "thin",
+            fillColor
+        };
+        cells[startColumnIndex + 2] = {
             value: "",
             border: "thin",
             fillColor
@@ -742,6 +768,14 @@
     function formatWbsDate(value) {
         return value ? value.slice(0, 10) : "-";
     }
+    function formatWbsExportTimestamp(value) {
+        const year = value.getFullYear();
+        const month = String(value.getMonth() + 1).padStart(2, "0");
+        const day = String(value.getDate()).padStart(2, "0");
+        const hours = String(value.getHours()).padStart(2, "0");
+        const minutes = String(value.getMinutes()).padStart(2, "0");
+        return `出力日時 ${year}-${month}-${day} ${hours}:${minutes}`;
+    }
     function dateNumberCell(day, currentDate, holidaySet, nonWorkingDayTypes) {
         const isToday = isSameDay(day, currentDate);
         const isWeekendDay = isWeeklyNonWorkingDay(day, nonWorkingDayTypes);
@@ -763,13 +797,16 @@
         const isHoliday = holidaySet.has(day);
         const weekStart = isWeekStart(day);
         const monthStart = isMonthStart(day);
+        const target = parseDateOnly(day);
+        const dayType = target ? (target.getDay() === 0 ? 1 : target.getDay() + 1) : 0;
+        const weekendHeaderFill = dayType === 7 ? SATURDAY_HEADER_FILL : (dayType === 1 ? SUNDAY_HEADER_FILL : WEEKEND_BAND_FILL);
         return {
             value: formatWeekdayValue(day),
             bold: true,
             border: "thin",
             horizontalAlign: "center",
             verticalAlign: "center",
-            fillColor: isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : (monthStart ? MONTH_START_HEADER_FILL : (weekStart ? WEEK_START_BAND_FILL : HEADER_FILL))))
+            fillColor: isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? weekendHeaderFill : (isToday ? TODAY_BAND_FILL : (monthStart ? MONTH_START_HEADER_FILL : (weekStart ? WEEK_START_BAND_FILL : HEADER_FILL))))
         };
     }
     function dateBandCell(task, day, currentDate, holidaySet, nonWorkingDayTypes, useBusinessDaysForProgressBand) {

--- a/src/ts/wbs-xlsx.ts
+++ b/src/ts/wbs-xlsx.ts
@@ -71,6 +71,8 @@
   const WEEK_START_BAND_FILL = "#E3EEF9";
   const MONTH_BOUNDARY_WEEK_FILL = "#D6E7F8";
   const MONTH_START_HEADER_FILL = "#DCEAF7";
+  const SATURDAY_HEADER_FILL = "#8EA9DB";
+  const SUNDAY_HEADER_FILL = "#E6B8AF";
   const TODAY_BAND_FILL = "#FFE6A7";
   const TODAY_ACTIVE_BAND_FILL = "#F3C96B";
   const TODAY_PROGRESS_BAND_FILL = "#D89A2B";
@@ -82,6 +84,7 @@
   const PROGRESS_COLUMN_FILL = "#FCF8FB";
   const REFERENCE_COLUMN_FILL = "#F8FBFB";
   const WBS_LAYOUT = createWbsSheetLayoutHelper();
+  const pxWidth = (pixels: number) => Math.round((pixels / 7) * 100) / 100;
 
   function collectWbsHolidayDates(model: ProjectModel): string[] {
     const holidaySet = new Set<string>();
@@ -205,10 +208,7 @@
     const dividerColumnIndex = fixedHeaders.length + 1;
     const dateBandStartColumnIndex = dividerColumnIndex;
     const totalColumns = fixedHeaders.length + 1 + dateBand.length;
-    const rows = [
-      sheetTitleRow("WBS", totalColumns),
-      emptyRow(totalColumns, 22)
-    ];
+    const rows: WbsXlsxWorkbookLike["sheets"][number]["rows"] = [];
     const mergedRanges = [];
     const projectInfoBlock = projectInfoRows(
       model.project,
@@ -218,28 +218,14 @@
       0,
       rows.length + 1
     );
-    overlayRows(rows, 2, projectInfoBlock.rows, totalColumns);
+    overlayRows(rows, 0, projectInfoBlock.rows, totalColumns);
+    const exportTimestampRow = rows[1] || (rows[1] = emptyRow(totalColumns));
+    exportTimestampRow.cells[9] = {
+      value: formatWbsExportTimestamp(new Date()),
+      horizontalAlign: "left",
+      verticalAlign: "center"
+    };
     mergedRanges.push(...projectInfoBlock.mergedRanges);
-    const summaryBlock = displaySummaryRows(
-      dateBand.length,
-      countBusinessDays(dateBand, holidaySet, nonWorkingDayTypes),
-      model.project.currentDate,
-      model.tasks.length,
-      model.resources.length,
-      model.assignments.length,
-      model.calendars.length,
-      totalColumns,
-      5,
-      3,
-      options.displayDaysBeforeBaseDate,
-      options.displayDaysAfterBaseDate,
-      options.useBusinessDaysForDisplayRange,
-      options.useBusinessDaysForProgressBand
-    );
-    overlayRows(rows, 2, summaryBlock.rows, totalColumns);
-    mergedRanges.push(...summaryBlock.mergedRanges);
-    const weekBandRanges = buildWeekBandRanges(dateBand, dateBandStartColumnIndex, rows.length + 1);
-    rows.push(weekBandRow(fixedHeaders.length + 1, weekBandRanges, dateBand.length));
     rows.push(dateBandHeaderRow(fixedHeaders.length + 1, dateBand, model.project.currentDate, holidaySet, nonWorkingDayTypes));
     rows.push(weekdayHeaderRow(fixedHeaders, dateBand, model.project.currentDate, holidaySet, nonWorkingDayTypes));
     rows.push(...model.tasks.map((task) => ({
@@ -271,17 +257,36 @@
     rows.push(emptyRow(totalColumns, 28));
     const legendBlock = legendRows(totalColumns, rows.length + 1);
     rows.push(...legendBlock.rows);
-    mergedRanges.push(...weekBandRanges.map((item) => item.range), ...legendBlock.mergedRanges);
+    mergedRanges.push(...legendBlock.mergedRanges);
+    rows.push(emptyRow(totalColumns, 28));
+    const summaryBlock = displaySummaryRows(
+      dateBand.length,
+      countBusinessDays(dateBand, holidaySet, nonWorkingDayTypes),
+      model.project.currentDate,
+      model.tasks.length,
+      model.resources.length,
+      model.assignments.length,
+      model.calendars.length,
+      totalColumns,
+      0,
+      rows.length + 1,
+      options.displayDaysBeforeBaseDate,
+      options.displayDaysAfterBaseDate,
+      options.useBusinessDaysForDisplayRange,
+      options.useBusinessDaysForProgressBand
+    );
+    rows.push(...summaryBlock.rows);
+    mergedRanges.push(...summaryBlock.mergedRanges);
 
     return {
       sheets: [
         {
           name: "WBS",
           columns: [
-            { width: 8 }, { width: 8 }, { width: 12 }, { width: 10 }, { width: 10 }, { width: 42 },
-            { width: 20 }, { width: 18 }, { width: 12 }, { width: 28 }, { width: 14 },
+            { width: pxWidth(45) }, { width: pxWidth(45) }, { width: pxWidth(65) }, { width: pxWidth(60) }, { width: pxWidth(45) }, { width: 42 },
+            { width: pxWidth(85) }, { width: pxWidth(85) }, { width: pxWidth(65) }, { width: 28 }, { width: 14 },
             { width: 18, hidden: true }, { width: 12, hidden: true }, { width: 12, hidden: true }, { width: 12, hidden: true },
-            { width: 16 }, { width: 12, hidden: true }, { width: 20, hidden: true }, { width: 18, hidden: true }, { width: 3 },
+            { width: pxWidth(85) }, { width: 12, hidden: true }, { width: 20, hidden: true }, { width: 18, hidden: true }, { width: 3 },
             ...dateBand.map(() => ({ width: 6 }))
           ],
           mergedRanges,
@@ -433,11 +438,9 @@
     startColumnIndex: number,
     startRowNumber: number
   ) {
-    const scheduleMode = project.scheduleFromStart ? "開始基準" : "終了基準";
     const items: Array<{ label: string; value: string | number; fillColor: string }> = [
       { label: "プロジェクト名", value: truncateWbsReference(project.name || "-", 18) || "-", fillColor: SUMMARY_ASSIGNMENT_FILL },
       { label: "カレンダ", value: formatCalendarLabel(project.calendarUID, calendarNameByUid), fillColor: SUMMARY_ASSIGNMENT_FILL },
-      { label: "基準", value: scheduleMode, fillColor: SUMMARY_ASSIGNMENT_FILL },
       { label: "開始日", value: formatWbsDate(project.startDate), fillColor: SUMMARY_SCHEDULE_FILL },
       { label: "終了日", value: formatWbsDate(project.finishDate), fillColor: SUMMARY_SCHEDULE_FILL },
       { label: "現在日", value: formatWbsDate(project.currentDate), fillColor: SUMMARY_SCHEDULE_FILL },
@@ -447,7 +450,7 @@
       mergedRanges: [
         WBS_LAYOUT.range(
           WBS_LAYOUT.reference(startRowNumber, startColumnIndex),
-          WBS_LAYOUT.reference(startRowNumber, startColumnIndex + 3)
+          WBS_LAYOUT.reference(startRowNumber, startColumnIndex + 4)
         ),
         ...items.map((_, index) => {
           const rowNumber = startRowNumber + index + 1;
@@ -458,13 +461,13 @@
             ),
             WBS_LAYOUT.range(
               WBS_LAYOUT.reference(rowNumber, startColumnIndex + 2),
-              WBS_LAYOUT.reference(rowNumber, startColumnIndex + 3)
+              WBS_LAYOUT.reference(rowNumber, startColumnIndex + 4)
             )
           ];
         }).flat()
       ],
       rows: [
-        projectBlockHeaderRow(columnCount, startColumnIndex, "プロジェクト"),
+        projectBlockHeaderRow(columnCount, startColumnIndex, "プロジェクト情報"),
         ...items.map((item) => projectPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor))
       ]
     };
@@ -586,18 +589,24 @@
     for (const item of scheduleItems) {
       blockRows.push(summaryPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor));
     }
-    for (let index = 0; index < countItems.length; index += 1) {
-      const rowIndex = 1 + index;
-      while (blockRows.length <= rowIndex) {
-        blockRows.push(emptyRow(columnCount, 22));
-      }
-      overlaySummaryPair(blockRows[rowIndex], startColumnIndex + 3, countItems[index].label, countItems[index].value, countItems[index].fillColor);
+    for (const item of countItems) {
+      blockRows.push(summaryPairRow(columnCount, startColumnIndex, item.label, item.value, item.fillColor));
+    }
+    const mergedRanges = [
+      WBS_LAYOUT.range(
+        WBS_LAYOUT.reference(startRowNumber, startColumnIndex),
+        WBS_LAYOUT.reference(startRowNumber, startColumnIndex + 2)
+      )
+    ];
+    for (let index = 1; index < blockRows.length; index += 1) {
+      const rowNumber = startRowNumber + index;
+      mergedRanges.push(WBS_LAYOUT.range(
+        WBS_LAYOUT.reference(rowNumber, startColumnIndex + 1),
+        WBS_LAYOUT.reference(rowNumber, startColumnIndex + 2)
+      ));
     }
     return {
-      mergedRanges: [WBS_LAYOUT.range(
-        WBS_LAYOUT.reference(startRowNumber, startColumnIndex),
-        WBS_LAYOUT.reference(startRowNumber, startColumnIndex + 1)
-      )],
+      mergedRanges,
       rows: blockRows
     };
   }
@@ -617,6 +626,11 @@
       border: "thin",
       fillColor: HEADER_ID_FILL
     };
+    cells[startColumnIndex + 2] = {
+      value: "",
+      border: "thin",
+      fillColor: HEADER_ID_FILL
+    };
     return { height: 24, cells };
   }
 
@@ -630,7 +644,7 @@
       fontSize: 14,
       fillColor: HEADER_ID_FILL
     };
-    for (let offset = 1; offset < 4; offset += 1) {
+    for (let offset = 1; offset < 5; offset += 1) {
       cells[startColumnIndex + offset] = {
         value: "",
         border: "thin",
@@ -672,6 +686,11 @@
       border: "thin",
       fillColor
     };
+    cells[startColumnIndex + 4] = {
+      value: "",
+      border: "thin",
+      fillColor
+    };
     return { height: 22, cells };
   }
 
@@ -685,6 +704,11 @@
     const cells = Array.from({ length: columnCount }, () => ({} as WbsXlsxCellLike));
     cells[startColumnIndex] = summaryStatCell(label, fillColor, false);
     cells[startColumnIndex + 1] = summaryStatCell(value, fillColor, true);
+    cells[startColumnIndex + 2] = {
+      value: "",
+      border: "thin",
+      fillColor
+    };
     return { height: 22, cells };
   }
 
@@ -715,6 +739,11 @@
       fillColor
     };
     cells[startColumnIndex + 1] = {
+      value: "",
+      border: "thin",
+      fillColor
+    };
+    cells[startColumnIndex + 2] = {
       value: "",
       border: "thin",
       fillColor
@@ -978,6 +1007,15 @@
     return value ? value.slice(0, 10) : "-";
   }
 
+  function formatWbsExportTimestamp(value: Date): string {
+    const year = value.getFullYear();
+    const month = String(value.getMonth() + 1).padStart(2, "0");
+    const day = String(value.getDate()).padStart(2, "0");
+    const hours = String(value.getHours()).padStart(2, "0");
+    const minutes = String(value.getMinutes()).padStart(2, "0");
+    return `出力日時 ${year}-${month}-${day} ${hours}:${minutes}`;
+  }
+
   function dateNumberCell(
     day: string,
     currentDate: string | undefined,
@@ -1010,13 +1048,16 @@
     const isHoliday = holidaySet.has(day);
     const weekStart = isWeekStart(day);
     const monthStart = isMonthStart(day);
+    const target = parseDateOnly(day);
+    const dayType = target ? (target.getDay() === 0 ? 1 : target.getDay() + 1) : 0;
+    const weekendHeaderFill = dayType === 7 ? SATURDAY_HEADER_FILL : (dayType === 1 ? SUNDAY_HEADER_FILL : WEEKEND_BAND_FILL);
     return {
       value: formatWeekdayValue(day),
       bold: true,
       border: "thin",
       horizontalAlign: "center",
       verticalAlign: "center",
-      fillColor: isToday ? TODAY_BAND_FILL : (isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? WEEKEND_BAND_FILL : (monthStart ? MONTH_START_HEADER_FILL : (weekStart ? WEEK_START_BAND_FILL : HEADER_FILL))))
+      fillColor: isHoliday ? HOLIDAY_BAND_FILL : (isWeekendDay ? weekendHeaderFill : (isToday ? TODAY_BAND_FILL : (monthStart ? MONTH_START_HEADER_FILL : (weekStart ? WEEK_START_BAND_FILL : HEADER_FILL))))
     };
   }
 

--- a/tests/mikuproject-wbs-xlsx.test.js
+++ b/tests/mikuproject-wbs-xlsx.test.js
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -92,18 +92,22 @@ describe("mikuproject wbs xlsx", () => {
   it("exports a dedicated WBS workbook from ProjectModel", () => {
     const { xml, wbsXlsx } = bootModules();
     const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-29T22:49:00+09:00"));
 
     const workbook = wbsXlsx.exportWbsWorkbook(model);
     const sheet = workbook.sheets[0];
 
     expect(workbook.sheets.map((item) => item.name)).toEqual(["WBS"]);
-    expect(sheet.columns[2].width).toBe(12);
-    expect(sheet.columns[3].width).toBe(10);
-    expect(sheet.columns[4].width).toBe(10);
+    expect(sheet.columns[0].width).toBeCloseTo(6.43, 2);
+    expect(sheet.columns[1].width).toBeCloseTo(6.43, 2);
+    expect(sheet.columns[2].width).toBeCloseTo(9.29, 2);
+    expect(sheet.columns[3].width).toBeCloseTo(8.57, 2);
+    expect(sheet.columns[4].width).toBeCloseTo(6.43, 2);
     expect(sheet.columns[5].width).toBe(42);
-    expect(sheet.columns[6].width).toBe(20);
-    expect(sheet.columns[7].width).toBe(18);
-    expect(sheet.columns[8].width).toBe(12);
+    expect(sheet.columns[6].width).toBeCloseTo(12.14, 2);
+    expect(sheet.columns[7].width).toBeCloseTo(12.14, 2);
+    expect(sheet.columns[8].width).toBeCloseTo(9.29, 2);
     expect(sheet.columns[9].width).toBe(28);
     expect(sheet.columns[11].width).toBe(18);
     expect(sheet.columns[11].hidden).toBe(true);
@@ -113,82 +117,65 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.columns[13].hidden).toBe(true);
     expect(sheet.columns[14].width).toBe(12);
     expect(sheet.columns[14].hidden).toBe(true);
-    expect(sheet.columns[15].width).toBe(16);
+    expect(sheet.columns[15].width).toBeCloseTo(12.14, 2);
     expect(sheet.columns[16].hidden).toBe(true);
     expect(sheet.columns[16].width).toBe(12);
     expect(sheet.columns[17].hidden).toBe(true);
     expect(sheet.columns[17].width).toBe(20);
     expect(sheet.columns[18].hidden).toBe(true);
     expect(sheet.columns[18].width).toBe(18);
-    expect(sheet.mergedRanges).toContain("A3:D3");
-    expect(sheet.mergedRanges).toContain("F3:G3");
-    expect(sheet.rows[0].cells[0].value).toBe("WBS");
-    expect(sheet.rows[0].cells[0].fontSize).toBe(16);
-    expect(sheet.rows[0].cells[0].fillColor).toBeUndefined();
-    expect(sheet.rows[0].cells[1].fillColor).toBe("#EEF4FA");
-    expect(sheet.rows[1].cells[0].value).toBeUndefined();
-    const projectInfoHeaderIndex = findRowIndexByCellValue(sheet, "プロジェクト", 0);
-    expect(projectInfoHeaderIndex).toBe(2);
+    expect(sheet.mergedRanges).toContain("A1:E1");
+    const projectInfoHeaderIndex = findRowIndexByCellValue(sheet, "プロジェクト情報", 0);
+    expect(projectInfoHeaderIndex).toBe(0);
     expect(sheet.rows[projectInfoHeaderIndex].cells[0].fontSize).toBe(14);
     expect(sheet.rows[projectInfoHeaderIndex + 1].cells[0].value).toBe("プロジェクト名");
     expect(sheet.rows[projectInfoHeaderIndex + 1].cells[2].value).toBe("mikuproject開発");
+    expect(sheet.rows[1].cells[9].value).toBe("出力日時 2026-03-29 22:49");
     expect(sheet.rows[projectInfoHeaderIndex + 2].cells[0].value).toBe("カレンダ");
     expect(sheet.rows[projectInfoHeaderIndex + 2].cells[2].value).toBe("1 Standard");
-    expect(sheet.rows[projectInfoHeaderIndex + 3].cells[0].value).toBe("基準");
-    expect(sheet.rows[projectInfoHeaderIndex + 3].cells[2].value).toBe("開始基準");
-    expect(sheet.rows[projectInfoHeaderIndex + 4].cells[0].value).toBe("開始日");
-    expect(sheet.rows[projectInfoHeaderIndex + 4].cells[2].value).toBe("2026-03-16");
-    expect(sheet.rows[projectInfoHeaderIndex + 5].cells[0].value).toBe("終了日");
-    expect(sheet.rows[projectInfoHeaderIndex + 5].cells[2].value).toBe("2026-04-01");
-    expect(sheet.rows[projectInfoHeaderIndex + 6].cells[0].value).toBe("現在日");
-    expect(sheet.rows[projectInfoHeaderIndex + 6].cells[2].value).toBe("2026-03-23");
-    expect(sheet.rows[projectInfoHeaderIndex + 7].cells[0].value).toBe("祝日");
-    expect(sheet.rows[projectInfoHeaderIndex + 7].cells[2].value).toBeGreaterThan(0);
-    const summaryHeaderIndex = findRowIndexByCellValue(sheet, "サマリ", 5);
-    expect(summaryHeaderIndex).toBe(2);
+    expect(sheet.rows[projectInfoHeaderIndex + 3].cells[0].value).toBe("開始日");
+    expect(sheet.rows[projectInfoHeaderIndex + 3].cells[2].value).toBe("2026-03-16");
+    expect(sheet.rows[projectInfoHeaderIndex + 4].cells[0].value).toBe("終了日");
+    expect(sheet.rows[projectInfoHeaderIndex + 4].cells[2].value).toBe("2026-04-01");
+    expect(sheet.rows[projectInfoHeaderIndex + 5].cells[0].value).toBe("現在日");
+    expect(sheet.rows[projectInfoHeaderIndex + 5].cells[2].value).toBe("2026-03-23");
+    expect(sheet.rows[projectInfoHeaderIndex + 6].cells[0].value).toBe("祝日");
+    expect(sheet.rows[projectInfoHeaderIndex + 6].cells[2].value).toBeGreaterThan(0);
+    const summaryHeaderIndex = findRowIndexByCellValue(sheet, "サマリ", 0);
     expect(sheet.rows[summaryHeaderIndex].height).toBe(24);
-    expect(sheet.rows[summaryHeaderIndex].cells[5].fontSize).toBe(14);
-    expect(sheet.rows[summaryHeaderIndex].cells[5].fillColor).toBe("#E1EDF8");
-    expect(sheet.rows[summaryHeaderIndex + 1].cells[5].value).toBe("表示日");
-    expect(sheet.rows[summaryHeaderIndex + 1].cells[6].value).toBe(17);
-    expect(sheet.rows[summaryHeaderIndex + 1].cells[5].horizontalAlign).toBe("right");
-    expect(sheet.rows[summaryHeaderIndex + 1].cells[6].horizontalAlign).toBe("center");
-    expect(sheet.rows[summaryHeaderIndex + 1].cells[6].bold).toBe(true);
+    expect(sheet.rows[summaryHeaderIndex].cells[0].fontSize).toBe(14);
+    expect(sheet.rows[summaryHeaderIndex].cells[0].fillColor).toBe("#E1EDF8");
+    expect(sheet.rows[summaryHeaderIndex + 1].cells[0].value).toBe("表示日");
+    expect(sheet.rows[summaryHeaderIndex + 1].cells[1].value).toBe(17);
+    expect(sheet.rows[summaryHeaderIndex + 1].cells[0].horizontalAlign).toBe("right");
+    expect(sheet.rows[summaryHeaderIndex + 1].cells[1].horizontalAlign).toBe("center");
+    expect(sheet.rows[summaryHeaderIndex + 1].cells[1].bold).toBe(true);
     expect(sheet.rows[projectInfoHeaderIndex + 1].cells[2].horizontalAlign).toBe("left");
-    expect(sheet.rows[projectInfoHeaderIndex + 4].cells[2].horizontalAlign).toBe("left");
-    expect(sheet.rows[summaryHeaderIndex + 3].cells[5].value).toBe("営業日");
-    expect(sheet.rows[summaryHeaderIndex + 3].cells[6].value).toBe(12);
-    expect(sheet.rows[summaryHeaderIndex + 4].cells[5].value).toBe("前日数");
-    expect(sheet.rows[summaryHeaderIndex + 4].cells[6].value).toBe("-");
-    expect(sheet.rows[summaryHeaderIndex + 5].cells[5].value).toBe("後日数");
-    expect(sheet.rows[summaryHeaderIndex + 5].cells[6].value).toBe("-");
-    expect(sheet.rows[summaryHeaderIndex + 6].cells[5].value).toBe("表示");
-    expect(sheet.rows[summaryHeaderIndex + 6].cells[6].value).toBe("暦日");
-    expect(sheet.rows[summaryHeaderIndex + 7].cells[5].value).toBe("進捗");
-    expect(sheet.rows[summaryHeaderIndex + 7].cells[6].value).toBe("暦日");
-    expect(sheet.rows[summaryHeaderIndex + 1].cells[8].value).toBe("タスク");
-    expect(sheet.rows[summaryHeaderIndex + 1].cells[9].value).toBe(13);
-    expect(sheet.rows[summaryHeaderIndex + 2].cells[8].value).toBe("リソース");
-    expect(sheet.rows[summaryHeaderIndex + 2].cells[9].value).toBe(0);
-    expect(sheet.rows[summaryHeaderIndex + 3].cells[8].value).toBe("割当");
-    expect(sheet.rows[summaryHeaderIndex + 3].cells[9].value).toBe(0);
-    expect(sheet.rows[summaryHeaderIndex + 4].cells[8].value).toBe("カレンダ");
-    expect(sheet.rows[summaryHeaderIndex + 4].cells[9].value).toBe(1);
-    expect(sheet.rows[summaryHeaderIndex + 8].cells[5].value).toBe("基準日");
-    expect(sheet.rows[summaryHeaderIndex + 8].cells[6].value).toBe("2026-03-23");
-    const weekRowIndex = findRowIndexByCellValue(sheet, "週", 18);
+    expect(sheet.rows[projectInfoHeaderIndex + 3].cells[2].horizontalAlign).toBe("left");
+    expect(sheet.rows[summaryHeaderIndex + 3].cells[0].value).toBe("営業日");
+    expect(sheet.rows[summaryHeaderIndex + 3].cells[1].value).toBe(12);
+    expect(sheet.rows[summaryHeaderIndex + 4].cells[0].value).toBe("前日数");
+    expect(sheet.rows[summaryHeaderIndex + 4].cells[1].value).toBe("-");
+    expect(sheet.rows[summaryHeaderIndex + 5].cells[0].value).toBe("後日数");
+    expect(sheet.rows[summaryHeaderIndex + 5].cells[1].value).toBe("-");
+    expect(sheet.rows[summaryHeaderIndex + 6].cells[0].value).toBe("表示");
+    expect(sheet.rows[summaryHeaderIndex + 6].cells[1].value).toBe("暦日");
+    expect(sheet.rows[summaryHeaderIndex + 7].cells[0].value).toBe("進捗");
+    expect(sheet.rows[summaryHeaderIndex + 7].cells[1].value).toBe("暦日");
+    expect(sheet.rows[summaryHeaderIndex + 8].cells[0].value).toBe("基準日");
+    expect(sheet.rows[summaryHeaderIndex + 8].cells[1].value).toBe("2026-03-23");
+    expect(sheet.rows[summaryHeaderIndex + 9].cells[0].value).toBe("タスク");
+    expect(sheet.rows[summaryHeaderIndex + 9].cells[1].value).toBe(13);
+    expect(sheet.rows[summaryHeaderIndex + 10].cells[0].value).toBe("リソース");
+    expect(sheet.rows[summaryHeaderIndex + 10].cells[1].value).toBe(0);
+    expect(sheet.rows[summaryHeaderIndex + 11].cells[0].value).toBe("割当");
+    expect(sheet.rows[summaryHeaderIndex + 11].cells[1].value).toBe(0);
+    expect(sheet.rows[summaryHeaderIndex + 12].cells[0].value).toBe("カレンダ");
+    expect(sheet.rows[summaryHeaderIndex + 12].cells[1].value).toBe(1);
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
     const dateRowIndex = headerRowIndex - 1;
-    expect(weekRowIndex).toBe(11);
-    expect(headerRowIndex).toBe(13);
-    expect(dateRowIndex).toBe(12);
-    expect(sheet.rows[weekRowIndex].height).toBe(24);
-    expect(sheet.rows[weekRowIndex].cells[5].value).toBeUndefined();
-    expect(sheet.rows[weekRowIndex].cells[18].fontSize).toBe(14);
-    expect(sheet.rows[weekRowIndex].cells[18].fillColor).toBe("#E3EEF9");
-    expect(sheet.rows[weekRowIndex].cells[19].fillColor).toBe("#D9E2EA");
-    expect(sheet.rows[weekRowIndex].cells[20].value).toBe("週 03/15");
-    expect(sheet.rows[weekRowIndex].cells[20].fontSize).toBe(14);
+    expect(headerRowIndex).toBe(8);
+    expect(dateRowIndex).toBe(7);
     expect(sheet.rows[headerRowIndex].cells.slice(0, 19).map((cell) => cell.value)).toEqual([
       "UID",
       "ID",
@@ -340,12 +327,16 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.rows[legendHeaderIndex + 12].cells[0].value).toBe("Sum:サマリ");
     expect(sheet.rows[legendHeaderIndex + 13].cells[0].value).toBe("Crit:クリティカル");
     expect(sheet.rows[legendHeaderIndex + 14].cells[0].value).toBe("-:未設定");
+    expect(summaryHeaderIndex).toBe(legendHeaderIndex + 16);
+    vi.useRealTimers();
   });
 
   it("can generate a real xlsx from the dedicated WBS workbook", () => {
     const { excelIo, xml, wbsXlsx } = bootModules();
     const codec = new excelIo.XlsxWorkbookCodec();
     const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-29T22:49:00+09:00"));
 
     const workbook = wbsXlsx.exportWbsWorkbook(model);
     const bytes = codec.exportWorkbook(workbook);
@@ -356,11 +347,9 @@ describe("mikuproject wbs xlsx", () => {
 
     expect(entries).toContain("xl/workbook.xml");
     expect(entries).toContain("xl/worksheets/sheet1.xml");
-    expect(sheetXml).toContain('ref="A3:D3"');
-    expect(sheetXml).toContain('ref="F3:G3"');
+    expect(sheetXml).toContain('ref="A1:E1"');
     expect(sheetXml).toContain('s="1"');
-    expect(stylesXml).toContain('<sz val="16"/>');
-    expect(sheetXml).toContain('ref="U12:Z12"');
+    expect(stylesXml).toContain('<sz val="14"/>');
     expect(sheetXml).toContain('min="12" max="12" width="18" customWidth="1" hidden="1"');
     expect(sheetXml).toContain('min="13" max="13" width="12" customWidth="1" hidden="1"');
     expect(sheetXml).toContain('min="14" max="14" width="12" customWidth="1" hidden="1"');
@@ -370,12 +359,12 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheetXml).toContain('min="19" max="19" width="18" customWidth="1" hidden="1"');
     expect(sheetXml).not.toContain("<pane");
     expect(sheetXml).toContain("凡例");
-    expect(sheetXml).toContain("プロジェクト");
-    expect(sheetXml).toContain("週 03/15");
+    expect(sheetXml).toContain("プロジェクト情報");
+    expect(sheetXml).toContain("出力日時 2026-03-29 22:49");
     expect(sheetXml).toContain("1 Standard");
     expect(sheetXml).toContain("階層");
     expect(sheetXml).toContain("3/16");
-    expect(sheetXml).toContain("Mon");
+    vi.useRealTimers();
   });
 
   it("marks weekend date-band cells with weekend fill", () => {
@@ -405,6 +394,8 @@ describe("mikuproject wbs xlsx", () => {
     ]);
     expect(sheet.rows[dateRowIndex].cells[21].fillColor).toBe("#FFE6A7");
     expect(sheet.rows[dateRowIndex].cells[22].fillColor).toBe("#C9D3E1");
+    expect(sheet.rows[headerRowIndex].cells[21].fillColor).toBe("#8EA9DB");
+    expect(sheet.rows[headerRowIndex].cells[22].fillColor).toBe("#E6B8AF");
   });
 
   it("uses project calendar weekdays instead of hardcoded weekends for non-working fill", () => {
@@ -444,6 +435,8 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.rows[dateRowIndex].cells[20].fillColor).toBe("#FFE6A7");
     expect(sheet.rows[dateRowIndex].cells[21].fillColor).toBe("#D9EAF7");
     expect(sheet.rows[dateRowIndex].cells[22].fillColor).toBe("#C9D3E1");
+    expect(sheet.rows[headerRowIndex].cells[21].fillColor).toBe("#D9EAF7");
+    expect(sheet.rows[headerRowIndex].cells[22].fillColor).toBe("#E6B8AF");
   });
 
   it("suppresses task bands on weekly non-working days and configured holidays", () => {
@@ -515,7 +508,7 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.rows[headerRowIndex + 1].cells[27].fillColor).toBe("#F4F7FB");
   });
 
-  it("emphasizes week labels that contain a month boundary", () => {
+  it("does not emit a dedicated week-label row even when a month boundary exists", () => {
     const { xml, wbsXlsx } = bootModules();
     const model = xml.importMsProjectXml(xml.SAMPLE_XML);
 
@@ -526,10 +519,7 @@ describe("mikuproject wbs xlsx", () => {
     const workbook = wbsXlsx.exportWbsWorkbook(model);
     const sheet = workbook.sheets[0];
 
-    const weekRowIndex = findRowIndexByCellValue(sheet, "週", 18);
-    expect(sheet.mergedRanges).toContain("U12:Y12");
-    expect(sheet.rows[weekRowIndex].cells[20].value).toBe("週 03/29 / 04");
-    expect(sheet.rows[weekRowIndex].cells[20].fillColor).toBe("#D6E7F8");
+    expect(findRowIndexByCellValue(sheet, "週", 18)).toBe(-1);
   });
 
   it("emphasizes month-start date headers", () => {
@@ -589,8 +579,8 @@ describe("mikuproject wbs xlsx", () => {
     });
     const sheet = workbook.sheets[0];
 
-    const projectInfoHeaderIndex = findRowIndexByCellValue(sheet, "プロジェクト", 0);
-    expect(sheet.rows[projectInfoHeaderIndex + 7].cells[2].value).toBeGreaterThan(0);
+    const projectInfoHeaderIndex = findRowIndexByCellValue(sheet, "プロジェクト情報", 0);
+    expect(sheet.rows[projectInfoHeaderIndex + 6].cells[2].value).toBeGreaterThan(0);
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
     expect(sheet.rows[headerRowIndex - 1].cells[24].value).toBe("3/20");
     expect(sheet.rows[headerRowIndex].cells[24].value).toBe("Fri");
@@ -608,7 +598,7 @@ describe("mikuproject wbs xlsx", () => {
       displayDaysAfterBaseDate: 2
     });
     const sheet = workbook.sheets[0];
-    const summaryHeaderIndex = findRowIndexByCellValue(sheet, "サマリ", 5);
+    const summaryHeaderIndex = findRowIndexByCellValue(sheet, "サマリ", 0);
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
     const dateRowIndex = headerRowIndex - 1;
 
@@ -618,10 +608,10 @@ describe("mikuproject wbs xlsx", () => {
       "3/24",
       "3/25"
     ]);
-    expect(sheet.rows[summaryHeaderIndex + 4].cells[6].value).toBe(1);
-    expect(sheet.rows[summaryHeaderIndex + 5].cells[6].value).toBe(2);
-    expect(sheet.rows[summaryHeaderIndex + 6].cells[6].value).toBe("暦日");
-    expect(sheet.rows[summaryHeaderIndex + 7].cells[6].value).toBe("暦日");
+    expect(sheet.rows[summaryHeaderIndex + 4].cells[1].value).toBe(1);
+    expect(sheet.rows[summaryHeaderIndex + 5].cells[1].value).toBe(2);
+    expect(sheet.rows[summaryHeaderIndex + 6].cells[1].value).toBe("暦日");
+    expect(sheet.rows[summaryHeaderIndex + 7].cells[1].value).toBe("暦日");
   });
 
   it("can limit the displayed date band around base date using business days", () => {
@@ -639,7 +629,7 @@ describe("mikuproject wbs xlsx", () => {
       useBusinessDaysForDisplayRange: true
     });
     const sheet = workbook.sheets[0];
-    const summaryHeaderIndex = findRowIndexByCellValue(sheet, "サマリ", 5);
+    const summaryHeaderIndex = findRowIndexByCellValue(sheet, "サマリ", 0);
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
     const dateRowIndex = headerRowIndex - 1;
 
@@ -652,9 +642,9 @@ describe("mikuproject wbs xlsx", () => {
       "3/22",
       "3/23"
     ]);
-    expect(sheet.rows[summaryHeaderIndex + 3].cells[6].value).toBe(4);
-    expect(sheet.rows[summaryHeaderIndex + 6].cells[6].value).toBe("営業日");
-    expect(sheet.rows[summaryHeaderIndex + 7].cells[6].value).toBe("暦日");
+    expect(sheet.rows[summaryHeaderIndex + 3].cells[1].value).toBe(4);
+    expect(sheet.rows[summaryHeaderIndex + 6].cells[1].value).toBe("営業日");
+    expect(sheet.rows[summaryHeaderIndex + 7].cells[1].value).toBe("暦日");
   });
 
   it("can calculate progress band using business days", () => {
@@ -671,11 +661,11 @@ describe("mikuproject wbs xlsx", () => {
       useBusinessDaysForProgressBand: true
     });
     const sheet = workbook.sheets[0];
-    const summaryHeaderIndex = findRowIndexByCellValue(sheet, "サマリ", 5);
+    const summaryHeaderIndex = findRowIndexByCellValue(sheet, "サマリ", 0);
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
     const designRow = sheet.rows[headerRowIndex + 3];
 
-    expect(sheet.rows[summaryHeaderIndex + 7].cells[6].value).toBe("営業日");
+    expect(sheet.rows[summaryHeaderIndex + 7].cells[1].value).toBe("営業日");
     expect(designRow.cells[8].value).toBe("4営業日");
     expect(designRow.cells[20].fillColor).toBe("#5BAE9C");
     expect(designRow.cells[21].fillColor).toBe("#5BAE9C");
@@ -716,7 +706,7 @@ describe("mikuproject wbs xlsx", () => {
 
     const workbook = wbsXlsx.exportWbsWorkbook(model);
     const sheet = workbook.sheets[0];
-    const projectInfoHeaderIndex = findRowIndexByCellValue(sheet, "プロジェクト", 0);
+    const projectInfoHeaderIndex = findRowIndexByCellValue(sheet, "プロジェクト情報", 0);
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
     const secondTaskRow = sheet.rows[headerRowIndex + 3];
     const thirdTaskRow = sheet.rows[headerRowIndex + 4];


### PR DESCRIPTION
## 概要

この変更では、`WBS XLSX` のレイアウトと見た目を集中的に調整しつつ、`XLSX Import` の実運用寄りの不具合にも対応しています。 この会話で確認できた範囲では、特に `Notes` の取込確認、Excel 保存後 `.xlsx` の再取込、`WBS XLSX` の project 情報ブロック・サマリ・曜日帯の見直しが含まれます。

## 変更内容

- `XLSX Import` の改善
  - Excel が保存した `deflate` 圧縮 `.xlsx` を読めるように修正
  - `sharedStrings` を読むようにして、`Notes` など文字列セルの取込を改善
  - 同じファイル名で保存し直した `.xlsx` の再選択対策を追加
  - 読込中ステータスと失敗時の `console.error` を追加
- `Project XLSX` の見た目改善
  - 空の editable セルでも罫線と editable 色が分かるように調整
  - `Resources` / `Assignments` が 0 件でも、反映対象列が分かるようにダミー行を追加
- `WBS XLSX` のレイアウト調整
  - project 情報ブロックの見出しを `プロジェクト情報` に変更
  - `project.title` ではなく `project.name` を表示するように変更
  - `基準 / 開始基準` 行を削除
  - `サマリ` ブロックを `凡例` の下へ移動
  - `タスク / リソース / 割当 / カレンダ` を `基準日` の下に縦並びで配置
  - `サマリ` ヘッダを `A:C` 結合、各データ行を `A` ラベル + `B:C` 値結合に変更
  - `プロジェクト情報` ブロックを `A:E`、各データ行を `A:B` ラベル + `C:E` 値結合に変更
  - 冒頭の不要行を削除し、先頭から `プロジェクト情報` ブロックを開始
  - `J2` に出力日時を追加
  - 曜日行の `Sat` を濃い青、`Sun` を濃い赤に変更
  - 指定列のセル幅を調整
- ドキュメント更新
  - `docs/spec.md` に `Tasks` シートの `import 可 / 表示のみ` の整理を追記
  - `docs/TODO.md` に `.editjson` import の今後対応予定と `XLSX Import` の実地回帰観点を追記