### PR TITLE
AI JSON Prompt / Spec の再構成とプロンプト文面の整理

### DIFF
--- a/docs/mikuproject-ai-json-spec.md
+++ b/docs/mikuproject-ai-json-spec.md
@@ -1,12 +1,21 @@
-# mikuproject AI JSON Spec
+# mikuproject AI JSON Prompt / Spec
 
-あなたはこれから `mikuproject` とやりとりしながら、プロジェクトの内容を理解し、必要に応じて変更提案を返していこうとしています。
+私たちは、これから取り組むプロジェクトの内容を理解し、WBS の観点から必要なマイルストーン / フェーズ / タスクを整理し、`mikuproject` に設定するための入力へ落とし込んでいきます。
 
-`mikuproject` は `MS Project XML` を取り扱うツールです。
+`mikuproject` は、`MS Project XML` を基軸に、変換・可視化・限定編集を行う single-file web app です。
 
-`mikuproject` と生成AIの間のやり取りは、XML ではなく JSON ベースで行います。
+特に、次の 3 つを重視して設計しています。
 
-現時点の実装状況:
+- `MS Project XML` を基軸にした変換・可視化・限定編集
+- 生成AI 連携を意識した projection / 再取込
+- 人が読むための `WBS Excel ブック (.xlsx)` 帳票出力
+
+`mikuproject` と私たち（生成AIを含む）の間のやり取りは、XML ではなく JSON ベースで行います。
+
+このプロンプトを読んだ直後は、内容を受け取ったことを示すために `OK` とだけ回答してください。
+
+## 現時点の実装状況
+
 - 実装済み: `project_overview_view` の export
 - 実装済み: `phase_detail_view` の export
 - 実装済み: `project_draft_view` の import
@@ -14,14 +23,16 @@
 - 未実装: Patch JSON の import / 適用
 - `project_draft_request` は補助的な構想・helper であり、現行 UI の主機能ではありません
 
-前提:
+## 前提
+
 - AI へ渡される入力は用途別 projection JSON です
 - AI は説明文を返してよいです
 - 既存編集向けの Patch JSON は将来案として設計中です
 - `MS Project XML` は保存と互換のための外部形式ですが、AI は直接扱いません
 - workbook JSON と AI 向け編集用 JSON を混同しないため、当面 `project_draft_view` などの編集用 JSON には `.editjson` 拡張子を推奨します
 
-重要方針:
+## 重要方針
+
 - 全体 JSON の再出力は禁止です
 - 不明な値を推測して補完してはいけません
 - 未指定項目は変更しない前提です
@@ -29,18 +40,22 @@
 - 業務意味が不明な場合、断定的な再設計は避けてください
 - 業務意味が不明な変更は候補案として扱ってください
 
-projection JSON の代表例:
+## Projection JSON の代表例
+
 - `project_overview_view`: プロジェクト全体の構造、粒度、主要節目を把握するための要約ビュー
 - `phase_detail_view`: 特定フェーズの task 群、主要 milestone、依存の要点を把握するための詳細ビュー
 - `task_edit_view`: 個別 task を安全に編集するための作業ビュー。現時点では未実装です
 - `project_draft_request`: 全く新規の project 草案を AI に生成させるための入力。現時点では設計メモ寄りです
 - `project_draft_view`: 新規 project 草案の全量出力。現時点では import 済みです
 
-ファイル拡張子の運用:
+## ファイル拡張子の運用
+
 - `mikuproject_workbook_json` は `.json` を推奨します
 - `project_draft_view` は `.editjson` を推奨します
 - `.editjson` は、将来 `task_edit_view` や Patch JSON などの AI 向け編集用 JSON 群にも拡張できる広めの拡張子として扱います
 - 拡張子は判別補助であり、必要に応じて中身の `view_type` / `format` でも判定します
+
+## 補足
 
 `phase_detail_view` は、安全な変更候補の抽出や、次に必要な `task_edit_view` の特定にも使えます。
 `phase_detail_view` には、phase 全体をそのまま渡す `full` モードと、対象を絞る `scoped` モードの両方がありえます。
@@ -117,7 +132,8 @@ projection JSON の代表例:
 }
 ```
 
-`phase_detail_view` の範囲指定:
+### `phase_detail_view` の範囲指定
+
 - `mode = "full"` の場合は、phase 全体を対象にします
 - `mode = "scoped"` の場合は、`root_uid` と `max_depth` で対象範囲を絞れます
 - `root_uid` を指定すると、その task を起点にした subtree を対象にできます
@@ -214,17 +230,20 @@ projection JSON の代表例:
 }
 ```
 
-phase の定義:
+### phase の定義
+
 - 当面、phase は top-level summary task を指します
 - ルート直下の summary task を phase とみなします
 - ここでいう summary task は `is_summary = true` 相当の task です
 - `UID=0` の project summary task は phase に含めません
 
-UID:
+### UID
+
 - `uid` は常に string です
 - `parent_uid`, `from_uid`, `to_uid`, `task_uid` も常に string です
 
-日付・期間:
+### 日付・期間
+
 - 当面、WBS 理解用 projection は計画ベースです
 - 曖昧な `start` / `finish` は使わず、意味名を分けます
 - 例:
@@ -240,7 +259,8 @@ UID:
   - `planned_duration_hours: 40`
 - 両方がある場合、理解や比較には `*_hours` を補助的に使ってよいです
 
-依存関係:
+### 依存関係
+
 - dependency は単なる前後順ではなく意味的な関係です
 - 少なくとも次を見ます
   - 相手 task の `uid`
@@ -256,7 +276,8 @@ UID:
 - `predecessors` だけでなく `successors` も見てください
 - `lag` は負値を取りうることがあります
 
-rules:
+### rules
+
 - 各 projection には `rules` が含まれることがあります
 - `rules` は参考情報ではなく、AI が返してよい Patch の契約です
 - `allow_patch_ops` にない操作は返してはいけません
@@ -281,13 +302,15 @@ rules:
 }
 ```
 
-Patch JSON の原則:
+### Patch JSON の原則
+
 - Patch JSON は `operations` 配列を持つオブジェクトです
 - task の field 更新は `update_task` を使います
 - 親子や順序の変更は `move_task` を使います
 - 依存関係の追加や解除は `link_tasks` / `unlink_tasks` を使います
 
-新規生成モードの原則:
+### 新規生成モードの原則
+
 - `project_draft_request` に対する返答は `project_draft_view` です
 - このとき `Patch JSON` は返しません
 - draft は正本ではなく草案です
@@ -299,7 +322,8 @@ Patch JSON の原則:
 - `planned_finish` だけが与えられた通常 task は、まず同日の `planned_start` を補完したうえで、上記の勤務時間帯補完を適用することがあります
 - `is_milestone: true` の task には、この勤務時間帯補完を適用しません
 
-Patch の例:
+### Patch の例
+
 ```json
 {
   "operations": [
@@ -314,7 +338,8 @@ Patch の例:
 }
 ```
 
-順序変更の例:
+### 順序変更の例
+
 ```json
 {
   "operations": [
@@ -328,7 +353,8 @@ Patch の例:
 }
 ```
 
-依存追加の例:
+### 依存追加の例
+
 ```json
 {
   "operations": [
@@ -344,14 +370,16 @@ Patch の例:
 }
 ```
 
-変更不要の例:
+### 変更不要の例
+
 ```json
 {
   "operations": []
 }
 ```
 
-出力ルール:
+## 出力ルール
+
 - 対話インタフェースでは、説明文を返してよいです
 - 変更理由や不確実性を簡潔に説明してよいです
 - ただし、最終的な機械処理対象 JSON は必ず最後に 1 個の `json` コードフェンスで囲って返してください
@@ -362,7 +390,8 @@ Patch の例:
 - 変更不要なら最後の `json` コードフェンスで空の `operations` を返してください
 - 与えられていない task や field を勝手に推測しないでください
 
-改善候補:
+## 改善候補
+
 - 将来的には `suggest_only` のような提案専用モードを追加する余地があります
 - 現時点の spec は task / phase / dependency を優先しており、resource や工数配分の扱いは今後の検討対象です
 - phase 定義は当面 `top-level summary task` 固定ですが、将来的にはより柔軟な定義へ拡張する余地があります

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -2260,15 +2260,24 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
                 <button id="importProjectDraftBtn" type="button" class="md-button md-button--tonal">貼り付けた JSON を取り込む</button>
                 <button id="loadProjectDraftSampleBtn" type="button" class="md-button md-button--surface">サンプル</button>
               </div>
-              <template id="aiPromptTemplate"># mikuproject AI JSON Spec
+              <template id="aiPromptTemplate"># mikuproject AI JSON Prompt / Spec
 
-あなたはこれから `mikuproject` とやりとりしながら、プロジェクトの内容を理解し、必要に応じて変更提案を返していこうとしています。
+私たちは、これから取り組むプロジェクトの内容を理解し、WBS の観点から必要なマイルストーン / フェーズ / タスクを整理し、`mikuproject` に設定するための入力へ落とし込んでいきます。
 
-`mikuproject` は `MS Project XML` を取り扱うツールです。
+`mikuproject` は、`MS Project XML` を基軸に、変換・可視化・限定編集を行う single-file web app です。
 
-`mikuproject` と生成AIの間のやり取りは、XML ではなく JSON ベースで行います。
+特に、次の 3 つを重視して設計しています。
 
-現時点の実装状況:
+- `MS Project XML` を基軸にした変換・可視化・限定編集
+- 生成AI 連携を意識した projection / 再取込
+- 人が読むための `WBS Excel ブック (.xlsx)` 帳票出力
+
+`mikuproject` と私たち（生成AIを含む）の間のやり取りは、XML ではなく JSON ベースで行います。
+
+このプロンプトを読んだ直後は、内容を受け取ったことを示すために `OK` とだけ回答してください。
+
+## 現時点の実装状況
+
 - 実装済み: `project_overview_view` の export
 - 実装済み: `phase_detail_view` の export
 - 実装済み: `project_draft_view` の import
@@ -2276,14 +2285,16 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 - 未実装: Patch JSON の import / 適用
 - `project_draft_request` は補助的な構想・helper であり、現行 UI の主機能ではありません
 
-前提:
+## 前提
+
 - AI へ渡される入力は用途別 projection JSON です
 - AI は説明文を返してよいです
 - 既存編集向けの Patch JSON は将来案として設計中です
 - `MS Project XML` は保存と互換のための外部形式ですが、AI は直接扱いません
 - workbook JSON と AI 向け編集用 JSON を混同しないため、当面 `project_draft_view` などの編集用 JSON には `.editjson` 拡張子を推奨します
 
-重要方針:
+## 重要方針
+
 - 全体 JSON の再出力は禁止です
 - 不明な値を推測して補完してはいけません
 - 未指定項目は変更しない前提です
@@ -2291,18 +2302,22 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 - 業務意味が不明な場合、断定的な再設計は避けてください
 - 業務意味が不明な変更は候補案として扱ってください
 
-projection JSON の代表例:
+## Projection JSON の代表例
+
 - `project_overview_view`: プロジェクト全体の構造、粒度、主要節目を把握するための要約ビュー
 - `phase_detail_view`: 特定フェーズの task 群、主要 milestone、依存の要点を把握するための詳細ビュー
 - `task_edit_view`: 個別 task を安全に編集するための作業ビュー。現時点では未実装です
 - `project_draft_request`: 全く新規の project 草案を AI に生成させるための入力。現時点では設計メモ寄りです
 - `project_draft_view`: 新規 project 草案の全量出力。現時点では import 済みです
 
-ファイル拡張子の運用:
+## ファイル拡張子の運用
+
 - `mikuproject_workbook_json` は `.json` を推奨します
 - `project_draft_view` は `.editjson` を推奨します
 - `.editjson` は、将来 `task_edit_view` や Patch JSON などの AI 向け編集用 JSON 群にも拡張できる広めの拡張子として扱います
 - 拡張子は判別補助であり、必要に応じて中身の `view_type` / `format` でも判定します
+
+## 補足
 
 `phase_detail_view` は、安全な変更候補の抽出や、次に必要な `task_edit_view` の特定にも使えます。
 `phase_detail_view` には、phase 全体をそのまま渡す `full` モードと、対象を絞る `scoped` モードの両方がありえます。
@@ -2379,7 +2394,8 @@ projection JSON の代表例:
 }
 ```
 
-`phase_detail_view` の範囲指定:
+### `phase_detail_view` の範囲指定
+
 - `mode = "full"` の場合は、phase 全体を対象にします
 - `mode = "scoped"` の場合は、`root_uid` と `max_depth` で対象範囲を絞れます
 - `root_uid` を指定すると、その task を起点にした subtree を対象にできます
@@ -2476,17 +2492,20 @@ projection JSON の代表例:
 }
 ```
 
-phase の定義:
+### phase の定義
+
 - 当面、phase は top-level summary task を指します
 - ルート直下の summary task を phase とみなします
 - ここでいう summary task は `is_summary = true` 相当の task です
 - `UID=0` の project summary task は phase に含めません
 
-UID:
+### UID
+
 - `uid` は常に string です
 - `parent_uid`, `from_uid`, `to_uid`, `task_uid` も常に string です
 
-日付・期間:
+### 日付・期間
+
 - 当面、WBS 理解用 projection は計画ベースです
 - 曖昧な `start` / `finish` は使わず、意味名を分けます
 - 例:
@@ -2502,7 +2521,8 @@ UID:
   - `planned_duration_hours: 40`
 - 両方がある場合、理解や比較には `*_hours` を補助的に使ってよいです
 
-依存関係:
+### 依存関係
+
 - dependency は単なる前後順ではなく意味的な関係です
 - 少なくとも次を見ます
   - 相手 task の `uid`
@@ -2518,7 +2538,8 @@ UID:
 - `predecessors` だけでなく `successors` も見てください
 - `lag` は負値を取りうることがあります
 
-rules:
+### rules
+
 - 各 projection には `rules` が含まれることがあります
 - `rules` は参考情報ではなく、AI が返してよい Patch の契約です
 - `allow_patch_ops` にない操作は返してはいけません
@@ -2543,13 +2564,15 @@ rules:
 }
 ```
 
-Patch JSON の原則:
+### Patch JSON の原則
+
 - Patch JSON は `operations` 配列を持つオブジェクトです
 - task の field 更新は `update_task` を使います
 - 親子や順序の変更は `move_task` を使います
 - 依存関係の追加や解除は `link_tasks` / `unlink_tasks` を使います
 
-新規生成モードの原則:
+### 新規生成モードの原則
+
 - `project_draft_request` に対する返答は `project_draft_view` です
 - このとき `Patch JSON` は返しません
 - draft は正本ではなく草案です
@@ -2561,7 +2584,8 @@ Patch JSON の原則:
 - `planned_finish` だけが与えられた通常 task は、まず同日の `planned_start` を補完したうえで、上記の勤務時間帯補完を適用することがあります
 - `is_milestone: true` の task には、この勤務時間帯補完を適用しません
 
-Patch の例:
+### Patch の例
+
 ```json
 {
   "operations": [
@@ -2576,7 +2600,8 @@ Patch の例:
 }
 ```
 
-順序変更の例:
+### 順序変更の例
+
 ```json
 {
   "operations": [
@@ -2590,7 +2615,8 @@ Patch の例:
 }
 ```
 
-依存追加の例:
+### 依存追加の例
+
 ```json
 {
   "operations": [
@@ -2606,14 +2632,16 @@ Patch の例:
 }
 ```
 
-変更不要の例:
+### 変更不要の例
+
 ```json
 {
   "operations": []
 }
 ```
 
-出力ルール:
+## 出力ルール
+
 - 対話インタフェースでは、説明文を返してよいです
 - 変更理由や不確実性を簡潔に説明してよいです
 - ただし、最終的な機械処理対象 JSON は必ず最後に 1 個の `json` コードフェンスで囲って返してください
@@ -2624,7 +2652,8 @@ Patch の例:
 - 変更不要なら最後の `json` コードフェンスで空の `operations` を返してください
 - 与えられていない task や field を勝手に推測しないでください
 
-改善候補:
+## 改善候補
+
 - 将来的には `suggest_only` のような提案専用モードを追加する余地があります
 - 現時点の spec は task / phase / dependency を優先しており、resource や工数配分の扱いは今後の検討対象です
 - phase 定義は当面 `top-level summary task` 固定ですが、将来的にはより柔軟な定義へ拡張する余地があります


### PR DESCRIPTION
## 概要

`docs/mikuproject-ai-json-spec.md` を、仕様書であると同時に生成AI向けプロンプトとしても読みやすい形に整理しました。 この会話で確認できた範囲では、導入文の見直し、README と整合する説明の追加、見出し構造の整理、出力ルールの明確化が含まれます。

## 変更内容

- 文書タイトルを更新
  - `mikuproject AI JSON Spec / Prompt` ではなく `mikuproject AI JSON Prompt / Spec` に整理
- 導入文を見直し
  - `mikuproject` とやりとりしながら変更提案を返す文脈から
  - 取り組むプロジェクトを理解し、WBS の観点で必要な `マイルストーン / フェーズ / タスク` を整理し、`mikuproject` に設定するための入力へ落とし込む文脈へ変更
- README と整合する説明を追加
  - `mikuproject` は `MS Project XML` を基軸に、変換・可視化・限定編集を行う single-file web app であることを明記
  - 次の 3 本柱を追記
    - `MS Project XML` を基軸にした変換・可視化・限定編集
    - 生成AI 連携を意識した projection / 再取込
    - 人が読むための `WBS Excel ブック (.xlsx)` 帳票出力
- プロンプト受領時の返答ルールを追加
  - このプロンプトを読んだ直後は `OK` とだけ回答する旨を追記
- 文書構造を見出しベースへ整理
  - `現時点の実装状況`
  - `前提`
  - `重要方針`
  - `Projection JSON の代表例`
  - `ファイル拡張子の運用`
  - `補足`
  - `出力ルール`
  - `改善候補` を `##` 見出しへ整理
  - `phase_detail_view` の範囲指定、`phase の定義`、`UID`、`日付・期間`、`依存関係`、`rules`、各種例などを `###` 見出しへ整理
- 用語を整理
  - `mikuproject` と生成AIだけでなく、`mikuproject` と私たち（生成AIを含む）のやり取りとして表現を拡張
- 補足段落を整理
  - `phase_detail_view` の使い方や新規生成モード説明を `## 補足` 配下へ移動

## 主な更新ファイル

- `docs/mikuproject-ai-json-spec.md`