### PR TITLE
WBS workbook の名称列とタスク詳細列を左寄せに統一

### DIFF
--- a/mikuproject.html
+++ b/mikuproject.html
@@ -10985,7 +10985,7 @@ if (!customElements.get("lht-page-menu")) {
                 identifierCell(task, task.wbs || task.outlineNumber),
                 kindCell(task),
                 identifierCell(task, task.outlineLevel),
-                taskCell(task, formatTaskLabel(task), "center"),
+                taskCell(task, formatTaskLabel(task), "left"),
                 taskCell(task, formatWbsDate(task.start), "center"),
                 taskCell(task, formatWbsDate(task.finish), "center"),
                 taskCell(task, formatDurationLabel(task, holidaySet, nonWorkingDayTypes, options.useBusinessDaysForProgressBand), "center"),
@@ -11508,7 +11508,7 @@ if (!customElements.get("lht-page-menu")) {
         return {
             value: placeholder ? "-" : normalized,
             border: "thin",
-            horizontalAlign: placeholder ? "center" : "left",
+            horizontalAlign: "left",
             verticalAlign: "center",
             wrapText: placeholder ? undefined : true,
             bold: task.summary || task.milestone || false,

--- a/src/js/wbs-xlsx.js
+++ b/src/js/wbs-xlsx.js
@@ -160,7 +160,7 @@
                 identifierCell(task, task.wbs || task.outlineNumber),
                 kindCell(task),
                 identifierCell(task, task.outlineLevel),
-                taskCell(task, formatTaskLabel(task), "center"),
+                taskCell(task, formatTaskLabel(task), "left"),
                 taskCell(task, formatWbsDate(task.start), "center"),
                 taskCell(task, formatWbsDate(task.finish), "center"),
                 taskCell(task, formatDurationLabel(task, holidaySet, nonWorkingDayTypes, options.useBusinessDaysForProgressBand), "center"),
@@ -683,7 +683,7 @@
         return {
             value: placeholder ? "-" : normalized,
             border: "thin",
-            horizontalAlign: placeholder ? "center" : "left",
+            horizontalAlign: "left",
             verticalAlign: "center",
             wrapText: placeholder ? undefined : true,
             bold: task.summary || task.milestone || false,

--- a/src/ts/wbs-xlsx.ts
+++ b/src/ts/wbs-xlsx.ts
@@ -236,7 +236,7 @@
         identifierCell(task, task.wbs || task.outlineNumber),
         kindCell(task),
         identifierCell(task, task.outlineLevel),
-        taskCell(task, formatTaskLabel(task), "center"),
+        taskCell(task, formatTaskLabel(task), "left"),
         taskCell(task, formatWbsDate(task.start), "center"),
         taskCell(task, formatWbsDate(task.finish), "center"),
         taskCell(task, formatDurationLabel(task, holidaySet, nonWorkingDayTypes, options.useBusinessDaysForProgressBand), "center"),
@@ -909,7 +909,7 @@
     return {
       value: placeholder ? "-" : normalized,
       border: "thin",
-      horizontalAlign: placeholder ? "center" : "left",
+      horizontalAlign: "left",
       verticalAlign: "center",
       wrapText: placeholder ? undefined : true,
       bold: task.summary || task.milestone || false,

--- a/tests/mikuproject-wbs-xlsx.test.js
+++ b/tests/mikuproject-wbs-xlsx.test.js
@@ -255,7 +255,7 @@ describe("mikuproject wbs xlsx", () => {
     expect(firstTaskRow.cells[5].bold).toBe(true);
     expect(firstTaskRow.cells[9].value).toBe("-");
     expect(firstTaskRow.cells[9].fillColor).toBe("#F5F7FA");
-    expect(firstTaskRow.cells[9].horizontalAlign).toBe("center");
+    expect(firstTaskRow.cells[9].horizontalAlign).toBe("left");
     expect(firstTaskRow.cells[15].value).toBe("-");
     expect(firstTaskRow.cells[15].fillColor).toBe("#F5F7FA");
     expect(firstTaskRow.cells[15].horizontalAlign).toBe("center");
@@ -275,7 +275,7 @@ describe("mikuproject wbs xlsx", () => {
     expect(firstTaskRow.cells[5].value).toBe("> 基盤整備");
     expect(secondTaskRow.cells[5].value).toBe("  * 着手");
     expect(secondTaskRow.cells[5].fillColor).toBe("#FFF4E0");
-    expect(secondTaskRow.cells[5].horizontalAlign).toBe("center");
+    expect(secondTaskRow.cells[5].horizontalAlign).toBe("left");
     expect(secondTaskRow.cells[5].wrapText).toBe(true);
     expect(secondTaskRow.cells[6].fillColor).toBe("#FFF4E0");
     expect(secondTaskRow.cells[9].value).toBe("-");


### PR DESCRIPTION
### 概要

WBS workbook の本文レイアウトを調整し、名称列とタスク詳細列のセル配置を左寄せへ変更しました。

### 変更内容

- `src/ts/wbs-xlsx.ts` を更新
  - WBS workbook の F列（名称）で使用する `taskCell(...)` の配置を `left` に変更
  - WBS workbook の J列（タスク詳細）で使用する `detailCell(...)` の配置を、プレースホルダ `-` を含めて `left` に変更
- 生成物を更新
  - `src/js/wbs-xlsx.js`
  - `mikuproject.html`
- テストを更新
  - `tests/mikuproject-wbs-xlsx.test.js` の期待値を、左寄せに合わせて更新

### 期待する効果

- WBS workbook の名称列とタスク詳細列が、本文として読みやすい左寄せレイアウトになる
- プレースホルダ `-` を含むタスク詳細列も、同じ列内で配置方針が揃う

### テスト

- `tests/mikuproject-wbs-xlsx.test.js`