### PR TITLE
XLSX 出力の文字列セル固定化と XML サニタイズを強化し、WBS 行高を安全側に調整

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -50,3 +50,4 @@
 - `mikuproject-sample.xlsx` の `Resources / Assignments / NonWorkingDays` で、強調色が過剰にならない最終バランスを調整する
 - WBS workbook の表示改善を継続する
 - WBS workbook の見た目改善と、構造忠実 workbook との責務分離を保つ
+- 将来検討: WBS workbook について、表示専用列と Excel 再利用向けの機械利用列（hidden 列）の分離が必要か整理する

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -5047,7 +5047,7 @@ if (!customElements.get("lht-page-menu")) {
     const TEXT_DECODER = new TextDecoder();
     const INVALID_SHEET_NAME_PATTERN = /[:\\/?*\[\]]/;
     const CRC32_TABLE = buildCrc32Table();
-    const NUMBER_FORMATS = ["general", "integer", "decimal", "date", "datetime", "percent"];
+    const NUMBER_FORMATS = ["general", "integer", "decimal", "date", "datetime", "percent", "text"];
     const HORIZONTAL_ALIGNS = ["left", "center", "right"];
     const VERTICAL_ALIGNS = ["top", "center", "bottom"];
     const BORDER_STYLES = ["thin"];
@@ -5380,6 +5380,7 @@ if (!customElements.get("lht-page-menu")) {
         const reference = `${encodeColumnName(cellIndex)}${rowIndex + 1}`;
         const styleIndex = resolveStyleIndex(cell, styleBook);
         const styleAttribute = styleIndex > 0 ? ` s="${styleIndex}"` : "";
+        const resolvedNumberFormat = resolveCellNumberFormat(cell);
         if (cell.formula !== undefined) {
             const formulaXml = `<f>${escapeXml(cell.formula)}</f>`;
             const valueXml = buildFormulaValueXml(cell.value);
@@ -5389,8 +5390,11 @@ if (!customElements.get("lht-page-menu")) {
         if (cell.value === undefined) {
             return styleIndex > 0 ? `<c r="${reference}"${styleAttribute}/>` : "";
         }
+        if (resolvedNumberFormat === "text") {
+            return `<c r="${reference}"${styleAttribute} t="inlineStr"><is>${buildInlineStringTextXml(String(cell.value))}</is></c>`;
+        }
         if (typeof cell.value === "string") {
-            return `<c r="${reference}"${styleAttribute} t="inlineStr"><is><t>${escapeXml(cell.value)}</t></is></c>`;
+            return `<c r="${reference}"${styleAttribute} t="inlineStr"><is>${buildInlineStringTextXml(cell.value)}</is></c>`;
         }
         if (typeof cell.value === "number") {
             return `<c r="${reference}"${styleAttribute}><v>${formatNumber(cell.value)}</v></c>`;
@@ -5448,11 +5452,12 @@ if (!customElements.get("lht-page-menu")) {
         return { styles, styleIndexByKey };
     }
     function getStyleDescriptor(cell) {
-        if (!cell.numberFormat && !cell.horizontalAlign && !cell.verticalAlign && !cell.wrapText && !cell.bold && !cell.fontSize && !cell.fillColor && !cell.border) {
+        const numberFormat = resolveCellNumberFormat(cell);
+        if (numberFormat === "general" && !cell.horizontalAlign && !cell.verticalAlign && !cell.wrapText && !cell.bold && !cell.fontSize && !cell.fillColor && !cell.border) {
             return null;
         }
         return {
-            numberFormat: cell.numberFormat || "general",
+            numberFormat,
             horizontalAlign: cell.horizontalAlign,
             verticalAlign: cell.verticalAlign,
             wrapText: cell.wrapText === true ? true : undefined,
@@ -5577,6 +5582,8 @@ if (!customElements.get("lht-page-menu")) {
                 return 1;
             case "decimal":
                 return 2;
+            case "text":
+                return 49;
             case "date":
                 return 14;
             case "datetime":
@@ -5854,6 +5861,21 @@ if (!customElements.get("lht-page-menu")) {
                 return "general";
         }
     }
+    function resolveCellNumberFormat(cell) {
+        if (cell.numberFormat) {
+            return cell.numberFormat;
+        }
+        if (cell.formula === undefined && cell.value !== undefined) {
+            return "text";
+        }
+        return "general";
+    }
+    function buildInlineStringTextXml(value) {
+        const sanitizedValue = sanitizeXmlText(value);
+        const preserveWhitespace = /^[\s]/.test(sanitizedValue) || /[\s]$/.test(sanitizedValue) || sanitizedValue.includes("\n") || sanitizedValue.includes("\r") || sanitizedValue.includes("\t");
+        const preserveAttribute = preserveWhitespace ? ` xml:space="preserve"` : "";
+        return `<t${preserveAttribute}>${escapeXml(sanitizedValue)}</t>`;
+    }
     function parseOptionalNumber(value) {
         if (!value) {
             return undefined;
@@ -5893,12 +5915,15 @@ if (!customElements.get("lht-page-menu")) {
         return TEXT_DECODER.decode(bytes);
     }
     function escapeXml(value) {
-        return value
+        return sanitizeXmlText(value)
             .replace(/&/g, "&amp;")
             .replace(/</g, "&lt;")
             .replace(/>/g, "&gt;")
             .replace(/"/g, "&quot;")
             .replace(/'/g, "&apos;");
+    }
+    function sanitizeXmlText(value) {
+        return value.replace(/[^\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD]/g, "");
     }
     function encodeColumnName(columnIndex) {
         let current = columnIndex + 1;
@@ -10119,9 +10144,12 @@ if (!customElements.get("lht-page-menu")) {
             return {};
         }
         return {
-            value,
+            value: stringifyCellValue(value),
             border: "thin"
         };
+    }
+    function stringifyCellValue(value) {
+        return typeof value === "string" ? value : String(value);
     }
     function keyValueCell(label, value) {
         if (isEditableProjectLabel(label)) {
@@ -11299,7 +11327,7 @@ if (!customElements.get("lht-page-menu")) {
             fillColor
         };
         cells[startColumnIndex + 2] = {
-            value,
+            value: stringifyCellValue(value),
             border: "thin",
             horizontalAlign: typeof value === "number" ? "center" : "left",
             bold: true,
@@ -11357,7 +11385,7 @@ if (!customElements.get("lht-page-menu")) {
     function summaryStatCell(value, fillColor, isValueCell) {
         const valueAlign = typeof value === "number" ? "center" : "left";
         return {
-            value,
+            value: stringifyCellValue(value),
             border: "thin",
             horizontalAlign: isValueCell ? valueAlign : "right",
             bold: true,
@@ -11447,16 +11475,19 @@ if (!customElements.get("lht-page-menu")) {
             return {};
         }
         return {
-            value,
+            value: stringifyCellValue(value),
             border: "thin"
         };
+    }
+    function stringifyCellValue(value) {
+        return typeof value === "string" ? value : String(value);
     }
     function taskCell(task, value, horizontalAlign = "left") {
         if (value === undefined || value === "") {
             return {};
         }
         return {
-            value,
+            value: stringifyCellValue(value),
             border: "thin",
             horizontalAlign,
             verticalAlign: "center",
@@ -11489,16 +11520,31 @@ if (!customElements.get("lht-page-menu")) {
         };
     }
     function taskRowHeight(task) {
-        const labelLength = formatTaskLabel(task).length;
-        const notesLength = (task.notes || "").trim().length;
-        const maxLength = Math.max(labelLength, notesLength);
-        if (maxLength > 72) {
+        const labelLineCount = estimateWrappedLineCount(formatTaskLabel(task), 22);
+        const notesLineCount = estimateWrappedLineCount((task.notes || "").trim(), 18);
+        const maxLineCount = Math.max(labelLineCount, notesLineCount, 1);
+        if (maxLineCount >= 5) {
+            return 82;
+        }
+        if (maxLineCount === 4) {
+            return 70;
+        }
+        if (maxLineCount === 3) {
+            return 58;
+        }
+        if (maxLineCount === 2) {
             return 46;
         }
-        if (maxLength > 36) {
-            return 34;
-        }
         return 34;
+    }
+    function estimateWrappedLineCount(value, charactersPerLine) {
+        const normalized = value.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+        if (!normalized) {
+            return 1;
+        }
+        return normalized
+            .split("\n")
+            .reduce((count, line) => count + Math.max(1, Math.ceil(line.length / charactersPerLine)), 0);
     }
     function kindCell(task) {
         return {
@@ -11515,7 +11561,7 @@ if (!customElements.get("lht-page-menu")) {
             return {};
         }
         return {
-            value,
+            value: stringifyCellValue(value),
             border: "thin",
             horizontalAlign: "center",
             verticalAlign: "center",

--- a/src/js/excel-io.js
+++ b/src/js/excel-io.js
@@ -7,7 +7,7 @@
     const TEXT_DECODER = new TextDecoder();
     const INVALID_SHEET_NAME_PATTERN = /[:\\/?*\[\]]/;
     const CRC32_TABLE = buildCrc32Table();
-    const NUMBER_FORMATS = ["general", "integer", "decimal", "date", "datetime", "percent"];
+    const NUMBER_FORMATS = ["general", "integer", "decimal", "date", "datetime", "percent", "text"];
     const HORIZONTAL_ALIGNS = ["left", "center", "right"];
     const VERTICAL_ALIGNS = ["top", "center", "bottom"];
     const BORDER_STYLES = ["thin"];
@@ -340,6 +340,7 @@
         const reference = `${encodeColumnName(cellIndex)}${rowIndex + 1}`;
         const styleIndex = resolveStyleIndex(cell, styleBook);
         const styleAttribute = styleIndex > 0 ? ` s="${styleIndex}"` : "";
+        const resolvedNumberFormat = resolveCellNumberFormat(cell);
         if (cell.formula !== undefined) {
             const formulaXml = `<f>${escapeXml(cell.formula)}</f>`;
             const valueXml = buildFormulaValueXml(cell.value);
@@ -349,8 +350,11 @@
         if (cell.value === undefined) {
             return styleIndex > 0 ? `<c r="${reference}"${styleAttribute}/>` : "";
         }
+        if (resolvedNumberFormat === "text") {
+            return `<c r="${reference}"${styleAttribute} t="inlineStr"><is>${buildInlineStringTextXml(String(cell.value))}</is></c>`;
+        }
         if (typeof cell.value === "string") {
-            return `<c r="${reference}"${styleAttribute} t="inlineStr"><is><t>${escapeXml(cell.value)}</t></is></c>`;
+            return `<c r="${reference}"${styleAttribute} t="inlineStr"><is>${buildInlineStringTextXml(cell.value)}</is></c>`;
         }
         if (typeof cell.value === "number") {
             return `<c r="${reference}"${styleAttribute}><v>${formatNumber(cell.value)}</v></c>`;
@@ -408,11 +412,12 @@
         return { styles, styleIndexByKey };
     }
     function getStyleDescriptor(cell) {
-        if (!cell.numberFormat && !cell.horizontalAlign && !cell.verticalAlign && !cell.wrapText && !cell.bold && !cell.fontSize && !cell.fillColor && !cell.border) {
+        const numberFormat = resolveCellNumberFormat(cell);
+        if (numberFormat === "general" && !cell.horizontalAlign && !cell.verticalAlign && !cell.wrapText && !cell.bold && !cell.fontSize && !cell.fillColor && !cell.border) {
             return null;
         }
         return {
-            numberFormat: cell.numberFormat || "general",
+            numberFormat,
             horizontalAlign: cell.horizontalAlign,
             verticalAlign: cell.verticalAlign,
             wrapText: cell.wrapText === true ? true : undefined,
@@ -537,6 +542,8 @@
                 return 1;
             case "decimal":
                 return 2;
+            case "text":
+                return 49;
             case "date":
                 return 14;
             case "datetime":
@@ -814,6 +821,21 @@
                 return "general";
         }
     }
+    function resolveCellNumberFormat(cell) {
+        if (cell.numberFormat) {
+            return cell.numberFormat;
+        }
+        if (cell.formula === undefined && cell.value !== undefined) {
+            return "text";
+        }
+        return "general";
+    }
+    function buildInlineStringTextXml(value) {
+        const sanitizedValue = sanitizeXmlText(value);
+        const preserveWhitespace = /^[\s]/.test(sanitizedValue) || /[\s]$/.test(sanitizedValue) || sanitizedValue.includes("\n") || sanitizedValue.includes("\r") || sanitizedValue.includes("\t");
+        const preserveAttribute = preserveWhitespace ? ` xml:space="preserve"` : "";
+        return `<t${preserveAttribute}>${escapeXml(sanitizedValue)}</t>`;
+    }
     function parseOptionalNumber(value) {
         if (!value) {
             return undefined;
@@ -853,12 +875,15 @@
         return TEXT_DECODER.decode(bytes);
     }
     function escapeXml(value) {
-        return value
+        return sanitizeXmlText(value)
             .replace(/&/g, "&amp;")
             .replace(/</g, "&lt;")
             .replace(/>/g, "&gt;")
             .replace(/"/g, "&quot;")
             .replace(/'/g, "&apos;");
+    }
+    function sanitizeXmlText(value) {
+        return value.replace(/[^\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD]/g, "");
     }
     function encodeColumnName(columnIndex) {
         let current = columnIndex + 1;

--- a/src/js/project-xlsx.js
+++ b/src/js/project-xlsx.js
@@ -370,9 +370,12 @@
             return {};
         }
         return {
-            value,
+            value: stringifyCellValue(value),
             border: "thin"
         };
+    }
+    function stringifyCellValue(value) {
+        return typeof value === "string" ? value : String(value);
     }
     function keyValueCell(label, value) {
         if (isEditableProjectLabel(label)) {

--- a/src/js/wbs-xlsx.js
+++ b/src/js/wbs-xlsx.js
@@ -502,7 +502,7 @@
             fillColor
         };
         cells[startColumnIndex + 2] = {
-            value,
+            value: stringifyCellValue(value),
             border: "thin",
             horizontalAlign: typeof value === "number" ? "center" : "left",
             bold: true,
@@ -560,7 +560,7 @@
     function summaryStatCell(value, fillColor, isValueCell) {
         const valueAlign = typeof value === "number" ? "center" : "left";
         return {
-            value,
+            value: stringifyCellValue(value),
             border: "thin",
             horizontalAlign: isValueCell ? valueAlign : "right",
             bold: true,
@@ -650,16 +650,19 @@
             return {};
         }
         return {
-            value,
+            value: stringifyCellValue(value),
             border: "thin"
         };
+    }
+    function stringifyCellValue(value) {
+        return typeof value === "string" ? value : String(value);
     }
     function taskCell(task, value, horizontalAlign = "left") {
         if (value === undefined || value === "") {
             return {};
         }
         return {
-            value,
+            value: stringifyCellValue(value),
             border: "thin",
             horizontalAlign,
             verticalAlign: "center",
@@ -692,16 +695,31 @@
         };
     }
     function taskRowHeight(task) {
-        const labelLength = formatTaskLabel(task).length;
-        const notesLength = (task.notes || "").trim().length;
-        const maxLength = Math.max(labelLength, notesLength);
-        if (maxLength > 72) {
+        const labelLineCount = estimateWrappedLineCount(formatTaskLabel(task), 22);
+        const notesLineCount = estimateWrappedLineCount((task.notes || "").trim(), 18);
+        const maxLineCount = Math.max(labelLineCount, notesLineCount, 1);
+        if (maxLineCount >= 5) {
+            return 82;
+        }
+        if (maxLineCount === 4) {
+            return 70;
+        }
+        if (maxLineCount === 3) {
+            return 58;
+        }
+        if (maxLineCount === 2) {
             return 46;
         }
-        if (maxLength > 36) {
-            return 34;
-        }
         return 34;
+    }
+    function estimateWrappedLineCount(value, charactersPerLine) {
+        const normalized = value.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+        if (!normalized) {
+            return 1;
+        }
+        return normalized
+            .split("\n")
+            .reduce((count, line) => count + Math.max(1, Math.ceil(line.length / charactersPerLine)), 0);
     }
     function kindCell(task) {
         return {
@@ -718,7 +736,7 @@
             return {};
         }
         return {
-            value,
+            value: stringifyCellValue(value),
             border: "thin",
             horizontalAlign: "center",
             verticalAlign: "center",

--- a/src/ts/excel-io.ts
+++ b/src/ts/excel-io.ts
@@ -4,7 +4,7 @@
  */
 (() => {
   type XlsxPrimitiveValue = string | number | boolean;
-  type XlsxNumberFormat = "general" | "integer" | "decimal" | "date" | "datetime" | "percent";
+  type XlsxNumberFormat = "general" | "integer" | "decimal" | "date" | "datetime" | "percent" | "text";
   type XlsxHorizontalAlign = "left" | "center" | "right";
   type XlsxVerticalAlign = "top" | "center" | "bottom";
   type XlsxBorderStyle = "thin";
@@ -87,7 +87,7 @@
   const TEXT_DECODER = new TextDecoder();
   const INVALID_SHEET_NAME_PATTERN = /[:\\/?*\[\]]/;
   const CRC32_TABLE = buildCrc32Table();
-  const NUMBER_FORMATS: XlsxNumberFormat[] = ["general", "integer", "decimal", "date", "datetime", "percent"];
+  const NUMBER_FORMATS: XlsxNumberFormat[] = ["general", "integer", "decimal", "date", "datetime", "percent", "text"];
   const HORIZONTAL_ALIGNS: XlsxHorizontalAlign[] = ["left", "center", "right"];
   const VERTICAL_ALIGNS: XlsxVerticalAlign[] = ["top", "center", "bottom"];
   const BORDER_STYLES: XlsxBorderStyle[] = ["thin"];
@@ -471,6 +471,7 @@
     const reference = `${encodeColumnName(cellIndex)}${rowIndex + 1}`;
     const styleIndex = resolveStyleIndex(cell, styleBook);
     const styleAttribute = styleIndex > 0 ? ` s="${styleIndex}"` : "";
+    const resolvedNumberFormat = resolveCellNumberFormat(cell);
 
     if (cell.formula !== undefined) {
       const formulaXml = `<f>${escapeXml(cell.formula)}</f>`;
@@ -483,8 +484,11 @@
       return styleIndex > 0 ? `<c r="${reference}"${styleAttribute}/>` : "";
     }
 
+    if (resolvedNumberFormat === "text") {
+      return `<c r="${reference}"${styleAttribute} t="inlineStr"><is>${buildInlineStringTextXml(String(cell.value))}</is></c>`;
+    }
     if (typeof cell.value === "string") {
-      return `<c r="${reference}"${styleAttribute} t="inlineStr"><is><t>${escapeXml(cell.value)}</t></is></c>`;
+      return `<c r="${reference}"${styleAttribute} t="inlineStr"><is>${buildInlineStringTextXml(cell.value)}</is></c>`;
     }
     if (typeof cell.value === "number") {
       return `<c r="${reference}"${styleAttribute}><v>${formatNumber(cell.value)}</v></c>`;
@@ -549,11 +553,12 @@
   }
 
   function getStyleDescriptor(cell: XlsxCellModel): StyleDescriptor | null {
-    if (!cell.numberFormat && !cell.horizontalAlign && !cell.verticalAlign && !cell.wrapText && !cell.bold && !cell.fontSize && !cell.fillColor && !cell.border) {
+    const numberFormat = resolveCellNumberFormat(cell);
+    if (numberFormat === "general" && !cell.horizontalAlign && !cell.verticalAlign && !cell.wrapText && !cell.bold && !cell.fontSize && !cell.fillColor && !cell.border) {
       return null;
     }
     return {
-      numberFormat: cell.numberFormat || "general",
+      numberFormat,
       horizontalAlign: cell.horizontalAlign,
       verticalAlign: cell.verticalAlign,
       wrapText: cell.wrapText === true ? true : undefined,
@@ -695,6 +700,8 @@
         return 1;
       case "decimal":
         return 2;
+      case "text":
+        return 49;
       case "date":
         return 14;
       case "datetime":
@@ -1045,6 +1052,23 @@
     }
   }
 
+  function resolveCellNumberFormat(cell: XlsxCellModel): XlsxNumberFormat {
+    if (cell.numberFormat) {
+      return cell.numberFormat;
+    }
+    if (cell.formula === undefined && cell.value !== undefined) {
+      return "text";
+    }
+    return "general";
+  }
+
+  function buildInlineStringTextXml(value: string): string {
+    const sanitizedValue = sanitizeXmlText(value);
+    const preserveWhitespace = /^[\s]/.test(sanitizedValue) || /[\s]$/.test(sanitizedValue) || sanitizedValue.includes("\n") || sanitizedValue.includes("\r") || sanitizedValue.includes("\t");
+    const preserveAttribute = preserveWhitespace ? ` xml:space="preserve"` : "";
+    return `<t${preserveAttribute}>${escapeXml(sanitizedValue)}</t>`;
+  }
+
   function parseOptionalNumber(value: string | null): number | undefined {
     if (!value) {
       return undefined;
@@ -1090,12 +1114,16 @@
   }
 
   function escapeXml(value: string): string {
-    return value
+    return sanitizeXmlText(value)
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")
       .replace(/>/g, "&gt;")
       .replace(/"/g, "&quot;")
       .replace(/'/g, "&apos;");
+  }
+
+  function sanitizeXmlText(value: string): string {
+    return value.replace(/[^\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD]/g, "");
   }
 
   function encodeColumnName(columnIndex: number): string {

--- a/src/ts/project-xlsx.ts
+++ b/src/ts/project-xlsx.ts
@@ -446,9 +446,13 @@
       return {};
     }
     return {
-      value,
+      value: stringifyCellValue(value),
       border: "thin"
     };
+  }
+
+  function stringifyCellValue(value: string | number | boolean): string {
+    return typeof value === "string" ? value : String(value);
   }
 
   function keyValueCell(label: string, value: string | number | boolean | undefined): XlsxCellLike {

--- a/src/ts/wbs-xlsx.ts
+++ b/src/ts/wbs-xlsx.ts
@@ -675,7 +675,7 @@
       fillColor
     };
     cells[startColumnIndex + 2] = {
-      value,
+      value: stringifyCellValue(value),
       border: "thin",
       horizontalAlign: typeof value === "number" ? "center" : "left",
       bold: true,
@@ -754,7 +754,7 @@
   function summaryStatCell(value: string | number, fillColor: string, isValueCell: boolean): WbsXlsxCellLike {
     const valueAlign = typeof value === "number" ? "center" : "left";
     return {
-      value,
+      value: stringifyCellValue(value),
       border: "thin",
       horizontalAlign: isValueCell ? valueAlign : "right",
       bold: true,
@@ -869,9 +869,13 @@
       return {};
     }
     return {
-      value,
+      value: stringifyCellValue(value),
       border: "thin"
     };
+  }
+
+  function stringifyCellValue(value: string | number | boolean): string {
+    return typeof value === "string" ? value : String(value);
   }
 
   function taskCell(
@@ -883,7 +887,7 @@
       return {};
     }
     return {
-      value,
+      value: stringifyCellValue(value),
       border: "thin",
       horizontalAlign,
       verticalAlign: "center",
@@ -918,16 +922,32 @@
   }
 
   function taskRowHeight(task: TaskModel): number | undefined {
-    const labelLength = formatTaskLabel(task).length;
-    const notesLength = (task.notes || "").trim().length;
-    const maxLength = Math.max(labelLength, notesLength);
-    if (maxLength > 72) {
+    const labelLineCount = estimateWrappedLineCount(formatTaskLabel(task), 22);
+    const notesLineCount = estimateWrappedLineCount((task.notes || "").trim(), 18);
+    const maxLineCount = Math.max(labelLineCount, notesLineCount, 1);
+    if (maxLineCount >= 5) {
+      return 82;
+    }
+    if (maxLineCount === 4) {
+      return 70;
+    }
+    if (maxLineCount === 3) {
+      return 58;
+    }
+    if (maxLineCount === 2) {
       return 46;
     }
-    if (maxLength > 36) {
-      return 34;
-    }
     return 34;
+  }
+
+  function estimateWrappedLineCount(value: string, charactersPerLine: number): number {
+    const normalized = value.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+    if (!normalized) {
+      return 1;
+    }
+    return normalized
+      .split("\n")
+      .reduce((count, line) => count + Math.max(1, Math.ceil(line.length / charactersPerLine)), 0);
   }
 
   function kindCell(task: TaskModel): WbsXlsxCellLike {
@@ -946,7 +966,7 @@
       return {};
     }
     return {
-      value,
+      value: stringifyCellValue(value),
       border: "thin",
       horizontalAlign: "center",
       verticalAlign: "center",

--- a/tests/mikuproject-excel-io.test.js
+++ b/tests/mikuproject-excel-io.test.js
@@ -121,12 +121,13 @@ describe("mikuproject excel io", () => {
       "[Content_Types].xml",
       "_rels/.rels",
       "xl/_rels/workbook.xml.rels",
+      "xl/styles.xml",
       "xl/workbook.xml",
       "xl/worksheets/sheet1.xml"
     ]);
   });
 
-  it("round-trips sheet names, sparse cells, formulas, and primitive cell values", () => {
+  it("round-trips sheet names, sparse cells, formulas, and primitive cell values as text by default", () => {
     const excelIo = bootExcelIoModule();
     const codec = new excelIo.XlsxWorkbookCodec();
     const workbook = {
@@ -145,8 +146,8 @@ describe("mikuproject excel io", () => {
             {
               cells: [
                 { value: "Design" },
-                { value: 2 },
-                { value: true },
+                { value: "2" },
+                { value: "true" },
                 { formula: "B2*2", value: 4 }
               ]
             },
@@ -154,7 +155,7 @@ describe("mikuproject excel io", () => {
               cells: [
                 { value: "Build" },
                 {},
-                { value: false },
+                { value: "false" },
                 { value: "" }
               ]
             }
@@ -178,6 +179,80 @@ describe("mikuproject excel io", () => {
           ]
         }
       ]
+    };
+
+    const bytes = codec.exportWorkbook(workbook);
+    const imported = codec.importWorkbook(bytes);
+
+    expect(imported).toEqual(workbook);
+  });
+
+  it("writes string cells as text-formatted inline strings and preserves leading whitespace", () => {
+    const excelIo = bootExcelIoModule();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const workbook = {
+      sheets: [{
+        name: "Sheet1",
+        rows: [{
+          cells: [
+            { value: "  - round-trip" },
+            { value: "plain" }
+          ]
+        }]
+      }]
+    };
+
+    const bytes = codec.exportWorkbook(workbook);
+    const entries = codec.unpackEntries(bytes);
+    const sheetXml = new TextDecoder().decode(entries["xl/worksheets/sheet1.xml"]);
+    const stylesXml = new TextDecoder().decode(entries["xl/styles.xml"]);
+
+    expect(sheetXml).toContain('t="inlineStr"><is><t xml:space="preserve">  - round-trip</t></is></c>');
+    expect(stylesXml).toContain('numFmtId="49"');
+    expect(codec.importWorkbook(bytes)).toEqual(workbook);
+  });
+
+  it("sanitizes XML-invalid control characters from cell strings", () => {
+    const excelIo = bootExcelIoModule();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const workbook = {
+      sheets: [{
+        name: "Sheet1",
+        rows: [{
+          cells: [
+            { value: "ok\u0000bad\u0008text" },
+            { value: "line1\nline2\tok" }
+          ]
+        }]
+      }]
+    };
+
+    const bytes = codec.exportWorkbook(workbook);
+    const entries = codec.unpackEntries(bytes);
+    const sheetXml = new TextDecoder().decode(entries["xl/worksheets/sheet1.xml"]);
+    const imported = codec.importWorkbook(bytes);
+
+    expect(sheetXml).toContain("okbadtext");
+    expect(sheetXml).not.toContain("\u0000");
+    expect(sheetXml).not.toContain("\u0008");
+    expect(imported.sheets[0].rows[0].cells[0].value).toBe("okbadtext");
+    expect(imported.sheets[0].rows[0].cells[1].value).toBe("line1\nline2\tok");
+  });
+
+  it("keeps explicitly formatted numeric cells as numeric values", () => {
+    const excelIo = bootExcelIoModule();
+    const codec = new excelIo.XlsxWorkbookCodec();
+    const workbook = {
+      sheets: [{
+        name: "Numeric",
+        rows: [{
+          cells: [
+            { value: 12, numberFormat: "integer" },
+            { value: 0.5, numberFormat: "percent" },
+            { formula: "A1*2", value: 24 }
+          ]
+        }]
+      }]
     };
 
     const bytes = codec.exportWorkbook(workbook);
@@ -412,10 +487,10 @@ describe("mikuproject excel io", () => {
             },
             {
               cells: [
-                { value: 1 },
-                { value: 2 },
-                { value: 3 },
-                { value: 4 }
+                { value: "1" },
+                { value: "2" },
+                { value: "3" },
+                { value: "4" }
               ]
             }
           ]
@@ -478,7 +553,7 @@ describe("mikuproject excel io", () => {
     expect(decodeUtf8(entries["xl/workbook.xml"])).toContain('name="One"');
     expect(decodeUtf8(entries["xl/worksheets/sheet1.xml"])).toContain('r="A1"');
     expect(decodeUtf8(entries["xl/worksheets/sheet1.xml"])).toContain("inlineStr");
-    expect(decodeUtf8(entries["xl/worksheets/sheet1.xml"])).toContain("<v>1</v>");
+    expect(decodeUtf8(entries["xl/worksheets/sheet1.xml"])).toContain("<t>1</t>");
   });
 
   it("writes styles and sheet layout xml when formatting is present", () => {
@@ -540,7 +615,7 @@ describe("mikuproject excel io", () => {
 
     expect(sheetXml).toContain('r="A1"');
     expect(sheetXml).toContain('r="B1"');
-    expect(sheetXml).toContain('<c r="B1" s="1"/>');
+    expect(sheetXml).toMatch(/<c r="B1" s="\d+"\/>/);
   });
 
   it("writes font, fill, and border definitions when style options are present", () => {

--- a/tests/mikuproject-project-xlsx.test.js
+++ b/tests/mikuproject-project-xlsx.test.js
@@ -233,7 +233,7 @@ describe("mikuproject project xlsx", () => {
     expect(nonWorkingDaysSheet.rows[3].cells[4].value).toBe(SAMPLE_FIRST_HOLIDAY_DATE);
     expect(nonWorkingDaysSheet.rows[3].cells[5].value).toBe(SAMPLE_FIRST_HOLIDAY_DATE);
     expect(nonWorkingDaysSheet.rows[3].cells[6].value).toBe(SAMPLE_FIRST_HOLIDAY_DATE);
-    expect(nonWorkingDaysSheet.rows[3].cells[7].value).toBe(false);
+    expect(nonWorkingDaysSheet.rows[3].cells[7].value).toBe("false");
     expect(nonWorkingDaysSheet.rows[3].cells[4].fillColor).toBe(EDITABLE_FILL);
     expect(nonWorkingDaysSheet.rows[3].cells[5].fillColor).toBe(EDITABLE_FILL);
     expect(nonWorkingDaysSheet.rows[3].cells[6].fillColor).toBe(EDITABLE_FILL);
@@ -256,6 +256,8 @@ describe("mikuproject project xlsx", () => {
     expect(entries).toContain("xl/styles.xml");
     expect(projectSheetXml).not.toContain('ref="A1:B1"');
     expect(projectSheetXml).toContain('ref="A11:B11"');
+    expect(projectSheetXml).toContain('t="inlineStr"><is><t>1</t></is>');
+    expect(projectSheetXml).toContain('t="inlineStr"><is><t>true</t></is>');
   });
 
   it("imports limited task fields from workbook rows back into ProjectModel", () => {

--- a/tests/mikuproject-wbs-xlsx.test.js
+++ b/tests/mikuproject-wbs-xlsx.test.js
@@ -140,20 +140,20 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.rows[projectInfoHeaderIndex + 5].cells[0].value).toBe("現在日");
     expect(sheet.rows[projectInfoHeaderIndex + 5].cells[2].value).toBe("2026-03-23");
     expect(sheet.rows[projectInfoHeaderIndex + 6].cells[0].value).toBe("祝日");
-    expect(sheet.rows[projectInfoHeaderIndex + 6].cells[2].value).toBeGreaterThan(0);
+    expect(sheet.rows[projectInfoHeaderIndex + 6].cells[2].value).toBe("1");
     const summaryHeaderIndex = findRowIndexByCellValue(sheet, "サマリ", 0);
     expect(sheet.rows[summaryHeaderIndex].height).toBe(24);
     expect(sheet.rows[summaryHeaderIndex].cells[0].fontSize).toBe(14);
     expect(sheet.rows[summaryHeaderIndex].cells[0].fillColor).toBe("#E1EDF8");
     expect(sheet.rows[summaryHeaderIndex + 1].cells[0].value).toBe("表示日");
-    expect(sheet.rows[summaryHeaderIndex + 1].cells[1].value).toBe(17);
+    expect(sheet.rows[summaryHeaderIndex + 1].cells[1].value).toBe("17");
     expect(sheet.rows[summaryHeaderIndex + 1].cells[0].horizontalAlign).toBe("right");
     expect(sheet.rows[summaryHeaderIndex + 1].cells[1].horizontalAlign).toBe("center");
     expect(sheet.rows[summaryHeaderIndex + 1].cells[1].bold).toBe(true);
     expect(sheet.rows[projectInfoHeaderIndex + 1].cells[2].horizontalAlign).toBe("left");
     expect(sheet.rows[projectInfoHeaderIndex + 3].cells[2].horizontalAlign).toBe("left");
     expect(sheet.rows[summaryHeaderIndex + 3].cells[0].value).toBe("営業日");
-    expect(sheet.rows[summaryHeaderIndex + 3].cells[1].value).toBe(12);
+    expect(sheet.rows[summaryHeaderIndex + 3].cells[1].value).toBe("12");
     expect(sheet.rows[summaryHeaderIndex + 4].cells[0].value).toBe("前日数");
     expect(sheet.rows[summaryHeaderIndex + 4].cells[1].value).toBe("-");
     expect(sheet.rows[summaryHeaderIndex + 5].cells[0].value).toBe("後日数");
@@ -165,13 +165,13 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.rows[summaryHeaderIndex + 8].cells[0].value).toBe("基準日");
     expect(sheet.rows[summaryHeaderIndex + 8].cells[1].value).toBe("2026-03-23");
     expect(sheet.rows[summaryHeaderIndex + 9].cells[0].value).toBe("タスク");
-    expect(sheet.rows[summaryHeaderIndex + 9].cells[1].value).toBe(13);
+    expect(sheet.rows[summaryHeaderIndex + 9].cells[1].value).toBe("13");
     expect(sheet.rows[summaryHeaderIndex + 10].cells[0].value).toBe("リソース");
-    expect(sheet.rows[summaryHeaderIndex + 10].cells[1].value).toBe(0);
+    expect(sheet.rows[summaryHeaderIndex + 10].cells[1].value).toBe("0");
     expect(sheet.rows[summaryHeaderIndex + 11].cells[0].value).toBe("割当");
-    expect(sheet.rows[summaryHeaderIndex + 11].cells[1].value).toBe(0);
+    expect(sheet.rows[summaryHeaderIndex + 11].cells[1].value).toBe("0");
     expect(sheet.rows[summaryHeaderIndex + 12].cells[0].value).toBe("カレンダ");
-    expect(sheet.rows[summaryHeaderIndex + 12].cells[1].value).toBe(1);
+    expect(sheet.rows[summaryHeaderIndex + 12].cells[1].value).toBe("1");
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
     const dateRowIndex = headerRowIndex - 1;
     expect(headerRowIndex).toBe(8);
@@ -364,6 +364,7 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheetXml).toContain("1 Standard");
     expect(sheetXml).toContain("階層");
     expect(sheetXml).toContain("3/16");
+    expect(sheetXml).toContain('t="inlineStr"><is><t>1</t></is>');
     vi.useRealTimers();
   });
 
@@ -580,7 +581,7 @@ describe("mikuproject wbs xlsx", () => {
     const sheet = workbook.sheets[0];
 
     const projectInfoHeaderIndex = findRowIndexByCellValue(sheet, "プロジェクト情報", 0);
-    expect(sheet.rows[projectInfoHeaderIndex + 6].cells[2].value).toBeGreaterThan(0);
+    expect(sheet.rows[projectInfoHeaderIndex + 6].cells[2].value).toBe("1");
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
     expect(sheet.rows[headerRowIndex - 1].cells[24].value).toBe("3/20");
     expect(sheet.rows[headerRowIndex].cells[24].value).toBe("Fri");
@@ -608,8 +609,8 @@ describe("mikuproject wbs xlsx", () => {
       "3/24",
       "3/25"
     ]);
-    expect(sheet.rows[summaryHeaderIndex + 4].cells[1].value).toBe(1);
-    expect(sheet.rows[summaryHeaderIndex + 5].cells[1].value).toBe(2);
+    expect(sheet.rows[summaryHeaderIndex + 4].cells[1].value).toBe("1");
+    expect(sheet.rows[summaryHeaderIndex + 5].cells[1].value).toBe("2");
     expect(sheet.rows[summaryHeaderIndex + 6].cells[1].value).toBe("暦日");
     expect(sheet.rows[summaryHeaderIndex + 7].cells[1].value).toBe("暦日");
   });
@@ -642,7 +643,7 @@ describe("mikuproject wbs xlsx", () => {
       "3/22",
       "3/23"
     ]);
-    expect(sheet.rows[summaryHeaderIndex + 3].cells[1].value).toBe(4);
+    expect(sheet.rows[summaryHeaderIndex + 3].cells[1].value).toBe("4");
     expect(sheet.rows[summaryHeaderIndex + 6].cells[1].value).toBe("営業日");
     expect(sheet.rows[summaryHeaderIndex + 7].cells[1].value).toBe("暦日");
   });
@@ -724,13 +725,15 @@ describe("mikuproject wbs xlsx", () => {
     const model = xml.importMsProjectXml(xml.SAMPLE_XML);
 
     model.tasks[2].name = "Design task with a very long title for wrapped display";
+    model.tasks[2].notes = "Detailed note line one\nDetailed note line two with additional context";
 
     const workbook = wbsXlsx.exportWbsWorkbook(model);
     const sheet = workbook.sheets[0];
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
     const designRow = sheet.rows[headerRowIndex + 3];
 
-    expect(designRow.height).toBe(34);
+    expect(designRow.height).toBe(82);
     expect(designRow.cells[5].wrapText).toBe(true);
+    expect(designRow.cells[9].wrapText).toBe(true);
   });
 });


### PR DESCRIPTION
### 概要

XLSX 出力時のセル解釈まわりを見直し、文字列セルを既定で text として扱うように調整しました。あわせて、XML 禁止文字のサニタイズを追加し、WBS workbook の長文セルで行高が不足しにくいように行高計算を安全側へ寄せています。

### 変更内容

- `excel-io` に `text` の number format を追加し、`formula` ではない値付きセルを既定で text 扱いに変更
- `inlineStr` 出力時に先頭・末尾空白や改行を保持するため、必要に応じて `xml:space="preserve"` を付与
- XML 1.0 で不正となる制御文字を、セル文字列の出力前に除去するサニタイズを追加
- `project-xlsx` / `wbs-xlsx` のセル値を文字列化し、数値や真偽値が Excel 側で再解釈されにくいよう調整
- WBS workbook の行高計算を、単純な文字数閾値ではなく折り返し行数ベースへ変更
- WBS workbook の将来検討事項として、表示専用列と Excel 再利用向け hidden 列の分離検討を `docs/TODO.md` に追記
- 関連するテストを更新し、文字列セルの text 出力、XML 禁止文字サニタイズ、WBS 行高調整を検証

### 期待する効果

- `-` 始まりや先頭空白付きの文字列が、Excel 上で数式や別型として再解釈されにくくなる
- XML 禁止文字を含む文字列が混入しても、壊れた XLSX を出力しにくくなる
- WBS workbook の長いタスク名やノートで、表示が見切れにくくなる

### テスト

- `tests/mikuproject-excel-io.test.js`
- `tests/mikuproject-project-xlsx.test.js`
- `tests/mikuproject-wbs-xlsx.test.js`