### PR TITLE
WBS SVG 出力を拡張し、Overview プレビュー切替と ALL ZIP ダウンロードを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@
 - 内部モデル、validation、native SVG preview、各 preview の確認
 - `MS Project XML / XLSX / WBS XLSX / workbook JSON / CSV + ParentID / Mermaid / 生成AI向け .editjson` の保存
 
+### Windows 11 での `Monthly SVG` / `SVG` 取扱いメモ
+
+- `Monthly SVG` は、月ごとの `SVG` をまとめた `ZIP` として保存される
+- `Windows 11` では、ダウンロードした `ZIP` や、その中の `SVG` が「危険なファイル」として警告される場合がある
+- これは `mikuproject` 固有の独自拡張ではなく、`ZIP` や `SVG` を Windows 側が外部由来ファイルとして慎重に扱う場合があるため
+- 少なくとも `Monthly SVG` の `ZIP` は、アプリ内で生成した `SVG` 群をまとめたもの
+- 警告の有無や表示文言は、利用するブラウザや Windows の設定に依存する可能性がある
+
 ## 開発
 
 ```bash

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -35,6 +35,7 @@
 - UI の微調整として、`Input / Overview / Output` の各カードの余白・見出し・ボタン階層を見直し、`miku` 系テーマの統一感をさらに整える
 - `Overview` タブの summary / validation / preview の情報密度を見直し、どこを見る画面なのかをより直感的に伝わる構成へ調整する
 - `Output` タブの生成AI連携と各種 export ボタンの優先度表現を見直し、主操作と補助操作の区別をより明確にする
+- `Output` の主要出力をまとめて取得できる、一括 ZIP ダウンロードボタンを追加する
 - calendar 未設定時に自動補完する既定 calendar の祝日 `Exceptions` を、project 期間内だけに限定する
 - WBS 上で土日と祝日を別色表示する場合も、`MS Project XML` 正本へ独自の非稼働日種別を追加せず、`WeekDays / Exceptions` の由来で描き分ける
 - `build:xlsx-sample` の所要時間を個別計測し、sample workbook 生成処理の支配要因を確認する

--- a/mikuproject-src.html
+++ b/mikuproject-src.html
@@ -168,6 +168,11 @@
         </div>
 
         <section class="md-note-card md-note-card--feature">
+          <div class="md-panel-actions">
+            <button id="previewDailySvgBtn" type="button" class="md-button md-button--tonal">Daily</button>
+            <button id="previewWeeklySvgBtn" type="button" class="md-button md-button--tonal">Weekly</button>
+            <button id="previewMonthlySvgBtn" type="button" class="md-button md-button--tonal">Monthly Calendar</button>
+          </div>
           <div id="nativeSvgPreview" class="md-svg-preview-stage">
             <div class="md-preview-empty">SVG を生成すると、ここにプレビューを表示します。</div>
           </div>
@@ -261,6 +266,12 @@
 
         <div class="md-output-actions">
           <div class="md-panel-actions">
+            <button id="downloadAllOutputsBtn" type="button" class="md-button md-button--tonal">
+              <svg aria-hidden="true" viewBox="0 0 16 16" class="md-button__icon" fill="currentColor">
+                <use href="#md-icon-download" xlink:href="#md-icon-download"></use>
+              </svg>
+              <span>ALL</span>
+            </button>
             <button id="downloadXmlBtn" type="button" class="md-button md-button--primary">
               <svg aria-hidden="true" viewBox="0 0 16 16" class="md-button__icon" fill="currentColor">
                 <use href="#md-icon-download" xlink:href="#md-icon-download"></use>
@@ -307,13 +318,19 @@
               <svg aria-hidden="true" viewBox="0 0 16 16" class="md-button__icon" fill="currentColor">
                 <use href="#md-icon-download" xlink:href="#md-icon-download"></use>
               </svg>
-              <span>SVG</span>
+              <span>Daily SVG</span>
+            </button>
+            <button id="downloadWeeklySvgBtn" type="button" class="md-button md-button--tonal" disabled>
+              <svg aria-hidden="true" viewBox="0 0 16 16" class="md-button__icon" fill="currentColor">
+                <use href="#md-icon-download" xlink:href="#md-icon-download"></use>
+              </svg>
+              <span>Weekly SVG</span>
             </button>
             <button id="downloadMonthlyWbsSvgZipBtn" type="button" class="md-button md-button--tonal" disabled>
               <svg aria-hidden="true" viewBox="0 0 16 16" class="md-button__icon" fill="currentColor">
                 <use href="#md-icon-download" xlink:href="#md-icon-download"></use>
               </svg>
-              <span>Monthly SVG</span>
+              <span>Monthly Calendar SVG</span>
             </button>
             <button id="exportMermaidMdBtn" type="button" class="md-button md-button--tonal">
               <svg aria-hidden="true" viewBox="0 0 16 16" class="md-button__icon" fill="currentColor">

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -2691,6 +2691,11 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
         </div>
 
         <section class="md-note-card md-note-card--feature">
+          <div class="md-panel-actions">
+            <button id="previewDailySvgBtn" type="button" class="md-button md-button--tonal">Daily</button>
+            <button id="previewWeeklySvgBtn" type="button" class="md-button md-button--tonal">Weekly</button>
+            <button id="previewMonthlySvgBtn" type="button" class="md-button md-button--tonal">Monthly Calendar</button>
+          </div>
           <div id="nativeSvgPreview" class="md-svg-preview-stage">
             <div class="md-preview-empty">SVG を生成すると、ここにプレビューを表示します。</div>
           </div>
@@ -2784,6 +2789,12 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 
         <div class="md-output-actions">
           <div class="md-panel-actions">
+            <button id="downloadAllOutputsBtn" type="button" class="md-button md-button--tonal">
+              <svg aria-hidden="true" viewBox="0 0 16 16" class="md-button__icon" fill="currentColor">
+                <use href="#md-icon-download" xlink:href="#md-icon-download"></use>
+              </svg>
+              <span>ALL</span>
+            </button>
             <button id="downloadXmlBtn" type="button" class="md-button md-button--primary">
               <svg aria-hidden="true" viewBox="0 0 16 16" class="md-button__icon" fill="currentColor">
                 <use href="#md-icon-download" xlink:href="#md-icon-download"></use>
@@ -2830,13 +2841,19 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
               <svg aria-hidden="true" viewBox="0 0 16 16" class="md-button__icon" fill="currentColor">
                 <use href="#md-icon-download" xlink:href="#md-icon-download"></use>
               </svg>
-              <span>SVG</span>
+              <span>Daily SVG</span>
+            </button>
+            <button id="downloadWeeklySvgBtn" type="button" class="md-button md-button--tonal" disabled>
+              <svg aria-hidden="true" viewBox="0 0 16 16" class="md-button__icon" fill="currentColor">
+                <use href="#md-icon-download" xlink:href="#md-icon-download"></use>
+              </svg>
+              <span>Weekly SVG</span>
             </button>
             <button id="downloadMonthlyWbsSvgZipBtn" type="button" class="md-button md-button--tonal" disabled>
               <svg aria-hidden="true" viewBox="0 0 16 16" class="md-button__icon" fill="currentColor">
                 <use href="#md-icon-download" xlink:href="#md-icon-download"></use>
               </svg>
-              <span>Monthly SVG</span>
+              <span>Monthly Calendar SVG</span>
             </button>
             <button id="exportMermaidMdBtn" type="button" class="md-button md-button--tonal">
               <svg aria-hidden="true" viewBox="0 0 16 16" class="md-button__icon" fill="currentColor">
@@ -12751,6 +12768,12 @@ if (!customElements.get("lht-page-menu")) {
     const MONTHLY_MAX_LABEL_CHARS = 15;
     const ZIP_FIXED_MOD_TIME = 0;
     const ZIP_FIXED_MOD_DATE = ((2025 - 1980) << 9) | (1 << 5) | 1;
+    const WEEK_WIDTH = 38;
+    const WEEKLY_HEADER_HEIGHT = 96;
+    const WEEKLY_TOP_PADDING = 22;
+    const WEEKLY_BOTTOM_PADDING = 28;
+    const WEEKLY_LEFT_PADDING = 0;
+    const WEEKLY_RIGHT_PADDING = 0;
     function exportNativeSvg(model, options = {}) {
         const labelMode = options.labelMode || "near";
         const holidaySet = new Set([
@@ -12786,6 +12809,7 @@ if (!customElements.get("lht-page-menu")) {
             ".axis { font-size: 12px; fill: #5b6370; }",
             ".label { font-size: 13px; }",
             ".phaseLabel { font-size: 13px; font-weight: 700; }",
+            ".onBarLabelBg { fill: rgba(255,255,255,0.9); }",
             ".grid { stroke: #c9d3e1; stroke-width: 1; }",
             ".today { stroke: #ff6b5a; stroke-width: 2; }",
             "</style>",
@@ -12810,6 +12834,7 @@ if (!customElements.get("lht-page-menu")) {
         }
         for (const row of rows) {
             const rowY = chartOriginY + row.y;
+            const useOnBarLabel = shouldUseDailyOnBarLabel(row, dateBand.length, labelMode);
             if (row.startIndex !== null && row.endIndex !== null) {
                 const barX = chartOriginX + (row.startIndex * DAY_WIDTH) + 6;
                 const barWidth = Math.max(12, ((row.endIndex - row.startIndex + 1) * DAY_WIDTH) - 12);
@@ -12844,9 +12869,127 @@ if (!customElements.get("lht-page-menu")) {
                         parts.push(`<rect x="${barX}" y="${barY}" width="${progressWidth}" height="22" rx="4" fill="${progressFill}" stroke="none"/>`);
                     }
                 }
+                if (useOnBarLabel) {
+                    const labelText = escapeXml(formatTaskLabel(row.task, labelMode));
+                    const labelWidth = estimateLabelWidth(row.label, row.kind === "phase");
+                    const labelCenterX = barX + (barWidth / 2);
+                    const labelX = labelCenterX - (labelWidth / 2) - 8;
+                    const labelY = row.kind === "phase" ? rowY + 15 : rowY + 10;
+                    const labelHeight = row.kind === "phase" ? 18 : 20;
+                    parts.push(`<rect class="onBarLabelBg" x="${labelX}" y="${labelY}" width="${labelWidth + 16}" height="${labelHeight}" rx="4"/>`);
+                    parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelCenterX}" y="${rowY + 24}" text-anchor="middle">${labelText}</text>`);
+                    continue;
+                }
             }
             const labelPlacement = labelPlacements[rows.indexOf(row)];
             parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelPlacement.x + shiftX}" y="${rowY + 24}" text-anchor="${labelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, labelMode))}</text>`);
+        }
+        parts.push("</svg>");
+        return parts.join("");
+    }
+    function exportWeeklyNativeSvg(model, options = {}) {
+        const holidaySet = new Set([
+            ...collectWbsHolidayDates(model),
+            ...(options.holidayDates || []).map((day) => String(day || "").slice(0, 10)).filter(Boolean)
+        ]);
+        const nonWorkingDayTypes = collectProjectNonWorkingDayTypes(model);
+        const dateBand = buildDisplayDateBand(model.project.startDate, model.project.finishDate, model.project.currentDate, options.displayDaysBeforeBaseDate, options.displayDaysAfterBaseDate, holidaySet, nonWorkingDayTypes, options.useBusinessDaysForDisplayRange);
+        if (dateBand.length === 0) {
+            return exportNativeSvg(model, { ...options, labelMode: "list" });
+        }
+        const weeklyBand = buildWeeklyBand(dateBand[0], dateBand[dateBand.length - 1]);
+        const rows = buildWeeklyTaskRows(model.tasks, weeklyBand);
+        const chartWidth = weeklyBand.length * WEEK_WIDTH;
+        const chartOriginXBase = WEEKLY_LEFT_PADDING;
+        const labelPlacements = rows.map((row) => resolveWeeklyLabelPlacement(row, chartOriginXBase, chartWidth));
+        const labelMaxX = labelPlacements.reduce((max, placement) => {
+            const placementMaxX = placement.anchor === "start" ? placement.x + placement.width : placement.x;
+            return Math.max(max, placementMaxX);
+        }, chartOriginXBase + chartWidth);
+        const chartOriginX = chartOriginXBase;
+        const svgWidth = labelMaxX + WEEKLY_RIGHT_PADDING;
+        const svgHeight = WEEKLY_TOP_PADDING + WEEKLY_HEADER_HEIGHT + (rows.length * ROW_HEIGHT) + WEEKLY_BOTTOM_PADDING;
+        const todayWeekIndex = indexOfWeekForDate(weeklyBand, model.project.currentDate);
+        const parts = [
+            `<svg xmlns="http://www.w3.org/2000/svg" width="${svgWidth}" height="${svgHeight}" viewBox="0 0 ${svgWidth} ${svgHeight}" role="img" aria-label="${escapeXml(model.project.name || "Project")} weekly overview">`,
+            "<style>",
+            "text { font-family: 'Hiragino Sans', 'Yu Gothic', sans-serif; fill: #1d2740; }",
+            ".title { font-size: 18px; font-weight: 700; }",
+            ".meta { font-size: 12px; fill: #5b6370; }",
+            ".monthAxis { font-size: 13px; font-weight: 700; fill: #475467; }",
+            ".weekAxis { font-size: 10px; fill: #667085; }",
+            ".label { font-size: 13px; }",
+            ".phaseLabel { font-size: 13px; font-weight: 700; }",
+            ".grid { stroke: #c9d3e1; stroke-width: 1; }",
+            ".today { stroke: #ff6b5a; stroke-width: 2; }",
+            ".monthBoundary { stroke: #98a2b3; stroke-width: 1.5; }",
+            "</style>",
+            `<rect x="0" y="0" width="${svgWidth}" height="${svgHeight}" fill="#ffffff"/>`,
+            `<text class="title" x="${chartOriginX + (chartWidth / 2)}" y="${WEEKLY_TOP_PADDING + 18}" text-anchor="middle">${escapeXml(model.project.name || "-")} weekly overview</text>`,
+            `<text class="meta" x="${chartOriginX + (chartWidth / 2)}" y="${WEEKLY_TOP_PADDING + 40}" text-anchor="middle">${escapeXml(`project range ${String(model.project.startDate || "").slice(0, 10)} - ${String(model.project.finishDate || "").slice(0, 10)}`)}</text>`
+        ];
+        const chartOriginY = WEEKLY_TOP_PADDING + WEEKLY_HEADER_HEIGHT;
+        const monthSpans = buildWeeklyMonthSpans(weeklyBand);
+        for (const span of monthSpans) {
+            const x = chartOriginX + (span.startIndex * WEEK_WIDTH);
+            const width = (span.endIndex - span.startIndex + 1) * WEEK_WIDTH;
+            parts.push(`<text class="monthAxis" x="${x + (width / 2)}" y="${WEEKLY_TOP_PADDING + 66}" text-anchor="middle">${escapeXml(span.monthKey)}</text>`);
+            parts.push(`<line class="monthBoundary" x1="${x}" y1="${WEEKLY_TOP_PADDING + 72}" x2="${x}" y2="${svgHeight - WEEKLY_BOTTOM_PADDING}" />`);
+        }
+        parts.push(`<line class="monthBoundary" x1="${chartOriginX + chartWidth}" y1="${WEEKLY_TOP_PADDING + 72}" x2="${chartOriginX + chartWidth}" y2="${svgHeight - WEEKLY_BOTTOM_PADDING}" />`);
+        for (let index = 0; index < weeklyBand.length; index += 1) {
+            const week = weeklyBand[index];
+            const x = chartOriginX + (index * WEEK_WIDTH);
+            parts.push(`<line class="grid" x1="${x}" y1="${WEEKLY_TOP_PADDING + 72}" x2="${x}" y2="${svgHeight - WEEKLY_BOTTOM_PADDING}" />`);
+            parts.push(`<text class="weekAxis" x="${x + (WEEK_WIDTH / 2)}" y="${WEEKLY_TOP_PADDING + 86}" text-anchor="middle">${escapeXml(formatWeeklyAxisLabel(week.startDay))}</text>`);
+        }
+        if (todayWeekIndex >= 0) {
+            const todayX = chartOriginX + (todayWeekIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2);
+            parts.push(`<line class="today" x1="${todayX}" y1="${WEEKLY_TOP_PADDING + 72}" x2="${todayX}" y2="${svgHeight - WEEKLY_BOTTOM_PADDING}" />`);
+        }
+        for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
+            const row = rows[rowIndex];
+            const rowY = chartOriginY + row.y;
+            if (row.startIndex === null || row.endIndex === null) {
+                const fallbackLabelPlacement = labelPlacements[rowIndex];
+                parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${fallbackLabelPlacement.x}" y="${rowY + 24}" text-anchor="${fallbackLabelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
+                continue;
+            }
+            const barX = chartOriginX + (row.startIndex * WEEK_WIDTH) + 4;
+            const barWidth = Math.max(10, ((row.endIndex - row.startIndex + 1) * WEEK_WIDTH) - 8);
+            const barY = rowY + 8;
+            if (row.kind === "milestone") {
+                const centerX = chartOriginX + (row.startIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2);
+                const centerY = rowY + (ROW_HEIGHT / 2);
+                const isCompleted = (row.task.percentComplete || 0) >= 100;
+                const fill = isCompleted ? "#d9efff" : "#ffffff";
+                parts.push(`<polygon points="${centerX},${centerY - 11} ${centerX + 11},${centerY} ${centerX},${centerY + 11} ${centerX - 11},${centerY}" fill="${fill}" stroke="#4f95d6" stroke-width="3"/>`);
+            }
+            else if (row.kind === "phase") {
+                const lineY = rowY + (ROW_HEIGHT / 2);
+                const startX = barX;
+                const endX = barX + barWidth;
+                const trackStroke = "#8eb9ea";
+                const progressStroke = "#2f79d0";
+                const phaseStrokeWidth = 3;
+                const progressEndX = startX + Math.max(0, Math.min(barWidth, Math.round(barWidth * (Math.max(0, Math.min(100, row.task.percentComplete || 0)) / 100))));
+                parts.push(`<line x1="${startX}" y1="${lineY}" x2="${endX}" y2="${lineY}" stroke="${trackStroke}" stroke-width="${phaseStrokeWidth}" stroke-linecap="round"/>`);
+                if (progressEndX > startX) {
+                    parts.push(`<line x1="${startX}" y1="${lineY}" x2="${progressEndX}" y2="${lineY}" stroke="${progressStroke}" stroke-width="${phaseStrokeWidth}" stroke-linecap="round"/>`);
+                }
+            }
+            else {
+                const trackFill = "#d9efff";
+                const trackStroke = "#4f95d6";
+                const progressFill = "#3f86d8";
+                parts.push(`<rect x="${barX}" y="${barY}" width="${barWidth}" height="22" rx="4" fill="${trackFill}" stroke="${trackStroke}" stroke-width="3"/>`);
+                const progressWidth = Math.max(0, Math.min(barWidth, Math.round(barWidth * (Math.max(0, Math.min(100, row.task.percentComplete || 0)) / 100))));
+                if (progressWidth > 0) {
+                    parts.push(`<rect x="${barX}" y="${barY}" width="${progressWidth}" height="22" rx="4" fill="${progressFill}" stroke="none"/>`);
+                }
+            }
+            const labelPlacement = labelPlacements[rowIndex];
+            parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelPlacement.x}" y="${rowY + 24}" text-anchor="${labelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
         }
         parts.push("</svg>");
         return parts.join("");
@@ -13033,6 +13176,16 @@ if (!customElements.get("lht-page-menu")) {
             y: index * ROW_HEIGHT
         }));
     }
+    function buildWeeklyTaskRows(tasks, weeklyBand) {
+        return tasks.map((task, index) => ({
+            task,
+            label: task.name || "-",
+            kind: task.summary ? "phase" : (task.milestone ? "milestone" : "task"),
+            startIndex: indexOfWeekForDate(weeklyBand, task.start),
+            endIndex: task.milestone ? indexOfWeekForDate(weeklyBand, task.start) : indexOfWeekForDate(weeklyBand, task.finish),
+            y: index * ROW_HEIGHT
+        }));
+    }
     function formatTaskLabel(task, labelMode) {
         if (labelMode === "list") {
             return `${"　".repeat(Math.max(0, task.outlineLevel - 1))}${task.name || "-"}`;
@@ -13061,7 +13214,44 @@ if (!customElements.get("lht-page-menu")) {
         const basePerChar = isPhase ? 14 : 13;
         return Math.max(48, Math.ceil(String(label || "").length * basePerChar));
     }
+    function shouldUseDailyOnBarLabel(row, bandLength, labelMode) {
+        if (labelMode !== "near") {
+            return false;
+        }
+        if (row.kind === "milestone") {
+            return false;
+        }
+        if (row.startIndex === null || row.endIndex === null || bandLength <= 0) {
+            return false;
+        }
+        return row.startIndex === 0 && row.endIndex === bandLength - 1;
+    }
+    function resolveWeeklyLabelPlacement(row, chartOriginX, chartWidth) {
+        if (row.startIndex === null || row.endIndex === null) {
+            return { x: chartOriginX + 10, anchor: "start", width: estimateLabelWidth(row.label, row.kind === "phase") };
+        }
+        const textWidth = estimateLabelWidth(row.label, row.kind === "phase");
+        const gap = 10;
+        const shapeStartX = row.kind === "milestone"
+            ? chartOriginX + (row.startIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2) - 11
+            : chartOriginX + (row.startIndex * WEEK_WIDTH) + 4;
+        const shapeEndX = row.kind === "milestone"
+            ? chartOriginX + (row.startIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2) + 11
+            : chartOriginX + (row.endIndex * WEEK_WIDTH) + WEEK_WIDTH - 4;
+        const chartMidX = chartOriginX + (chartWidth / 2);
+        if (shapeEndX <= chartMidX) {
+            return { x: shapeEndX + gap, anchor: "start", width: textWidth };
+        }
+        return { x: Math.max(textWidth, shapeStartX - gap), anchor: "end", width: textWidth };
+    }
     function formatSvgAxisDate(day) {
+        const match = day.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+        if (!match) {
+            return day;
+        }
+        return `${Number(match[2])}/${Number(match[3])}`;
+    }
+    function formatWeeklyAxisLabel(day) {
         const match = day.match(/^(\d{4})-(\d{2})-(\d{2})$/);
         if (!match) {
             return day;
@@ -13075,6 +13265,19 @@ if (!customElements.get("lht-page-menu")) {
         }
         const index = dateBand.indexOf(key);
         return index >= 0 ? index : null;
+    }
+    function indexOfWeekForDate(weeklyBand, value) {
+        const key = String(value || "").slice(0, 10);
+        if (!key) {
+            return null;
+        }
+        for (let index = 0; index < weeklyBand.length; index += 1) {
+            const week = weeklyBand[index];
+            if (week.startDay <= key && key <= week.endDay) {
+                return index;
+            }
+        }
+        return null;
     }
     function collectWbsHolidayDates(model) {
         const holidaySet = new Set();
@@ -13152,6 +13355,46 @@ if (!customElements.get("lht-page-menu")) {
             cursor.setDate(cursor.getDate() + 1);
         }
         return days;
+    }
+    function buildWeeklyBand(startDate, finishDate) {
+        const start = parseDateOnly(startDate);
+        const finish = parseDateOnly(finishDate);
+        if (!start || !finish || start.getTime() > finish.getTime()) {
+            return [];
+        }
+        const cursor = startOfWeekSunday(start);
+        const limit = endOfWeekSaturday(finish);
+        const weeks = [];
+        while (cursor.getTime() <= limit.getTime()) {
+            const weekStart = new Date(cursor.getTime());
+            const weekEnd = new Date(cursor.getTime());
+            weekEnd.setDate(weekEnd.getDate() + 6);
+            weeks.push({
+                startDay: formatDateOnly(weekStart),
+                endDay: formatDateOnly(weekEnd),
+                monthKey: formatMonthLabel(new Date(weekStart.getFullYear(), weekStart.getMonth(), 1))
+            });
+            cursor.setDate(cursor.getDate() + 7);
+        }
+        return weeks;
+    }
+    function buildWeeklyMonthSpans(weeklyBand) {
+        const spans = [];
+        for (let index = 0; index < weeklyBand.length; index += 1) {
+            const current = weeklyBand[index];
+            const last = spans[spans.length - 1];
+            if (last && last.monthKey === current.monthKey) {
+                last.endIndex = index;
+            }
+            else {
+                spans.push({
+                    monthKey: current.monthKey,
+                    startIndex: index,
+                    endIndex: index
+                });
+            }
+        }
+        return spans;
     }
     function buildDisplayDateBand(startDate, finishDate, baseDate, displayDaysBeforeBaseDate, displayDaysAfterBaseDate, holidaySet, nonWorkingDayTypes, useBusinessDaysForDisplayRange) {
         const fullBand = buildDateBand(startDate, finishDate);
@@ -13331,6 +13574,7 @@ if (!customElements.get("lht-page-menu")) {
     }
     globalThis.__mikuprojectNativeSvg = {
         exportNativeSvg,
+        exportWeeklyNativeSvg,
         exportMonthlyWbsCalendarSvgArchive
     };
 })();
@@ -13372,11 +13616,16 @@ if (!customElements.get("lht-page-menu")) {
     }
     let currentModel = null;
     let currentNativeSvg = "";
+    let currentWeeklyPreviewSvg = "";
+    let currentMonthlyPreviewSvg = "";
     let lastSavedXmlText = "";
     let lastSavedXmlStamp = "";
     let currentTabId = "input";
+    let currentSvgPreviewMode = "daily";
     let isXmlSourceDirty = true;
     let isRefreshingTransformTab = false;
+    const ZIP_TEXT_ENCODER = new TextEncoder();
+    const ZIP_CRC32_TABLE = buildZipCrc32Table();
     function getElement(id) {
         const element = document.getElementById(id);
         if (!element) {
@@ -13609,11 +13858,47 @@ if (!customElements.get("lht-page-menu")) {
     function setSvgPreviewMarkup(markup) {
         getElement("nativeSvgPreview").innerHTML = markup;
     }
+    function updateSvgPreviewModeButtons() {
+        const dailyButton = getElement("previewDailySvgBtn");
+        const weeklyButton = getElement("previewWeeklySvgBtn");
+        const monthlyButton = getElement("previewMonthlySvgBtn");
+        dailyButton.classList.toggle("md-button--primary", currentSvgPreviewMode === "daily");
+        dailyButton.classList.toggle("md-button--tonal", currentSvgPreviewMode !== "daily");
+        weeklyButton.classList.toggle("md-button--primary", currentSvgPreviewMode === "weekly");
+        weeklyButton.classList.toggle("md-button--tonal", currentSvgPreviewMode !== "weekly");
+        monthlyButton.classList.toggle("md-button--primary", currentSvgPreviewMode === "monthly");
+        monthlyButton.classList.toggle("md-button--tonal", currentSvgPreviewMode !== "monthly");
+    }
+    function renderCurrentSvgPreviewMarkup() {
+        if (currentSvgPreviewMode === "weekly") {
+            if (currentWeeklyPreviewSvg) {
+                setSvgPreviewMarkup(currentWeeklyPreviewSvg);
+                return;
+            }
+            setSvgPreviewMarkup(`<div class="md-preview-empty">Weekly SVG を生成すると、ここにプレビューを表示します。</div>`);
+            return;
+        }
+        if (currentSvgPreviewMode === "monthly") {
+            if (currentMonthlyPreviewSvg) {
+                setSvgPreviewMarkup(currentMonthlyPreviewSvg);
+                return;
+            }
+            setSvgPreviewMarkup(`<div class="md-preview-empty">Monthly Calendar SVG を生成すると、ここにプレビューを表示します。</div>`);
+            return;
+        }
+        if (currentNativeSvg) {
+            setSvgPreviewMarkup(currentNativeSvg);
+            return;
+        }
+        setSvgPreviewMarkup(`<div class="md-preview-empty">Daily SVG を生成すると、ここにプレビューを表示します。</div>`);
+    }
     function updateSvgButton() {
         const nativeSvgButton = getElement("downloadSvgBtn");
+        const weeklySvgButton = getElement("downloadWeeklySvgBtn");
         const monthlyWbsButton = getElement("downloadMonthlyWbsSvgZipBtn");
         const disabled = !currentModel;
         nativeSvgButton.disabled = disabled;
+        weeklySvgButton.disabled = disabled;
         monthlyWbsButton.disabled = disabled;
     }
     function buildCurrentWbsOptions(model) {
@@ -13636,16 +13921,196 @@ if (!customElements.get("lht-page-menu")) {
         document.body.removeChild(link);
         window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
     }
+    function formatTimestampCompact(date) {
+        return [
+            date.getFullYear(),
+            String(date.getMonth() + 1).padStart(2, "0"),
+            String(date.getDate()).padStart(2, "0"),
+            String(date.getHours()).padStart(2, "0"),
+            String(date.getMinutes()).padStart(2, "0")
+        ].join("");
+    }
+    function encodeUtf8(value) {
+        return ZIP_TEXT_ENCODER.encode(value);
+    }
+    function concatUint8Arrays(parts) {
+        const totalLength = parts.reduce((sum, part) => sum + part.byteLength, 0);
+        const result = new Uint8Array(totalLength);
+        let offset = 0;
+        for (const part of parts) {
+            result.set(part, offset);
+            offset += part.byteLength;
+        }
+        return result;
+    }
+    function computeZipCrc32(bytes) {
+        let crc = 0xffffffff;
+        for (const byte of bytes) {
+            crc = (crc >>> 8) ^ ZIP_CRC32_TABLE[(crc ^ byte) & 0xff];
+        }
+        return (crc ^ 0xffffffff) >>> 0;
+    }
+    function buildZipCrc32Table() {
+        const table = new Uint32Array(256);
+        for (let index = 0; index < 256; index += 1) {
+            let value = index;
+            for (let bit = 0; bit < 8; bit += 1) {
+                value = (value & 1) !== 0 ? (0xedb88320 ^ (value >>> 1)) : (value >>> 1);
+            }
+            table[index] = value >>> 0;
+        }
+        return table;
+    }
+    function packZipEntries(entries) {
+        const localParts = [];
+        const centralParts = [];
+        let offset = 0;
+        const zipFixedModTime = 0;
+        const zipFixedModDate = ((2025 - 1980) << 9) | (1 << 5) | 1;
+        for (const entry of entries) {
+            const nameBytes = encodeUtf8(entry.name);
+            const crc32 = computeZipCrc32(entry.data);
+            const localHeader = new Uint8Array(30 + nameBytes.length);
+            const localView = new DataView(localHeader.buffer);
+            localView.setUint32(0, 0x04034b50, true);
+            localView.setUint16(4, 20, true);
+            localView.setUint16(6, 0, true);
+            localView.setUint16(8, 0, true);
+            localView.setUint16(10, zipFixedModTime, true);
+            localView.setUint16(12, zipFixedModDate, true);
+            localView.setUint32(14, crc32, true);
+            localView.setUint32(18, entry.data.byteLength, true);
+            localView.setUint32(22, entry.data.byteLength, true);
+            localView.setUint16(26, nameBytes.length, true);
+            localView.setUint16(28, 0, true);
+            localHeader.set(nameBytes, 30);
+            const centralHeader = new Uint8Array(46 + nameBytes.length);
+            const centralView = new DataView(centralHeader.buffer);
+            centralView.setUint32(0, 0x02014b50, true);
+            centralView.setUint16(4, 20, true);
+            centralView.setUint16(6, 20, true);
+            centralView.setUint16(8, 0, true);
+            centralView.setUint16(10, 0, true);
+            centralView.setUint16(12, zipFixedModTime, true);
+            centralView.setUint16(14, zipFixedModDate, true);
+            centralView.setUint32(16, crc32, true);
+            centralView.setUint32(20, entry.data.byteLength, true);
+            centralView.setUint32(24, entry.data.byteLength, true);
+            centralView.setUint16(28, nameBytes.length, true);
+            centralView.setUint16(30, 0, true);
+            centralView.setUint16(32, 0, true);
+            centralView.setUint16(34, 0, true);
+            centralView.setUint16(36, 0, true);
+            centralView.setUint32(38, 0, true);
+            centralView.setUint32(42, offset, true);
+            centralHeader.set(nameBytes, 46);
+            localParts.push(localHeader, entry.data);
+            centralParts.push(centralHeader);
+            offset += localHeader.byteLength + entry.data.byteLength;
+        }
+        const centralDirectoryOffset = offset;
+        const centralDirectorySize = centralParts.reduce((sum, part) => sum + part.byteLength, 0);
+        const endOfCentralDirectory = new Uint8Array(22);
+        const endView = new DataView(endOfCentralDirectory.buffer);
+        endView.setUint32(0, 0x06054b50, true);
+        endView.setUint16(4, 0, true);
+        endView.setUint16(6, 0, true);
+        endView.setUint16(8, entries.length, true);
+        endView.setUint16(10, entries.length, true);
+        endView.setUint32(12, centralDirectorySize, true);
+        endView.setUint32(16, centralDirectoryOffset, true);
+        endView.setUint16(20, 0, true);
+        return concatUint8Arrays([...localParts, ...centralParts, endOfCentralDirectory]);
+    }
     async function renderSvgPreview() {
         if (!currentModel) {
             currentNativeSvg = "";
+            currentWeeklyPreviewSvg = "";
+            currentMonthlyPreviewSvg = "";
             updateSvgButton();
-            setSvgPreviewMarkup(`<div class="md-preview-empty">SVG を生成すると、ここにプレビューを表示します。</div>`);
+            renderCurrentSvgPreviewMarkup();
             return;
         }
-        currentNativeSvg = mikuprojectNativeSvg.exportNativeSvg(currentModel, buildCurrentWbsOptions(currentModel));
-        setSvgPreviewMarkup(currentNativeSvg);
+        const wbsOptions = buildCurrentWbsOptions(currentModel);
+        currentNativeSvg = mikuprojectNativeSvg.exportNativeSvg(currentModel, wbsOptions);
+        currentWeeklyPreviewSvg = mikuprojectNativeSvg.exportWeeklyNativeSvg(currentModel, wbsOptions);
+        const monthlyArchive = mikuprojectNativeSvg.exportMonthlyWbsCalendarSvgArchive(currentModel);
+        currentMonthlyPreviewSvg = monthlyArchive.entries.length > 0
+            ? monthlyArchive.entries.map((entry) => entry.svg).join("")
+            : "";
+        renderCurrentSvgPreviewMarkup();
         updateSvgButton();
+    }
+    function setSvgPreviewMode(mode) {
+        currentSvgPreviewMode = mode;
+        updateSvgPreviewModeButtons();
+        renderCurrentSvgPreviewMarkup();
+    }
+    function buildCurrentOutputArchive() {
+        const model = ensureCurrentModel();
+        const xmlText = syncXmlTextFromModel(model);
+        const now = new Date();
+        const stamp = formatTimestampCompact(now);
+        const dateOnlyStamp = [
+            now.getFullYear(),
+            String(now.getMonth() + 1).padStart(2, "0"),
+            String(now.getDate()).padStart(2, "0")
+        ].join("");
+        const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
+        const workbook = mikuprojectProjectXlsx.exportProjectWorkbook(model);
+        const workbookJsonText = JSON.stringify(mikuprojectProjectWorkbookJson.exportProjectWorkbookJson(model), null, 2);
+        const csvText = mikuprojectXml.exportCsvParentId(model);
+        const wbsOptions = buildCurrentWbsOptions(model);
+        const wbsWorkbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, wbsOptions);
+        const wbsMarkdown = mikuprojectWbsMarkdown.exportWbsMarkdown(model, wbsOptions);
+        const dailySvg = mikuprojectNativeSvg.exportNativeSvg(model, wbsOptions);
+        const weeklySvg = mikuprojectNativeSvg.exportWeeklyNativeSvg(model, wbsOptions);
+        const monthlyArchive = mikuprojectNativeSvg.exportMonthlyWbsCalendarSvgArchive(model);
+        const mermaidText = mikuprojectXml.exportMermaidGantt(model);
+        const projectOverview = mikuprojectXml.exportProjectOverviewView(model);
+        const phaseDetailViewsFull = (projectOverview.phases || [])
+            .map((phase) => phase === null || phase === void 0 ? void 0 : phase.uid)
+            .filter((uid) => Boolean(uid))
+            .map((phaseUid) => mikuprojectXml.exportPhaseDetailView(model, phaseUid, { mode: "full" }));
+        const aiBundle = {
+            view_type: "ai_projection_bundle",
+            project_overview_view: projectOverview,
+            phase_detail_views_full: phaseDetailViewsFull
+        };
+        const phaseDetailFull = mikuprojectXml.exportPhaseDetailView(model, undefined, { mode: "full" });
+        const entries = [
+            { name: `mikuproject-export-${stamp}.xml`, data: encodeUtf8(`${xmlText}\n`) },
+            { name: `mikuproject-export-${stamp}.xlsx`, data: codec.exportWorkbook(workbook) },
+            { name: `mikuproject-workbook-${stamp}.json`, data: encodeUtf8(`${workbookJsonText}\n`) },
+            { name: `mikuproject-export-${stamp}.csv`, data: encodeUtf8(`${csvText}\n`) },
+            { name: `mikuproject-wbs-${stamp}.xlsx`, data: codec.exportWorkbook(wbsWorkbook) },
+            { name: `mikuproject-wbs-${dateOnlyStamp}.md`, data: encodeUtf8(`${wbsMarkdown}\n`) },
+            { name: `mikuproject-wbs-daily-${stamp}.svg`, data: encodeUtf8(dailySvg) },
+            { name: `mikuproject-wbs-weekly-${stamp}.svg`, data: encodeUtf8(weeklySvg) },
+            { name: `mikuproject-wbs-mermaid-${stamp}.md`, data: encodeUtf8(`\`\`\`mermaid\n${mermaidText}\n\`\`\`\n`) },
+            { name: "mikuproject-project-overview-view.editjson", data: encodeUtf8(`${JSON.stringify(projectOverview, null, 2)}\n`) },
+            { name: "mikuproject-full-bundle.editjson", data: encodeUtf8(`${JSON.stringify(aiBundle, null, 2)}\n`) },
+            { name: "mikuproject-phase-detail-view-full.editjson", data: encodeUtf8(`${JSON.stringify(phaseDetailFull, null, 2)}\n`) }
+        ];
+        for (const entry of monthlyArchive.entries) {
+            const shortFileName = entry.fileName.replace(/^mikuproject-monthly-wbs-calendar-/, "");
+            entries.push({
+                name: `monthly-calendar/${shortFileName}`,
+                data: encodeUtf8(entry.svg)
+            });
+        }
+        return {
+            fileName: `mikuproject-all-${stamp}.zip`,
+            zipBytes: packZipEntries(entries),
+            entryCount: entries.length
+        };
+    }
+    function downloadAllOutputs() {
+        const archive = buildCurrentOutputArchive();
+        downloadBlob(new Blob([archive.zipBytes], { type: "application/zip" }), archive.fileName);
+        setStatus(`All 出力を保存しました (${archive.entryCount} 件, ZIP)`);
+        showToast("All を保存しました");
+        setActiveTab("output");
     }
     function setStatus(message) {
         getElement("statusMessage").textContent = message;
@@ -14487,9 +14952,30 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             String(now.getHours()).padStart(2, "0"),
             String(now.getMinutes()).padStart(2, "0")
         ].join("");
-        downloadBlob(new Blob([currentNativeSvg], { type: "image/svg+xml;charset=utf-8" }), `mikuproject-wbs-${stamp}.svg`);
-        setStatus("SVG を保存しました");
-        showToast("SVG を保存しました");
+        downloadBlob(new Blob([currentNativeSvg], { type: "image/svg+xml;charset=utf-8" }), `mikuproject-wbs-daily-${stamp}.svg`);
+        setStatus("Daily SVG を保存しました");
+        showToast("Daily SVG を保存しました");
+        setActiveTab("output");
+    }
+    function downloadCurrentWeeklySvg() {
+        const model = ensureCurrentModel();
+        syncXmlTextFromModel(model);
+        const weeklySvg = mikuprojectNativeSvg.exportWeeklyNativeSvg(model, buildCurrentWbsOptions(model));
+        if (!weeklySvg) {
+            setStatus("出力する Weekly SVG がありません");
+            return;
+        }
+        const now = new Date();
+        const stamp = [
+            now.getFullYear(),
+            String(now.getMonth() + 1).padStart(2, "0"),
+            String(now.getDate()).padStart(2, "0"),
+            String(now.getHours()).padStart(2, "0"),
+            String(now.getMinutes()).padStart(2, "0")
+        ].join("");
+        downloadBlob(new Blob([weeklySvg], { type: "image/svg+xml;charset=utf-8" }), `mikuproject-wbs-weekly-${stamp}.svg`);
+        setStatus("Weekly SVG を保存しました");
+        showToast("Weekly SVG を保存しました");
         setActiveTab("output");
     }
     function downloadCurrentMonthlyWbsSvgZip() {
@@ -14508,8 +14994,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             String(now.getMinutes()).padStart(2, "0")
         ].join("");
         downloadBlob(new Blob([archive.zipBytes], { type: "application/zip" }), `mikuproject-monthly-wbs-calendar-${stamp}.zip`);
-        setStatus(`Monthly WBS SVG を保存しました (${archive.entries.length} か月分, ZIP)`);
-        showToast("Monthly WBS SVG を保存しました");
+        setStatus(`Monthly Calendar SVG を保存しました (${archive.entries.length} か月分, ZIP)`);
+        showToast("Monthly Calendar SVG を保存しました");
         setActiveTab("output");
     }
     function downloadCurrentMermaidMarkdown() {
@@ -14594,11 +15080,38 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             input.value = "";
             input.click();
         });
+        getElement("downloadAllOutputsBtn").addEventListener("click", () => {
+            try {
+                downloadAllOutputs();
+            }
+            catch (error) {
+                console.error("[mikuproject] all outputs download failed", error);
+                setStatus(error instanceof Error ? error.message : "All 出力保存に失敗しました");
+            }
+        });
+        getElement("previewDailySvgBtn").addEventListener("click", () => {
+            setSvgPreviewMode("daily");
+        });
+        getElement("previewWeeklySvgBtn").addEventListener("click", () => {
+            setSvgPreviewMode("weekly");
+        });
+        getElement("previewMonthlySvgBtn").addEventListener("click", () => {
+            setSvgPreviewMode("monthly");
+        });
         getElement("downloadSvgBtn").addEventListener("click", () => {
             void downloadCurrentSvg().catch((error) => {
                 console.error("[mikuproject] native SVG download failed", error);
                 setStatus(error instanceof Error ? error.message : "SVG 保存に失敗しました");
             });
+        });
+        getElement("downloadWeeklySvgBtn").addEventListener("click", () => {
+            try {
+                downloadCurrentWeeklySvg();
+            }
+            catch (error) {
+                console.error("[mikuproject] weekly SVG download failed", error);
+                setStatus(error instanceof Error ? error.message : "Weekly SVG 保存に失敗しました");
+            }
         });
         getElement("downloadMonthlyWbsSvgZipBtn").addEventListener("click", () => {
             try {
@@ -14753,6 +15266,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         renderValidationIssues([]);
         renderImportWarnings([]);
         renderXlsxImportSummary([]);
+        updateSvgPreviewModeButtons();
         updateSvgButton();
         loadSample();
     }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -33,11 +33,16 @@
     }
     let currentModel = null;
     let currentNativeSvg = "";
+    let currentWeeklyPreviewSvg = "";
+    let currentMonthlyPreviewSvg = "";
     let lastSavedXmlText = "";
     let lastSavedXmlStamp = "";
     let currentTabId = "input";
+    let currentSvgPreviewMode = "daily";
     let isXmlSourceDirty = true;
     let isRefreshingTransformTab = false;
+    const ZIP_TEXT_ENCODER = new TextEncoder();
+    const ZIP_CRC32_TABLE = buildZipCrc32Table();
     function getElement(id) {
         const element = document.getElementById(id);
         if (!element) {
@@ -270,11 +275,47 @@
     function setSvgPreviewMarkup(markup) {
         getElement("nativeSvgPreview").innerHTML = markup;
     }
+    function updateSvgPreviewModeButtons() {
+        const dailyButton = getElement("previewDailySvgBtn");
+        const weeklyButton = getElement("previewWeeklySvgBtn");
+        const monthlyButton = getElement("previewMonthlySvgBtn");
+        dailyButton.classList.toggle("md-button--primary", currentSvgPreviewMode === "daily");
+        dailyButton.classList.toggle("md-button--tonal", currentSvgPreviewMode !== "daily");
+        weeklyButton.classList.toggle("md-button--primary", currentSvgPreviewMode === "weekly");
+        weeklyButton.classList.toggle("md-button--tonal", currentSvgPreviewMode !== "weekly");
+        monthlyButton.classList.toggle("md-button--primary", currentSvgPreviewMode === "monthly");
+        monthlyButton.classList.toggle("md-button--tonal", currentSvgPreviewMode !== "monthly");
+    }
+    function renderCurrentSvgPreviewMarkup() {
+        if (currentSvgPreviewMode === "weekly") {
+            if (currentWeeklyPreviewSvg) {
+                setSvgPreviewMarkup(currentWeeklyPreviewSvg);
+                return;
+            }
+            setSvgPreviewMarkup(`<div class="md-preview-empty">Weekly SVG を生成すると、ここにプレビューを表示します。</div>`);
+            return;
+        }
+        if (currentSvgPreviewMode === "monthly") {
+            if (currentMonthlyPreviewSvg) {
+                setSvgPreviewMarkup(currentMonthlyPreviewSvg);
+                return;
+            }
+            setSvgPreviewMarkup(`<div class="md-preview-empty">Monthly Calendar SVG を生成すると、ここにプレビューを表示します。</div>`);
+            return;
+        }
+        if (currentNativeSvg) {
+            setSvgPreviewMarkup(currentNativeSvg);
+            return;
+        }
+        setSvgPreviewMarkup(`<div class="md-preview-empty">Daily SVG を生成すると、ここにプレビューを表示します。</div>`);
+    }
     function updateSvgButton() {
         const nativeSvgButton = getElement("downloadSvgBtn");
+        const weeklySvgButton = getElement("downloadWeeklySvgBtn");
         const monthlyWbsButton = getElement("downloadMonthlyWbsSvgZipBtn");
         const disabled = !currentModel;
         nativeSvgButton.disabled = disabled;
+        weeklySvgButton.disabled = disabled;
         monthlyWbsButton.disabled = disabled;
     }
     function buildCurrentWbsOptions(model) {
@@ -297,16 +338,196 @@
         document.body.removeChild(link);
         window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
     }
+    function formatTimestampCompact(date) {
+        return [
+            date.getFullYear(),
+            String(date.getMonth() + 1).padStart(2, "0"),
+            String(date.getDate()).padStart(2, "0"),
+            String(date.getHours()).padStart(2, "0"),
+            String(date.getMinutes()).padStart(2, "0")
+        ].join("");
+    }
+    function encodeUtf8(value) {
+        return ZIP_TEXT_ENCODER.encode(value);
+    }
+    function concatUint8Arrays(parts) {
+        const totalLength = parts.reduce((sum, part) => sum + part.byteLength, 0);
+        const result = new Uint8Array(totalLength);
+        let offset = 0;
+        for (const part of parts) {
+            result.set(part, offset);
+            offset += part.byteLength;
+        }
+        return result;
+    }
+    function computeZipCrc32(bytes) {
+        let crc = 0xffffffff;
+        for (const byte of bytes) {
+            crc = (crc >>> 8) ^ ZIP_CRC32_TABLE[(crc ^ byte) & 0xff];
+        }
+        return (crc ^ 0xffffffff) >>> 0;
+    }
+    function buildZipCrc32Table() {
+        const table = new Uint32Array(256);
+        for (let index = 0; index < 256; index += 1) {
+            let value = index;
+            for (let bit = 0; bit < 8; bit += 1) {
+                value = (value & 1) !== 0 ? (0xedb88320 ^ (value >>> 1)) : (value >>> 1);
+            }
+            table[index] = value >>> 0;
+        }
+        return table;
+    }
+    function packZipEntries(entries) {
+        const localParts = [];
+        const centralParts = [];
+        let offset = 0;
+        const zipFixedModTime = 0;
+        const zipFixedModDate = ((2025 - 1980) << 9) | (1 << 5) | 1;
+        for (const entry of entries) {
+            const nameBytes = encodeUtf8(entry.name);
+            const crc32 = computeZipCrc32(entry.data);
+            const localHeader = new Uint8Array(30 + nameBytes.length);
+            const localView = new DataView(localHeader.buffer);
+            localView.setUint32(0, 0x04034b50, true);
+            localView.setUint16(4, 20, true);
+            localView.setUint16(6, 0, true);
+            localView.setUint16(8, 0, true);
+            localView.setUint16(10, zipFixedModTime, true);
+            localView.setUint16(12, zipFixedModDate, true);
+            localView.setUint32(14, crc32, true);
+            localView.setUint32(18, entry.data.byteLength, true);
+            localView.setUint32(22, entry.data.byteLength, true);
+            localView.setUint16(26, nameBytes.length, true);
+            localView.setUint16(28, 0, true);
+            localHeader.set(nameBytes, 30);
+            const centralHeader = new Uint8Array(46 + nameBytes.length);
+            const centralView = new DataView(centralHeader.buffer);
+            centralView.setUint32(0, 0x02014b50, true);
+            centralView.setUint16(4, 20, true);
+            centralView.setUint16(6, 20, true);
+            centralView.setUint16(8, 0, true);
+            centralView.setUint16(10, 0, true);
+            centralView.setUint16(12, zipFixedModTime, true);
+            centralView.setUint16(14, zipFixedModDate, true);
+            centralView.setUint32(16, crc32, true);
+            centralView.setUint32(20, entry.data.byteLength, true);
+            centralView.setUint32(24, entry.data.byteLength, true);
+            centralView.setUint16(28, nameBytes.length, true);
+            centralView.setUint16(30, 0, true);
+            centralView.setUint16(32, 0, true);
+            centralView.setUint16(34, 0, true);
+            centralView.setUint16(36, 0, true);
+            centralView.setUint32(38, 0, true);
+            centralView.setUint32(42, offset, true);
+            centralHeader.set(nameBytes, 46);
+            localParts.push(localHeader, entry.data);
+            centralParts.push(centralHeader);
+            offset += localHeader.byteLength + entry.data.byteLength;
+        }
+        const centralDirectoryOffset = offset;
+        const centralDirectorySize = centralParts.reduce((sum, part) => sum + part.byteLength, 0);
+        const endOfCentralDirectory = new Uint8Array(22);
+        const endView = new DataView(endOfCentralDirectory.buffer);
+        endView.setUint32(0, 0x06054b50, true);
+        endView.setUint16(4, 0, true);
+        endView.setUint16(6, 0, true);
+        endView.setUint16(8, entries.length, true);
+        endView.setUint16(10, entries.length, true);
+        endView.setUint32(12, centralDirectorySize, true);
+        endView.setUint32(16, centralDirectoryOffset, true);
+        endView.setUint16(20, 0, true);
+        return concatUint8Arrays([...localParts, ...centralParts, endOfCentralDirectory]);
+    }
     async function renderSvgPreview() {
         if (!currentModel) {
             currentNativeSvg = "";
+            currentWeeklyPreviewSvg = "";
+            currentMonthlyPreviewSvg = "";
             updateSvgButton();
-            setSvgPreviewMarkup(`<div class="md-preview-empty">SVG を生成すると、ここにプレビューを表示します。</div>`);
+            renderCurrentSvgPreviewMarkup();
             return;
         }
-        currentNativeSvg = mikuprojectNativeSvg.exportNativeSvg(currentModel, buildCurrentWbsOptions(currentModel));
-        setSvgPreviewMarkup(currentNativeSvg);
+        const wbsOptions = buildCurrentWbsOptions(currentModel);
+        currentNativeSvg = mikuprojectNativeSvg.exportNativeSvg(currentModel, wbsOptions);
+        currentWeeklyPreviewSvg = mikuprojectNativeSvg.exportWeeklyNativeSvg(currentModel, wbsOptions);
+        const monthlyArchive = mikuprojectNativeSvg.exportMonthlyWbsCalendarSvgArchive(currentModel);
+        currentMonthlyPreviewSvg = monthlyArchive.entries.length > 0
+            ? monthlyArchive.entries.map((entry) => entry.svg).join("")
+            : "";
+        renderCurrentSvgPreviewMarkup();
         updateSvgButton();
+    }
+    function setSvgPreviewMode(mode) {
+        currentSvgPreviewMode = mode;
+        updateSvgPreviewModeButtons();
+        renderCurrentSvgPreviewMarkup();
+    }
+    function buildCurrentOutputArchive() {
+        const model = ensureCurrentModel();
+        const xmlText = syncXmlTextFromModel(model);
+        const now = new Date();
+        const stamp = formatTimestampCompact(now);
+        const dateOnlyStamp = [
+            now.getFullYear(),
+            String(now.getMonth() + 1).padStart(2, "0"),
+            String(now.getDate()).padStart(2, "0")
+        ].join("");
+        const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
+        const workbook = mikuprojectProjectXlsx.exportProjectWorkbook(model);
+        const workbookJsonText = JSON.stringify(mikuprojectProjectWorkbookJson.exportProjectWorkbookJson(model), null, 2);
+        const csvText = mikuprojectXml.exportCsvParentId(model);
+        const wbsOptions = buildCurrentWbsOptions(model);
+        const wbsWorkbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, wbsOptions);
+        const wbsMarkdown = mikuprojectWbsMarkdown.exportWbsMarkdown(model, wbsOptions);
+        const dailySvg = mikuprojectNativeSvg.exportNativeSvg(model, wbsOptions);
+        const weeklySvg = mikuprojectNativeSvg.exportWeeklyNativeSvg(model, wbsOptions);
+        const monthlyArchive = mikuprojectNativeSvg.exportMonthlyWbsCalendarSvgArchive(model);
+        const mermaidText = mikuprojectXml.exportMermaidGantt(model);
+        const projectOverview = mikuprojectXml.exportProjectOverviewView(model);
+        const phaseDetailViewsFull = (projectOverview.phases || [])
+            .map((phase) => phase === null || phase === void 0 ? void 0 : phase.uid)
+            .filter((uid) => Boolean(uid))
+            .map((phaseUid) => mikuprojectXml.exportPhaseDetailView(model, phaseUid, { mode: "full" }));
+        const aiBundle = {
+            view_type: "ai_projection_bundle",
+            project_overview_view: projectOverview,
+            phase_detail_views_full: phaseDetailViewsFull
+        };
+        const phaseDetailFull = mikuprojectXml.exportPhaseDetailView(model, undefined, { mode: "full" });
+        const entries = [
+            { name: `mikuproject-export-${stamp}.xml`, data: encodeUtf8(`${xmlText}\n`) },
+            { name: `mikuproject-export-${stamp}.xlsx`, data: codec.exportWorkbook(workbook) },
+            { name: `mikuproject-workbook-${stamp}.json`, data: encodeUtf8(`${workbookJsonText}\n`) },
+            { name: `mikuproject-export-${stamp}.csv`, data: encodeUtf8(`${csvText}\n`) },
+            { name: `mikuproject-wbs-${stamp}.xlsx`, data: codec.exportWorkbook(wbsWorkbook) },
+            { name: `mikuproject-wbs-${dateOnlyStamp}.md`, data: encodeUtf8(`${wbsMarkdown}\n`) },
+            { name: `mikuproject-wbs-daily-${stamp}.svg`, data: encodeUtf8(dailySvg) },
+            { name: `mikuproject-wbs-weekly-${stamp}.svg`, data: encodeUtf8(weeklySvg) },
+            { name: `mikuproject-wbs-mermaid-${stamp}.md`, data: encodeUtf8(`\`\`\`mermaid\n${mermaidText}\n\`\`\`\n`) },
+            { name: "mikuproject-project-overview-view.editjson", data: encodeUtf8(`${JSON.stringify(projectOverview, null, 2)}\n`) },
+            { name: "mikuproject-full-bundle.editjson", data: encodeUtf8(`${JSON.stringify(aiBundle, null, 2)}\n`) },
+            { name: "mikuproject-phase-detail-view-full.editjson", data: encodeUtf8(`${JSON.stringify(phaseDetailFull, null, 2)}\n`) }
+        ];
+        for (const entry of monthlyArchive.entries) {
+            const shortFileName = entry.fileName.replace(/^mikuproject-monthly-wbs-calendar-/, "");
+            entries.push({
+                name: `monthly-calendar/${shortFileName}`,
+                data: encodeUtf8(entry.svg)
+            });
+        }
+        return {
+            fileName: `mikuproject-all-${stamp}.zip`,
+            zipBytes: packZipEntries(entries),
+            entryCount: entries.length
+        };
+    }
+    function downloadAllOutputs() {
+        const archive = buildCurrentOutputArchive();
+        downloadBlob(new Blob([archive.zipBytes], { type: "application/zip" }), archive.fileName);
+        setStatus(`All 出力を保存しました (${archive.entryCount} 件, ZIP)`);
+        showToast("All を保存しました");
+        setActiveTab("output");
     }
     function setStatus(message) {
         getElement("statusMessage").textContent = message;
@@ -1148,9 +1369,30 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             String(now.getHours()).padStart(2, "0"),
             String(now.getMinutes()).padStart(2, "0")
         ].join("");
-        downloadBlob(new Blob([currentNativeSvg], { type: "image/svg+xml;charset=utf-8" }), `mikuproject-wbs-${stamp}.svg`);
-        setStatus("SVG を保存しました");
-        showToast("SVG を保存しました");
+        downloadBlob(new Blob([currentNativeSvg], { type: "image/svg+xml;charset=utf-8" }), `mikuproject-wbs-daily-${stamp}.svg`);
+        setStatus("Daily SVG を保存しました");
+        showToast("Daily SVG を保存しました");
+        setActiveTab("output");
+    }
+    function downloadCurrentWeeklySvg() {
+        const model = ensureCurrentModel();
+        syncXmlTextFromModel(model);
+        const weeklySvg = mikuprojectNativeSvg.exportWeeklyNativeSvg(model, buildCurrentWbsOptions(model));
+        if (!weeklySvg) {
+            setStatus("出力する Weekly SVG がありません");
+            return;
+        }
+        const now = new Date();
+        const stamp = [
+            now.getFullYear(),
+            String(now.getMonth() + 1).padStart(2, "0"),
+            String(now.getDate()).padStart(2, "0"),
+            String(now.getHours()).padStart(2, "0"),
+            String(now.getMinutes()).padStart(2, "0")
+        ].join("");
+        downloadBlob(new Blob([weeklySvg], { type: "image/svg+xml;charset=utf-8" }), `mikuproject-wbs-weekly-${stamp}.svg`);
+        setStatus("Weekly SVG を保存しました");
+        showToast("Weekly SVG を保存しました");
         setActiveTab("output");
     }
     function downloadCurrentMonthlyWbsSvgZip() {
@@ -1169,8 +1411,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             String(now.getMinutes()).padStart(2, "0")
         ].join("");
         downloadBlob(new Blob([archive.zipBytes], { type: "application/zip" }), `mikuproject-monthly-wbs-calendar-${stamp}.zip`);
-        setStatus(`Monthly WBS SVG を保存しました (${archive.entries.length} か月分, ZIP)`);
-        showToast("Monthly WBS SVG を保存しました");
+        setStatus(`Monthly Calendar SVG を保存しました (${archive.entries.length} か月分, ZIP)`);
+        showToast("Monthly Calendar SVG を保存しました");
         setActiveTab("output");
     }
     function downloadCurrentMermaidMarkdown() {
@@ -1255,11 +1497,38 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             input.value = "";
             input.click();
         });
+        getElement("downloadAllOutputsBtn").addEventListener("click", () => {
+            try {
+                downloadAllOutputs();
+            }
+            catch (error) {
+                console.error("[mikuproject] all outputs download failed", error);
+                setStatus(error instanceof Error ? error.message : "All 出力保存に失敗しました");
+            }
+        });
+        getElement("previewDailySvgBtn").addEventListener("click", () => {
+            setSvgPreviewMode("daily");
+        });
+        getElement("previewWeeklySvgBtn").addEventListener("click", () => {
+            setSvgPreviewMode("weekly");
+        });
+        getElement("previewMonthlySvgBtn").addEventListener("click", () => {
+            setSvgPreviewMode("monthly");
+        });
         getElement("downloadSvgBtn").addEventListener("click", () => {
             void downloadCurrentSvg().catch((error) => {
                 console.error("[mikuproject] native SVG download failed", error);
                 setStatus(error instanceof Error ? error.message : "SVG 保存に失敗しました");
             });
+        });
+        getElement("downloadWeeklySvgBtn").addEventListener("click", () => {
+            try {
+                downloadCurrentWeeklySvg();
+            }
+            catch (error) {
+                console.error("[mikuproject] weekly SVG download failed", error);
+                setStatus(error instanceof Error ? error.message : "Weekly SVG 保存に失敗しました");
+            }
         });
         getElement("downloadMonthlyWbsSvgZipBtn").addEventListener("click", () => {
             try {
@@ -1414,6 +1683,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         renderValidationIssues([]);
         renderImportWarnings([]);
         renderXlsxImportSummary([]);
+        updateSvgPreviewModeButtons();
         updateSvgButton();
         loadSample();
     }

--- a/src/js/native-svg.js
+++ b/src/js/native-svg.js
@@ -27,6 +27,12 @@
     const MONTHLY_MAX_LABEL_CHARS = 15;
     const ZIP_FIXED_MOD_TIME = 0;
     const ZIP_FIXED_MOD_DATE = ((2025 - 1980) << 9) | (1 << 5) | 1;
+    const WEEK_WIDTH = 38;
+    const WEEKLY_HEADER_HEIGHT = 96;
+    const WEEKLY_TOP_PADDING = 22;
+    const WEEKLY_BOTTOM_PADDING = 28;
+    const WEEKLY_LEFT_PADDING = 0;
+    const WEEKLY_RIGHT_PADDING = 0;
     function exportNativeSvg(model, options = {}) {
         const labelMode = options.labelMode || "near";
         const holidaySet = new Set([
@@ -62,6 +68,7 @@
             ".axis { font-size: 12px; fill: #5b6370; }",
             ".label { font-size: 13px; }",
             ".phaseLabel { font-size: 13px; font-weight: 700; }",
+            ".onBarLabelBg { fill: rgba(255,255,255,0.9); }",
             ".grid { stroke: #c9d3e1; stroke-width: 1; }",
             ".today { stroke: #ff6b5a; stroke-width: 2; }",
             "</style>",
@@ -86,6 +93,7 @@
         }
         for (const row of rows) {
             const rowY = chartOriginY + row.y;
+            const useOnBarLabel = shouldUseDailyOnBarLabel(row, dateBand.length, labelMode);
             if (row.startIndex !== null && row.endIndex !== null) {
                 const barX = chartOriginX + (row.startIndex * DAY_WIDTH) + 6;
                 const barWidth = Math.max(12, ((row.endIndex - row.startIndex + 1) * DAY_WIDTH) - 12);
@@ -120,9 +128,127 @@
                         parts.push(`<rect x="${barX}" y="${barY}" width="${progressWidth}" height="22" rx="4" fill="${progressFill}" stroke="none"/>`);
                     }
                 }
+                if (useOnBarLabel) {
+                    const labelText = escapeXml(formatTaskLabel(row.task, labelMode));
+                    const labelWidth = estimateLabelWidth(row.label, row.kind === "phase");
+                    const labelCenterX = barX + (barWidth / 2);
+                    const labelX = labelCenterX - (labelWidth / 2) - 8;
+                    const labelY = row.kind === "phase" ? rowY + 15 : rowY + 10;
+                    const labelHeight = row.kind === "phase" ? 18 : 20;
+                    parts.push(`<rect class="onBarLabelBg" x="${labelX}" y="${labelY}" width="${labelWidth + 16}" height="${labelHeight}" rx="4"/>`);
+                    parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelCenterX}" y="${rowY + 24}" text-anchor="middle">${labelText}</text>`);
+                    continue;
+                }
             }
             const labelPlacement = labelPlacements[rows.indexOf(row)];
             parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelPlacement.x + shiftX}" y="${rowY + 24}" text-anchor="${labelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, labelMode))}</text>`);
+        }
+        parts.push("</svg>");
+        return parts.join("");
+    }
+    function exportWeeklyNativeSvg(model, options = {}) {
+        const holidaySet = new Set([
+            ...collectWbsHolidayDates(model),
+            ...(options.holidayDates || []).map((day) => String(day || "").slice(0, 10)).filter(Boolean)
+        ]);
+        const nonWorkingDayTypes = collectProjectNonWorkingDayTypes(model);
+        const dateBand = buildDisplayDateBand(model.project.startDate, model.project.finishDate, model.project.currentDate, options.displayDaysBeforeBaseDate, options.displayDaysAfterBaseDate, holidaySet, nonWorkingDayTypes, options.useBusinessDaysForDisplayRange);
+        if (dateBand.length === 0) {
+            return exportNativeSvg(model, { ...options, labelMode: "list" });
+        }
+        const weeklyBand = buildWeeklyBand(dateBand[0], dateBand[dateBand.length - 1]);
+        const rows = buildWeeklyTaskRows(model.tasks, weeklyBand);
+        const chartWidth = weeklyBand.length * WEEK_WIDTH;
+        const chartOriginXBase = WEEKLY_LEFT_PADDING;
+        const labelPlacements = rows.map((row) => resolveWeeklyLabelPlacement(row, chartOriginXBase, chartWidth));
+        const labelMaxX = labelPlacements.reduce((max, placement) => {
+            const placementMaxX = placement.anchor === "start" ? placement.x + placement.width : placement.x;
+            return Math.max(max, placementMaxX);
+        }, chartOriginXBase + chartWidth);
+        const chartOriginX = chartOriginXBase;
+        const svgWidth = labelMaxX + WEEKLY_RIGHT_PADDING;
+        const svgHeight = WEEKLY_TOP_PADDING + WEEKLY_HEADER_HEIGHT + (rows.length * ROW_HEIGHT) + WEEKLY_BOTTOM_PADDING;
+        const todayWeekIndex = indexOfWeekForDate(weeklyBand, model.project.currentDate);
+        const parts = [
+            `<svg xmlns="http://www.w3.org/2000/svg" width="${svgWidth}" height="${svgHeight}" viewBox="0 0 ${svgWidth} ${svgHeight}" role="img" aria-label="${escapeXml(model.project.name || "Project")} weekly overview">`,
+            "<style>",
+            "text { font-family: 'Hiragino Sans', 'Yu Gothic', sans-serif; fill: #1d2740; }",
+            ".title { font-size: 18px; font-weight: 700; }",
+            ".meta { font-size: 12px; fill: #5b6370; }",
+            ".monthAxis { font-size: 13px; font-weight: 700; fill: #475467; }",
+            ".weekAxis { font-size: 10px; fill: #667085; }",
+            ".label { font-size: 13px; }",
+            ".phaseLabel { font-size: 13px; font-weight: 700; }",
+            ".grid { stroke: #c9d3e1; stroke-width: 1; }",
+            ".today { stroke: #ff6b5a; stroke-width: 2; }",
+            ".monthBoundary { stroke: #98a2b3; stroke-width: 1.5; }",
+            "</style>",
+            `<rect x="0" y="0" width="${svgWidth}" height="${svgHeight}" fill="#ffffff"/>`,
+            `<text class="title" x="${chartOriginX + (chartWidth / 2)}" y="${WEEKLY_TOP_PADDING + 18}" text-anchor="middle">${escapeXml(model.project.name || "-")} weekly overview</text>`,
+            `<text class="meta" x="${chartOriginX + (chartWidth / 2)}" y="${WEEKLY_TOP_PADDING + 40}" text-anchor="middle">${escapeXml(`project range ${String(model.project.startDate || "").slice(0, 10)} - ${String(model.project.finishDate || "").slice(0, 10)}`)}</text>`
+        ];
+        const chartOriginY = WEEKLY_TOP_PADDING + WEEKLY_HEADER_HEIGHT;
+        const monthSpans = buildWeeklyMonthSpans(weeklyBand);
+        for (const span of monthSpans) {
+            const x = chartOriginX + (span.startIndex * WEEK_WIDTH);
+            const width = (span.endIndex - span.startIndex + 1) * WEEK_WIDTH;
+            parts.push(`<text class="monthAxis" x="${x + (width / 2)}" y="${WEEKLY_TOP_PADDING + 66}" text-anchor="middle">${escapeXml(span.monthKey)}</text>`);
+            parts.push(`<line class="monthBoundary" x1="${x}" y1="${WEEKLY_TOP_PADDING + 72}" x2="${x}" y2="${svgHeight - WEEKLY_BOTTOM_PADDING}" />`);
+        }
+        parts.push(`<line class="monthBoundary" x1="${chartOriginX + chartWidth}" y1="${WEEKLY_TOP_PADDING + 72}" x2="${chartOriginX + chartWidth}" y2="${svgHeight - WEEKLY_BOTTOM_PADDING}" />`);
+        for (let index = 0; index < weeklyBand.length; index += 1) {
+            const week = weeklyBand[index];
+            const x = chartOriginX + (index * WEEK_WIDTH);
+            parts.push(`<line class="grid" x1="${x}" y1="${WEEKLY_TOP_PADDING + 72}" x2="${x}" y2="${svgHeight - WEEKLY_BOTTOM_PADDING}" />`);
+            parts.push(`<text class="weekAxis" x="${x + (WEEK_WIDTH / 2)}" y="${WEEKLY_TOP_PADDING + 86}" text-anchor="middle">${escapeXml(formatWeeklyAxisLabel(week.startDay))}</text>`);
+        }
+        if (todayWeekIndex >= 0) {
+            const todayX = chartOriginX + (todayWeekIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2);
+            parts.push(`<line class="today" x1="${todayX}" y1="${WEEKLY_TOP_PADDING + 72}" x2="${todayX}" y2="${svgHeight - WEEKLY_BOTTOM_PADDING}" />`);
+        }
+        for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
+            const row = rows[rowIndex];
+            const rowY = chartOriginY + row.y;
+            if (row.startIndex === null || row.endIndex === null) {
+                const fallbackLabelPlacement = labelPlacements[rowIndex];
+                parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${fallbackLabelPlacement.x}" y="${rowY + 24}" text-anchor="${fallbackLabelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
+                continue;
+            }
+            const barX = chartOriginX + (row.startIndex * WEEK_WIDTH) + 4;
+            const barWidth = Math.max(10, ((row.endIndex - row.startIndex + 1) * WEEK_WIDTH) - 8);
+            const barY = rowY + 8;
+            if (row.kind === "milestone") {
+                const centerX = chartOriginX + (row.startIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2);
+                const centerY = rowY + (ROW_HEIGHT / 2);
+                const isCompleted = (row.task.percentComplete || 0) >= 100;
+                const fill = isCompleted ? "#d9efff" : "#ffffff";
+                parts.push(`<polygon points="${centerX},${centerY - 11} ${centerX + 11},${centerY} ${centerX},${centerY + 11} ${centerX - 11},${centerY}" fill="${fill}" stroke="#4f95d6" stroke-width="3"/>`);
+            }
+            else if (row.kind === "phase") {
+                const lineY = rowY + (ROW_HEIGHT / 2);
+                const startX = barX;
+                const endX = barX + barWidth;
+                const trackStroke = "#8eb9ea";
+                const progressStroke = "#2f79d0";
+                const phaseStrokeWidth = 3;
+                const progressEndX = startX + Math.max(0, Math.min(barWidth, Math.round(barWidth * (Math.max(0, Math.min(100, row.task.percentComplete || 0)) / 100))));
+                parts.push(`<line x1="${startX}" y1="${lineY}" x2="${endX}" y2="${lineY}" stroke="${trackStroke}" stroke-width="${phaseStrokeWidth}" stroke-linecap="round"/>`);
+                if (progressEndX > startX) {
+                    parts.push(`<line x1="${startX}" y1="${lineY}" x2="${progressEndX}" y2="${lineY}" stroke="${progressStroke}" stroke-width="${phaseStrokeWidth}" stroke-linecap="round"/>`);
+                }
+            }
+            else {
+                const trackFill = "#d9efff";
+                const trackStroke = "#4f95d6";
+                const progressFill = "#3f86d8";
+                parts.push(`<rect x="${barX}" y="${barY}" width="${barWidth}" height="22" rx="4" fill="${trackFill}" stroke="${trackStroke}" stroke-width="3"/>`);
+                const progressWidth = Math.max(0, Math.min(barWidth, Math.round(barWidth * (Math.max(0, Math.min(100, row.task.percentComplete || 0)) / 100))));
+                if (progressWidth > 0) {
+                    parts.push(`<rect x="${barX}" y="${barY}" width="${progressWidth}" height="22" rx="4" fill="${progressFill}" stroke="none"/>`);
+                }
+            }
+            const labelPlacement = labelPlacements[rowIndex];
+            parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelPlacement.x}" y="${rowY + 24}" text-anchor="${labelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
         }
         parts.push("</svg>");
         return parts.join("");
@@ -309,6 +435,16 @@
             y: index * ROW_HEIGHT
         }));
     }
+    function buildWeeklyTaskRows(tasks, weeklyBand) {
+        return tasks.map((task, index) => ({
+            task,
+            label: task.name || "-",
+            kind: task.summary ? "phase" : (task.milestone ? "milestone" : "task"),
+            startIndex: indexOfWeekForDate(weeklyBand, task.start),
+            endIndex: task.milestone ? indexOfWeekForDate(weeklyBand, task.start) : indexOfWeekForDate(weeklyBand, task.finish),
+            y: index * ROW_HEIGHT
+        }));
+    }
     function formatTaskLabel(task, labelMode) {
         if (labelMode === "list") {
             return `${"　".repeat(Math.max(0, task.outlineLevel - 1))}${task.name || "-"}`;
@@ -337,7 +473,44 @@
         const basePerChar = isPhase ? 14 : 13;
         return Math.max(48, Math.ceil(String(label || "").length * basePerChar));
     }
+    function shouldUseDailyOnBarLabel(row, bandLength, labelMode) {
+        if (labelMode !== "near") {
+            return false;
+        }
+        if (row.kind === "milestone") {
+            return false;
+        }
+        if (row.startIndex === null || row.endIndex === null || bandLength <= 0) {
+            return false;
+        }
+        return row.startIndex === 0 && row.endIndex === bandLength - 1;
+    }
+    function resolveWeeklyLabelPlacement(row, chartOriginX, chartWidth) {
+        if (row.startIndex === null || row.endIndex === null) {
+            return { x: chartOriginX + 10, anchor: "start", width: estimateLabelWidth(row.label, row.kind === "phase") };
+        }
+        const textWidth = estimateLabelWidth(row.label, row.kind === "phase");
+        const gap = 10;
+        const shapeStartX = row.kind === "milestone"
+            ? chartOriginX + (row.startIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2) - 11
+            : chartOriginX + (row.startIndex * WEEK_WIDTH) + 4;
+        const shapeEndX = row.kind === "milestone"
+            ? chartOriginX + (row.startIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2) + 11
+            : chartOriginX + (row.endIndex * WEEK_WIDTH) + WEEK_WIDTH - 4;
+        const chartMidX = chartOriginX + (chartWidth / 2);
+        if (shapeEndX <= chartMidX) {
+            return { x: shapeEndX + gap, anchor: "start", width: textWidth };
+        }
+        return { x: Math.max(textWidth, shapeStartX - gap), anchor: "end", width: textWidth };
+    }
     function formatSvgAxisDate(day) {
+        const match = day.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+        if (!match) {
+            return day;
+        }
+        return `${Number(match[2])}/${Number(match[3])}`;
+    }
+    function formatWeeklyAxisLabel(day) {
         const match = day.match(/^(\d{4})-(\d{2})-(\d{2})$/);
         if (!match) {
             return day;
@@ -351,6 +524,19 @@
         }
         const index = dateBand.indexOf(key);
         return index >= 0 ? index : null;
+    }
+    function indexOfWeekForDate(weeklyBand, value) {
+        const key = String(value || "").slice(0, 10);
+        if (!key) {
+            return null;
+        }
+        for (let index = 0; index < weeklyBand.length; index += 1) {
+            const week = weeklyBand[index];
+            if (week.startDay <= key && key <= week.endDay) {
+                return index;
+            }
+        }
+        return null;
     }
     function collectWbsHolidayDates(model) {
         const holidaySet = new Set();
@@ -428,6 +614,46 @@
             cursor.setDate(cursor.getDate() + 1);
         }
         return days;
+    }
+    function buildWeeklyBand(startDate, finishDate) {
+        const start = parseDateOnly(startDate);
+        const finish = parseDateOnly(finishDate);
+        if (!start || !finish || start.getTime() > finish.getTime()) {
+            return [];
+        }
+        const cursor = startOfWeekSunday(start);
+        const limit = endOfWeekSaturday(finish);
+        const weeks = [];
+        while (cursor.getTime() <= limit.getTime()) {
+            const weekStart = new Date(cursor.getTime());
+            const weekEnd = new Date(cursor.getTime());
+            weekEnd.setDate(weekEnd.getDate() + 6);
+            weeks.push({
+                startDay: formatDateOnly(weekStart),
+                endDay: formatDateOnly(weekEnd),
+                monthKey: formatMonthLabel(new Date(weekStart.getFullYear(), weekStart.getMonth(), 1))
+            });
+            cursor.setDate(cursor.getDate() + 7);
+        }
+        return weeks;
+    }
+    function buildWeeklyMonthSpans(weeklyBand) {
+        const spans = [];
+        for (let index = 0; index < weeklyBand.length; index += 1) {
+            const current = weeklyBand[index];
+            const last = spans[spans.length - 1];
+            if (last && last.monthKey === current.monthKey) {
+                last.endIndex = index;
+            }
+            else {
+                spans.push({
+                    monthKey: current.monthKey,
+                    startIndex: index,
+                    endIndex: index
+                });
+            }
+        }
+        return spans;
     }
     function buildDisplayDateBand(startDate, finishDate, baseDate, displayDaysBeforeBaseDate, displayDaysAfterBaseDate, holidaySet, nonWorkingDayTypes, useBusinessDaysForDisplayRange) {
         const fullBand = buildDateBand(startDate, finishDate);
@@ -607,6 +833,7 @@
     }
     globalThis.__mikuprojectNativeSvg = {
         exportNativeSvg,
+        exportWeeklyNativeSvg,
         exportMonthlyWbsCalendarSvgArchive
     };
 })();

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -157,6 +157,16 @@
           useBusinessDaysForProgressBand?: boolean;
         }
       ) => string;
+      exportWeeklyNativeSvg: (
+        model: ProjectModel,
+        options?: {
+          holidayDates?: string[];
+          displayDaysBeforeBaseDate?: number;
+          displayDaysAfterBaseDate?: number;
+          useBusinessDaysForDisplayRange?: boolean;
+          useBusinessDaysForProgressBand?: boolean;
+        }
+      ) => string;
       exportMonthlyWbsCalendarSvgArchive: (
         model: ProjectModel
       ) => {
@@ -175,11 +185,16 @@
 
   let currentModel: ProjectModel | null = null;
   let currentNativeSvg = "";
+  let currentWeeklyPreviewSvg = "";
+  let currentMonthlyPreviewSvg = "";
   let lastSavedXmlText = "";
   let lastSavedXmlStamp = "";
   let currentTabId: "input" | "transform" | "output" = "input";
+  let currentSvgPreviewMode: "daily" | "weekly" | "monthly" = "daily";
   let isXmlSourceDirty = true;
   let isRefreshingTransformTab = false;
+  const ZIP_TEXT_ENCODER = new TextEncoder();
+  const ZIP_CRC32_TABLE = buildZipCrc32Table();
 
   function getElement<T extends HTMLElement>(id: string): T {
     const element = document.getElementById(id);
@@ -439,11 +454,49 @@
     getElement<HTMLElement>("nativeSvgPreview").innerHTML = markup;
   }
 
+  function updateSvgPreviewModeButtons(): void {
+    const dailyButton = getElement<HTMLButtonElement>("previewDailySvgBtn");
+    const weeklyButton = getElement<HTMLButtonElement>("previewWeeklySvgBtn");
+    const monthlyButton = getElement<HTMLButtonElement>("previewMonthlySvgBtn");
+    dailyButton.classList.toggle("md-button--primary", currentSvgPreviewMode === "daily");
+    dailyButton.classList.toggle("md-button--tonal", currentSvgPreviewMode !== "daily");
+    weeklyButton.classList.toggle("md-button--primary", currentSvgPreviewMode === "weekly");
+    weeklyButton.classList.toggle("md-button--tonal", currentSvgPreviewMode !== "weekly");
+    monthlyButton.classList.toggle("md-button--primary", currentSvgPreviewMode === "monthly");
+    monthlyButton.classList.toggle("md-button--tonal", currentSvgPreviewMode !== "monthly");
+  }
+
+  function renderCurrentSvgPreviewMarkup(): void {
+    if (currentSvgPreviewMode === "weekly") {
+      if (currentWeeklyPreviewSvg) {
+        setSvgPreviewMarkup(currentWeeklyPreviewSvg);
+        return;
+      }
+      setSvgPreviewMarkup(`<div class="md-preview-empty">Weekly SVG を生成すると、ここにプレビューを表示します。</div>`);
+      return;
+    }
+    if (currentSvgPreviewMode === "monthly") {
+      if (currentMonthlyPreviewSvg) {
+        setSvgPreviewMarkup(currentMonthlyPreviewSvg);
+        return;
+      }
+      setSvgPreviewMarkup(`<div class="md-preview-empty">Monthly Calendar SVG を生成すると、ここにプレビューを表示します。</div>`);
+      return;
+    }
+    if (currentNativeSvg) {
+      setSvgPreviewMarkup(currentNativeSvg);
+      return;
+    }
+    setSvgPreviewMarkup(`<div class="md-preview-empty">Daily SVG を生成すると、ここにプレビューを表示します。</div>`);
+  }
+
   function updateSvgButton(): void {
     const nativeSvgButton = getElement<HTMLButtonElement>("downloadSvgBtn");
+    const weeklySvgButton = getElement<HTMLButtonElement>("downloadWeeklySvgBtn");
     const monthlyWbsButton = getElement<HTMLButtonElement>("downloadMonthlyWbsSvgZipBtn");
     const disabled = !currentModel;
     nativeSvgButton.disabled = disabled;
+    weeklySvgButton.disabled = disabled;
     monthlyWbsButton.disabled = disabled;
   }
 
@@ -475,16 +528,215 @@
     window.setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
   }
 
+  function formatTimestampCompact(date: Date): string {
+    return [
+      date.getFullYear(),
+      String(date.getMonth() + 1).padStart(2, "0"),
+      String(date.getDate()).padStart(2, "0"),
+      String(date.getHours()).padStart(2, "0"),
+      String(date.getMinutes()).padStart(2, "0")
+    ].join("");
+  }
+
+  function encodeUtf8(value: string): Uint8Array {
+    return ZIP_TEXT_ENCODER.encode(value);
+  }
+
+  function concatUint8Arrays(parts: Uint8Array[]): Uint8Array {
+    const totalLength = parts.reduce((sum, part) => sum + part.byteLength, 0);
+    const result = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const part of parts) {
+      result.set(part, offset);
+      offset += part.byteLength;
+    }
+    return result;
+  }
+
+  function computeZipCrc32(bytes: Uint8Array): number {
+    let crc = 0xffffffff;
+    for (const byte of bytes) {
+      crc = (crc >>> 8) ^ ZIP_CRC32_TABLE[(crc ^ byte) & 0xff];
+    }
+    return (crc ^ 0xffffffff) >>> 0;
+  }
+
+  function buildZipCrc32Table(): Uint32Array {
+    const table = new Uint32Array(256);
+    for (let index = 0; index < 256; index += 1) {
+      let value = index;
+      for (let bit = 0; bit < 8; bit += 1) {
+        value = (value & 1) !== 0 ? (0xedb88320 ^ (value >>> 1)) : (value >>> 1);
+      }
+      table[index] = value >>> 0;
+    }
+    return table;
+  }
+
+  function packZipEntries(entries: Array<{ name: string; data: Uint8Array }>): Uint8Array {
+    const localParts: Uint8Array[] = [];
+    const centralParts: Uint8Array[] = [];
+    let offset = 0;
+    const zipFixedModTime = 0;
+    const zipFixedModDate = ((2025 - 1980) << 9) | (1 << 5) | 1;
+
+    for (const entry of entries) {
+      const nameBytes = encodeUtf8(entry.name);
+      const crc32 = computeZipCrc32(entry.data);
+      const localHeader = new Uint8Array(30 + nameBytes.length);
+      const localView = new DataView(localHeader.buffer);
+      localView.setUint32(0, 0x04034b50, true);
+      localView.setUint16(4, 20, true);
+      localView.setUint16(6, 0, true);
+      localView.setUint16(8, 0, true);
+      localView.setUint16(10, zipFixedModTime, true);
+      localView.setUint16(12, zipFixedModDate, true);
+      localView.setUint32(14, crc32, true);
+      localView.setUint32(18, entry.data.byteLength, true);
+      localView.setUint32(22, entry.data.byteLength, true);
+      localView.setUint16(26, nameBytes.length, true);
+      localView.setUint16(28, 0, true);
+      localHeader.set(nameBytes, 30);
+
+      const centralHeader = new Uint8Array(46 + nameBytes.length);
+      const centralView = new DataView(centralHeader.buffer);
+      centralView.setUint32(0, 0x02014b50, true);
+      centralView.setUint16(4, 20, true);
+      centralView.setUint16(6, 20, true);
+      centralView.setUint16(8, 0, true);
+      centralView.setUint16(10, 0, true);
+      centralView.setUint16(12, zipFixedModTime, true);
+      centralView.setUint16(14, zipFixedModDate, true);
+      centralView.setUint32(16, crc32, true);
+      centralView.setUint32(20, entry.data.byteLength, true);
+      centralView.setUint32(24, entry.data.byteLength, true);
+      centralView.setUint16(28, nameBytes.length, true);
+      centralView.setUint16(30, 0, true);
+      centralView.setUint16(32, 0, true);
+      centralView.setUint16(34, 0, true);
+      centralView.setUint16(36, 0, true);
+      centralView.setUint32(38, 0, true);
+      centralView.setUint32(42, offset, true);
+      centralHeader.set(nameBytes, 46);
+
+      localParts.push(localHeader, entry.data);
+      centralParts.push(centralHeader);
+      offset += localHeader.byteLength + entry.data.byteLength;
+    }
+
+    const centralDirectoryOffset = offset;
+    const centralDirectorySize = centralParts.reduce((sum, part) => sum + part.byteLength, 0);
+    const endOfCentralDirectory = new Uint8Array(22);
+    const endView = new DataView(endOfCentralDirectory.buffer);
+    endView.setUint32(0, 0x06054b50, true);
+    endView.setUint16(4, 0, true);
+    endView.setUint16(6, 0, true);
+    endView.setUint16(8, entries.length, true);
+    endView.setUint16(10, entries.length, true);
+    endView.setUint32(12, centralDirectorySize, true);
+    endView.setUint32(16, centralDirectoryOffset, true);
+    endView.setUint16(20, 0, true);
+
+    return concatUint8Arrays([...localParts, ...centralParts, endOfCentralDirectory]);
+  }
+
   async function renderSvgPreview(): Promise<void> {
     if (!currentModel) {
       currentNativeSvg = "";
+      currentWeeklyPreviewSvg = "";
+      currentMonthlyPreviewSvg = "";
       updateSvgButton();
-      setSvgPreviewMarkup(`<div class="md-preview-empty">SVG を生成すると、ここにプレビューを表示します。</div>`);
+      renderCurrentSvgPreviewMarkup();
       return;
     }
-    currentNativeSvg = mikuprojectNativeSvg.exportNativeSvg(currentModel, buildCurrentWbsOptions(currentModel));
-    setSvgPreviewMarkup(currentNativeSvg);
+    const wbsOptions = buildCurrentWbsOptions(currentModel);
+    currentNativeSvg = mikuprojectNativeSvg.exportNativeSvg(currentModel, wbsOptions);
+    currentWeeklyPreviewSvg = mikuprojectNativeSvg.exportWeeklyNativeSvg(currentModel, wbsOptions);
+    const monthlyArchive = mikuprojectNativeSvg.exportMonthlyWbsCalendarSvgArchive(currentModel);
+    currentMonthlyPreviewSvg = monthlyArchive.entries.length > 0
+      ? monthlyArchive.entries.map((entry) => entry.svg).join("")
+      : "";
+    renderCurrentSvgPreviewMarkup();
     updateSvgButton();
+  }
+
+  function setSvgPreviewMode(mode: "daily" | "weekly" | "monthly"): void {
+    currentSvgPreviewMode = mode;
+    updateSvgPreviewModeButtons();
+    renderCurrentSvgPreviewMarkup();
+  }
+
+  function buildCurrentOutputArchive(): { fileName: string; zipBytes: Uint8Array; entryCount: number } {
+    const model = ensureCurrentModel();
+    const xmlText = syncXmlTextFromModel(model);
+    const now = new Date();
+    const stamp = formatTimestampCompact(now);
+    const dateOnlyStamp = [
+      now.getFullYear(),
+      String(now.getMonth() + 1).padStart(2, "0"),
+      String(now.getDate()).padStart(2, "0")
+    ].join("");
+    const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = mikuprojectProjectXlsx.exportProjectWorkbook(model);
+    const workbookJsonText = JSON.stringify(mikuprojectProjectWorkbookJson.exportProjectWorkbookJson(model), null, 2);
+    const csvText = mikuprojectXml.exportCsvParentId(model);
+    const wbsOptions = buildCurrentWbsOptions(model);
+    const wbsWorkbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, wbsOptions);
+    const wbsMarkdown = mikuprojectWbsMarkdown.exportWbsMarkdown(model, wbsOptions);
+    const dailySvg = mikuprojectNativeSvg.exportNativeSvg(model, wbsOptions);
+    const weeklySvg = mikuprojectNativeSvg.exportWeeklyNativeSvg(model, wbsOptions);
+    const monthlyArchive = mikuprojectNativeSvg.exportMonthlyWbsCalendarSvgArchive(model);
+    const mermaidText = mikuprojectXml.exportMermaidGantt(model);
+    const projectOverview = mikuprojectXml.exportProjectOverviewView(model) as { phases?: Array<{ uid?: string }> };
+    const phaseDetailViewsFull = (projectOverview.phases || [])
+      .map((phase) => phase?.uid)
+      .filter((uid): uid is string => Boolean(uid))
+      .map((phaseUid) => mikuprojectXml.exportPhaseDetailView(model, phaseUid, { mode: "full" }));
+    const aiBundle = {
+      view_type: "ai_projection_bundle",
+      project_overview_view: projectOverview,
+      phase_detail_views_full: phaseDetailViewsFull
+    };
+    const phaseDetailFull = mikuprojectXml.exportPhaseDetailView(model, undefined, { mode: "full" });
+
+    const entries = [
+      { name: `mikuproject-export-${stamp}.xml`, data: encodeUtf8(`${xmlText}\n`) },
+      { name: `mikuproject-export-${stamp}.xlsx`, data: codec.exportWorkbook(workbook) },
+      { name: `mikuproject-workbook-${stamp}.json`, data: encodeUtf8(`${workbookJsonText}\n`) },
+      { name: `mikuproject-export-${stamp}.csv`, data: encodeUtf8(`${csvText}\n`) },
+      { name: `mikuproject-wbs-${stamp}.xlsx`, data: codec.exportWorkbook(wbsWorkbook) },
+      { name: `mikuproject-wbs-${dateOnlyStamp}.md`, data: encodeUtf8(`${wbsMarkdown}\n`) },
+      { name: `mikuproject-wbs-daily-${stamp}.svg`, data: encodeUtf8(dailySvg) },
+      { name: `mikuproject-wbs-weekly-${stamp}.svg`, data: encodeUtf8(weeklySvg) },
+      { name: `mikuproject-wbs-mermaid-${stamp}.md`, data: encodeUtf8(`\`\`\`mermaid\n${mermaidText}\n\`\`\`\n`) },
+      { name: "mikuproject-project-overview-view.editjson", data: encodeUtf8(`${JSON.stringify(projectOverview, null, 2)}\n`) },
+      { name: "mikuproject-full-bundle.editjson", data: encodeUtf8(`${JSON.stringify(aiBundle, null, 2)}\n`) },
+      { name: "mikuproject-phase-detail-view-full.editjson", data: encodeUtf8(`${JSON.stringify(phaseDetailFull, null, 2)}\n`) }
+    ];
+    for (const entry of monthlyArchive.entries) {
+      const shortFileName = entry.fileName.replace(/^mikuproject-monthly-wbs-calendar-/, "");
+      entries.push({
+        name: `monthly-calendar/${shortFileName}`,
+        data: encodeUtf8(entry.svg)
+      });
+    }
+
+    return {
+      fileName: `mikuproject-all-${stamp}.zip`,
+      zipBytes: packZipEntries(entries),
+      entryCount: entries.length
+    };
+  }
+
+  function downloadAllOutputs(): void {
+    const archive = buildCurrentOutputArchive();
+    downloadBlob(
+      new Blob([archive.zipBytes], { type: "application/zip" }),
+      archive.fileName
+    );
+    setStatus(`All 出力を保存しました (${archive.entryCount} 件, ZIP)`);
+    showToast("All を保存しました");
+    setActiveTab("output");
   }
 
   function setStatus(message: string): void {
@@ -1428,10 +1680,35 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     ].join("");
     downloadBlob(
       new Blob([currentNativeSvg], { type: "image/svg+xml;charset=utf-8" }),
-      `mikuproject-wbs-${stamp}.svg`
+      `mikuproject-wbs-daily-${stamp}.svg`
     );
-    setStatus("SVG を保存しました");
-    showToast("SVG を保存しました");
+    setStatus("Daily SVG を保存しました");
+    showToast("Daily SVG を保存しました");
+    setActiveTab("output");
+  }
+
+  function downloadCurrentWeeklySvg(): void {
+    const model = ensureCurrentModel();
+    syncXmlTextFromModel(model);
+    const weeklySvg = mikuprojectNativeSvg.exportWeeklyNativeSvg(model, buildCurrentWbsOptions(model));
+    if (!weeklySvg) {
+      setStatus("出力する Weekly SVG がありません");
+      return;
+    }
+    const now = new Date();
+    const stamp = [
+      now.getFullYear(),
+      String(now.getMonth() + 1).padStart(2, "0"),
+      String(now.getDate()).padStart(2, "0"),
+      String(now.getHours()).padStart(2, "0"),
+      String(now.getMinutes()).padStart(2, "0")
+    ].join("");
+    downloadBlob(
+      new Blob([weeklySvg], { type: "image/svg+xml;charset=utf-8" }),
+      `mikuproject-wbs-weekly-${stamp}.svg`
+    );
+    setStatus("Weekly SVG を保存しました");
+    showToast("Weekly SVG を保存しました");
     setActiveTab("output");
   }
 
@@ -1454,8 +1731,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
       new Blob([archive.zipBytes], { type: "application/zip" }),
       `mikuproject-monthly-wbs-calendar-${stamp}.zip`
     );
-    setStatus(`Monthly WBS SVG を保存しました (${archive.entries.length} か月分, ZIP)`);
-    showToast("Monthly WBS SVG を保存しました");
+    setStatus(`Monthly Calendar SVG を保存しました (${archive.entries.length} か月分, ZIP)`);
+    showToast("Monthly Calendar SVG を保存しました");
     setActiveTab("output");
   }
 
@@ -1550,11 +1827,36 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
       input.value = "";
       input.click();
     });
+    getElement<HTMLButtonElement>("downloadAllOutputsBtn").addEventListener("click", () => {
+      try {
+        downloadAllOutputs();
+      } catch (error) {
+        console.error("[mikuproject] all outputs download failed", error);
+        setStatus(error instanceof Error ? error.message : "All 出力保存に失敗しました");
+      }
+    });
+    getElement<HTMLButtonElement>("previewDailySvgBtn").addEventListener("click", () => {
+      setSvgPreviewMode("daily");
+    });
+    getElement<HTMLButtonElement>("previewWeeklySvgBtn").addEventListener("click", () => {
+      setSvgPreviewMode("weekly");
+    });
+    getElement<HTMLButtonElement>("previewMonthlySvgBtn").addEventListener("click", () => {
+      setSvgPreviewMode("monthly");
+    });
     getElement<HTMLButtonElement>("downloadSvgBtn").addEventListener("click", () => {
       void downloadCurrentSvg().catch((error) => {
         console.error("[mikuproject] native SVG download failed", error);
         setStatus(error instanceof Error ? error.message : "SVG 保存に失敗しました");
       });
+    });
+    getElement<HTMLButtonElement>("downloadWeeklySvgBtn").addEventListener("click", () => {
+      try {
+        downloadCurrentWeeklySvg();
+      } catch (error) {
+        console.error("[mikuproject] weekly SVG download failed", error);
+        setStatus(error instanceof Error ? error.message : "Weekly SVG 保存に失敗しました");
+      }
     });
     getElement<HTMLButtonElement>("downloadMonthlyWbsSvgZipBtn").addEventListener("click", () => {
       try {
@@ -1693,6 +1995,7 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     renderValidationIssues([]);
     renderImportWarnings([]);
     renderXlsxImportSummary([]);
+    updateSvgPreviewModeButtons();
     updateSvgButton();
     loadSample();
   }

--- a/src/ts/native-svg.ts
+++ b/src/ts/native-svg.ts
@@ -40,6 +40,12 @@
     zipBytes: Uint8Array;
   };
 
+  type WeeklyBand = {
+    startDay: string;
+    endDay: string;
+    monthKey: string;
+  };
+
   const DAY_WIDTH = 56;
   const LIST_LABEL_WIDTH = 360;
   const NEAR_LEFT_LABEL_WIDTH = 0;
@@ -64,6 +70,12 @@
   const MONTHLY_MAX_LABEL_CHARS = 15;
   const ZIP_FIXED_MOD_TIME = 0;
   const ZIP_FIXED_MOD_DATE = ((2025 - 1980) << 9) | (1 << 5) | 1;
+  const WEEK_WIDTH = 38;
+  const WEEKLY_HEADER_HEIGHT = 96;
+  const WEEKLY_TOP_PADDING = 22;
+  const WEEKLY_BOTTOM_PADDING = 28;
+  const WEEKLY_LEFT_PADDING = 0;
+  const WEEKLY_RIGHT_PADDING = 0;
 
   function exportNativeSvg(model: ProjectModel, options: NativeSvgExportOptions = {}): string {
     const labelMode = options.labelMode || "near";
@@ -110,6 +122,7 @@
       ".axis { font-size: 12px; fill: #5b6370; }",
       ".label { font-size: 13px; }",
       ".phaseLabel { font-size: 13px; font-weight: 700; }",
+      ".onBarLabelBg { fill: rgba(255,255,255,0.9); }",
       ".grid { stroke: #c9d3e1; stroke-width: 1; }",
       ".today { stroke: #ff6b5a; stroke-width: 2; }",
       "</style>",
@@ -138,6 +151,7 @@
 
     for (const row of rows) {
       const rowY = chartOriginY + row.y;
+      const useOnBarLabel = shouldUseDailyOnBarLabel(row, dateBand.length, labelMode);
       if (row.startIndex !== null && row.endIndex !== null) {
         const barX = chartOriginX + (row.startIndex * DAY_WIDTH) + 6;
         const barWidth = Math.max(12, ((row.endIndex - row.startIndex + 1) * DAY_WIDTH) - 12);
@@ -170,9 +184,143 @@
             parts.push(`<rect x="${barX}" y="${barY}" width="${progressWidth}" height="22" rx="4" fill="${progressFill}" stroke="none"/>`);
           }
         }
+        if (useOnBarLabel) {
+          const labelText = escapeXml(formatTaskLabel(row.task, labelMode));
+          const labelWidth = estimateLabelWidth(row.label, row.kind === "phase");
+          const labelCenterX = barX + (barWidth / 2);
+          const labelX = labelCenterX - (labelWidth / 2) - 8;
+          const labelY = row.kind === "phase" ? rowY + 15 : rowY + 10;
+          const labelHeight = row.kind === "phase" ? 18 : 20;
+          parts.push(`<rect class="onBarLabelBg" x="${labelX}" y="${labelY}" width="${labelWidth + 16}" height="${labelHeight}" rx="4"/>`);
+          parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelCenterX}" y="${rowY + 24}" text-anchor="middle">${labelText}</text>`);
+          continue;
+        }
       }
       const labelPlacement = labelPlacements[rows.indexOf(row)];
       parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelPlacement.x + shiftX}" y="${rowY + 24}" text-anchor="${labelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, labelMode))}</text>`);
+    }
+
+    parts.push("</svg>");
+    return parts.join("");
+  }
+
+  function exportWeeklyNativeSvg(model: ProjectModel, options: NativeSvgExportOptions = {}): string {
+    const holidaySet = new Set([
+      ...collectWbsHolidayDates(model),
+      ...(options.holidayDates || []).map((day) => String(day || "").slice(0, 10)).filter(Boolean)
+    ]);
+    const nonWorkingDayTypes = collectProjectNonWorkingDayTypes(model);
+    const dateBand = buildDisplayDateBand(
+      model.project.startDate,
+      model.project.finishDate,
+      model.project.currentDate,
+      options.displayDaysBeforeBaseDate,
+      options.displayDaysAfterBaseDate,
+      holidaySet,
+      nonWorkingDayTypes,
+      options.useBusinessDaysForDisplayRange
+    );
+    if (dateBand.length === 0) {
+      return exportNativeSvg(model, { ...options, labelMode: "list" });
+    }
+
+    const weeklyBand = buildWeeklyBand(dateBand[0], dateBand[dateBand.length - 1]);
+    const rows = buildWeeklyTaskRows(model.tasks, weeklyBand);
+    const chartWidth = weeklyBand.length * WEEK_WIDTH;
+    const chartOriginXBase = WEEKLY_LEFT_PADDING;
+    const labelPlacements = rows.map((row) => resolveWeeklyLabelPlacement(row, chartOriginXBase, chartWidth));
+    const labelMaxX = labelPlacements.reduce((max, placement) => {
+      const placementMaxX = placement.anchor === "start" ? placement.x + placement.width : placement.x;
+      return Math.max(max, placementMaxX);
+    }, chartOriginXBase + chartWidth);
+    const chartOriginX = chartOriginXBase;
+    const svgWidth = labelMaxX + WEEKLY_RIGHT_PADDING;
+    const svgHeight = WEEKLY_TOP_PADDING + WEEKLY_HEADER_HEIGHT + (rows.length * ROW_HEIGHT) + WEEKLY_BOTTOM_PADDING;
+    const todayWeekIndex = indexOfWeekForDate(weeklyBand, model.project.currentDate);
+
+    const parts: string[] = [
+      `<svg xmlns="http://www.w3.org/2000/svg" width="${svgWidth}" height="${svgHeight}" viewBox="0 0 ${svgWidth} ${svgHeight}" role="img" aria-label="${escapeXml(model.project.name || "Project")} weekly overview">`,
+      "<style>",
+      "text { font-family: 'Hiragino Sans', 'Yu Gothic', sans-serif; fill: #1d2740; }",
+      ".title { font-size: 18px; font-weight: 700; }",
+      ".meta { font-size: 12px; fill: #5b6370; }",
+      ".monthAxis { font-size: 13px; font-weight: 700; fill: #475467; }",
+      ".weekAxis { font-size: 10px; fill: #667085; }",
+      ".label { font-size: 13px; }",
+      ".phaseLabel { font-size: 13px; font-weight: 700; }",
+      ".grid { stroke: #c9d3e1; stroke-width: 1; }",
+      ".today { stroke: #ff6b5a; stroke-width: 2; }",
+      ".monthBoundary { stroke: #98a2b3; stroke-width: 1.5; }",
+      "</style>",
+      `<rect x="0" y="0" width="${svgWidth}" height="${svgHeight}" fill="#ffffff"/>`,
+      `<text class="title" x="${chartOriginX + (chartWidth / 2)}" y="${WEEKLY_TOP_PADDING + 18}" text-anchor="middle">${escapeXml(model.project.name || "-")} weekly overview</text>`,
+      `<text class="meta" x="${chartOriginX + (chartWidth / 2)}" y="${WEEKLY_TOP_PADDING + 40}" text-anchor="middle">${escapeXml(`project range ${String(model.project.startDate || "").slice(0, 10)} - ${String(model.project.finishDate || "").slice(0, 10)}`)}</text>`
+    ];
+
+    const chartOriginY = WEEKLY_TOP_PADDING + WEEKLY_HEADER_HEIGHT;
+    const monthSpans = buildWeeklyMonthSpans(weeklyBand);
+
+    for (const span of monthSpans) {
+      const x = chartOriginX + (span.startIndex * WEEK_WIDTH);
+      const width = (span.endIndex - span.startIndex + 1) * WEEK_WIDTH;
+      parts.push(`<text class="monthAxis" x="${x + (width / 2)}" y="${WEEKLY_TOP_PADDING + 66}" text-anchor="middle">${escapeXml(span.monthKey)}</text>`);
+      parts.push(`<line class="monthBoundary" x1="${x}" y1="${WEEKLY_TOP_PADDING + 72}" x2="${x}" y2="${svgHeight - WEEKLY_BOTTOM_PADDING}" />`);
+    }
+    parts.push(`<line class="monthBoundary" x1="${chartOriginX + chartWidth}" y1="${WEEKLY_TOP_PADDING + 72}" x2="${chartOriginX + chartWidth}" y2="${svgHeight - WEEKLY_BOTTOM_PADDING}" />`);
+
+    for (let index = 0; index < weeklyBand.length; index += 1) {
+      const week = weeklyBand[index];
+      const x = chartOriginX + (index * WEEK_WIDTH);
+      parts.push(`<line class="grid" x1="${x}" y1="${WEEKLY_TOP_PADDING + 72}" x2="${x}" y2="${svgHeight - WEEKLY_BOTTOM_PADDING}" />`);
+      parts.push(`<text class="weekAxis" x="${x + (WEEK_WIDTH / 2)}" y="${WEEKLY_TOP_PADDING + 86}" text-anchor="middle">${escapeXml(formatWeeklyAxisLabel(week.startDay))}</text>`);
+    }
+
+    if (todayWeekIndex >= 0) {
+      const todayX = chartOriginX + (todayWeekIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2);
+      parts.push(`<line class="today" x1="${todayX}" y1="${WEEKLY_TOP_PADDING + 72}" x2="${todayX}" y2="${svgHeight - WEEKLY_BOTTOM_PADDING}" />`);
+    }
+
+    for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
+      const row = rows[rowIndex];
+      const rowY = chartOriginY + row.y;
+      if (row.startIndex === null || row.endIndex === null) {
+        const fallbackLabelPlacement = labelPlacements[rowIndex];
+        parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${fallbackLabelPlacement.x}" y="${rowY + 24}" text-anchor="${fallbackLabelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
+        continue;
+      }
+      const barX = chartOriginX + (row.startIndex * WEEK_WIDTH) + 4;
+      const barWidth = Math.max(10, ((row.endIndex - row.startIndex + 1) * WEEK_WIDTH) - 8);
+      const barY = rowY + 8;
+      if (row.kind === "milestone") {
+        const centerX = chartOriginX + (row.startIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2);
+        const centerY = rowY + (ROW_HEIGHT / 2);
+        const isCompleted = (row.task.percentComplete || 0) >= 100;
+        const fill = isCompleted ? "#d9efff" : "#ffffff";
+        parts.push(`<polygon points="${centerX},${centerY - 11} ${centerX + 11},${centerY} ${centerX},${centerY + 11} ${centerX - 11},${centerY}" fill="${fill}" stroke="#4f95d6" stroke-width="3"/>`);
+      } else if (row.kind === "phase") {
+        const lineY = rowY + (ROW_HEIGHT / 2);
+        const startX = barX;
+        const endX = barX + barWidth;
+        const trackStroke = "#8eb9ea";
+        const progressStroke = "#2f79d0";
+        const phaseStrokeWidth = 3;
+        const progressEndX = startX + Math.max(0, Math.min(barWidth, Math.round(barWidth * (Math.max(0, Math.min(100, row.task.percentComplete || 0)) / 100))));
+        parts.push(`<line x1="${startX}" y1="${lineY}" x2="${endX}" y2="${lineY}" stroke="${trackStroke}" stroke-width="${phaseStrokeWidth}" stroke-linecap="round"/>`);
+        if (progressEndX > startX) {
+          parts.push(`<line x1="${startX}" y1="${lineY}" x2="${progressEndX}" y2="${lineY}" stroke="${progressStroke}" stroke-width="${phaseStrokeWidth}" stroke-linecap="round"/>`);
+        }
+      } else {
+        const trackFill = "#d9efff";
+        const trackStroke = "#4f95d6";
+        const progressFill = "#3f86d8";
+        parts.push(`<rect x="${barX}" y="${barY}" width="${barWidth}" height="22" rx="4" fill="${trackFill}" stroke="${trackStroke}" stroke-width="3"/>`);
+        const progressWidth = Math.max(0, Math.min(barWidth, Math.round(barWidth * (Math.max(0, Math.min(100, row.task.percentComplete || 0)) / 100))));
+        if (progressWidth > 0) {
+          parts.push(`<rect x="${barX}" y="${barY}" width="${progressWidth}" height="22" rx="4" fill="${progressFill}" stroke="none"/>`);
+        }
+      }
+      const labelPlacement = labelPlacements[rowIndex];
+      parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelPlacement.x}" y="${rowY + 24}" text-anchor="${labelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
     }
 
     parts.push("</svg>");
@@ -385,6 +533,17 @@
     }));
   }
 
+  function buildWeeklyTaskRows(tasks: TaskModel[], weeklyBand: WeeklyBand[]): NativeSvgTaskRow[] {
+    return tasks.map((task, index) => ({
+      task,
+      label: task.name || "-",
+      kind: task.summary ? "phase" : (task.milestone ? "milestone" : "task"),
+      startIndex: indexOfWeekForDate(weeklyBand, task.start),
+      endIndex: task.milestone ? indexOfWeekForDate(weeklyBand, task.start) : indexOfWeekForDate(weeklyBand, task.finish),
+      y: index * ROW_HEIGHT
+    }));
+  }
+
   function formatTaskLabel(task: TaskModel, labelMode: "near" | "list"): string {
     if (labelMode === "list") {
       return `${"　".repeat(Math.max(0, task.outlineLevel - 1))}${task.name || "-"}`;
@@ -422,7 +581,56 @@
     return Math.max(48, Math.ceil(String(label || "").length * basePerChar));
   }
 
+  function shouldUseDailyOnBarLabel(
+    row: NativeSvgTaskRow,
+    bandLength: number,
+    labelMode: "near" | "list"
+  ): boolean {
+    if (labelMode !== "near") {
+      return false;
+    }
+    if (row.kind === "milestone") {
+      return false;
+    }
+    if (row.startIndex === null || row.endIndex === null || bandLength <= 0) {
+      return false;
+    }
+    return row.startIndex === 0 && row.endIndex === bandLength - 1;
+  }
+
+  function resolveWeeklyLabelPlacement(
+    row: NativeSvgTaskRow,
+    chartOriginX: number,
+    chartWidth: number
+  ): NativeSvgLabelPlacement {
+    if (row.startIndex === null || row.endIndex === null) {
+      return { x: chartOriginX + 10, anchor: "start", width: estimateLabelWidth(row.label, row.kind === "phase") };
+    }
+
+    const textWidth = estimateLabelWidth(row.label, row.kind === "phase");
+    const gap = 10;
+    const shapeStartX = row.kind === "milestone"
+      ? chartOriginX + (row.startIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2) - 11
+      : chartOriginX + (row.startIndex * WEEK_WIDTH) + 4;
+    const shapeEndX = row.kind === "milestone"
+      ? chartOriginX + (row.startIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2) + 11
+      : chartOriginX + (row.endIndex * WEEK_WIDTH) + WEEK_WIDTH - 4;
+    const chartMidX = chartOriginX + (chartWidth / 2);
+    if (shapeEndX <= chartMidX) {
+      return { x: shapeEndX + gap, anchor: "start", width: textWidth };
+    }
+    return { x: Math.max(textWidth, shapeStartX - gap), anchor: "end", width: textWidth };
+  }
+
   function formatSvgAxisDate(day: string): string {
+    const match = day.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!match) {
+      return day;
+    }
+    return `${Number(match[2])}/${Number(match[3])}`;
+  }
+
+  function formatWeeklyAxisLabel(day: string): string {
     const match = day.match(/^(\d{4})-(\d{2})-(\d{2})$/);
     if (!match) {
       return day;
@@ -437,6 +645,20 @@
     }
     const index = dateBand.indexOf(key);
     return index >= 0 ? index : null;
+  }
+
+  function indexOfWeekForDate(weeklyBand: WeeklyBand[], value: string | undefined): number | null {
+    const key = String(value || "").slice(0, 10);
+    if (!key) {
+      return null;
+    }
+    for (let index = 0; index < weeklyBand.length; index += 1) {
+      const week = weeklyBand[index];
+      if (week.startDay <= key && key <= week.endDay) {
+        return index;
+      }
+    }
+    return null;
   }
 
   function collectWbsHolidayDates(model: ProjectModel): string[] {
@@ -525,6 +747,47 @@
       cursor.setDate(cursor.getDate() + 1);
     }
     return days;
+  }
+
+  function buildWeeklyBand(startDate: string | undefined, finishDate: string | undefined): WeeklyBand[] {
+    const start = parseDateOnly(startDate);
+    const finish = parseDateOnly(finishDate);
+    if (!start || !finish || start.getTime() > finish.getTime()) {
+      return [];
+    }
+    const cursor = startOfWeekSunday(start);
+    const limit = endOfWeekSaturday(finish);
+    const weeks: WeeklyBand[] = [];
+    while (cursor.getTime() <= limit.getTime()) {
+      const weekStart = new Date(cursor.getTime());
+      const weekEnd = new Date(cursor.getTime());
+      weekEnd.setDate(weekEnd.getDate() + 6);
+      weeks.push({
+        startDay: formatDateOnly(weekStart),
+        endDay: formatDateOnly(weekEnd),
+        monthKey: formatMonthLabel(new Date(weekStart.getFullYear(), weekStart.getMonth(), 1))
+      });
+      cursor.setDate(cursor.getDate() + 7);
+    }
+    return weeks;
+  }
+
+  function buildWeeklyMonthSpans(weeklyBand: WeeklyBand[]): Array<{ monthKey: string; startIndex: number; endIndex: number }> {
+    const spans: Array<{ monthKey: string; startIndex: number; endIndex: number }> = [];
+    for (let index = 0; index < weeklyBand.length; index += 1) {
+      const current = weeklyBand[index];
+      const last = spans[spans.length - 1];
+      if (last && last.monthKey === current.monthKey) {
+        last.endIndex = index;
+      } else {
+        spans.push({
+          monthKey: current.monthKey,
+          startIndex: index,
+          endIndex: index
+        });
+      }
+    }
+    return spans;
   }
 
   function buildDisplayDateBand(
@@ -733,10 +996,12 @@
   (globalThis as typeof globalThis & {
     __mikuprojectNativeSvg?: {
       exportNativeSvg: typeof exportNativeSvg;
+      exportWeeklyNativeSvg: typeof exportWeeklyNativeSvg;
       exportMonthlyWbsCalendarSvgArchive: typeof exportMonthlyWbsCalendarSvgArchive;
     };
   }).__mikuprojectNativeSvg = {
     exportNativeSvg,
+    exportWeeklyNativeSvg,
     exportMonthlyWbsCalendarSvgArchive
   };
 })();

--- a/tests/mikuproject-main.test.js
+++ b/tests/mikuproject-main.test.js
@@ -74,14 +74,19 @@ function mountDom() {
   document.body.innerHTML = `
     <button id="importFileBtn" type="button">Load from file</button>
     <button id="loadSampleBtn" type="button">サンプル</button>
+    <button id="downloadAllOutputsBtn" type="button">All</button>
     <button id="exportXlsxBtn" type="button">XLSX</button>
     <button id="exportWorkbookJsonBtn" type="button">JSON</button>
     <button id="exportCsvBtn" type="button">CSV</button>
     <button id="exportWbsXlsxBtn" type="button">WBS XLSX</button>
     <button id="exportWbsMdBtn" type="button">WBS Markdown</button>
-    <button id="downloadMonthlyWbsSvgZipBtn" type="button" disabled>Monthly WBS SVG</button>
+    <button id="downloadWeeklySvgBtn" type="button" disabled>Weekly SVG</button>
+    <button id="downloadMonthlyWbsSvgZipBtn" type="button" disabled>Monthly Calendar SVG</button>
     <button id="exportMermaidMdBtn" type="button">Mermaid</button>
-    <button id="downloadSvgBtn" type="button" disabled>SVG</button>
+    <button id="downloadSvgBtn" type="button" disabled>Daily SVG</button>
+    <button id="previewDailySvgBtn" type="button">Daily SVG</button>
+    <button id="previewWeeklySvgBtn" type="button">Weekly SVG</button>
+    <button id="previewMonthlySvgBtn" type="button">Monthly Calendar SVG</button>
     <button id="exportAiBundleBtn" type="button">project_overview + all phase_detail full</button>
     <button id="exportProjectOverviewBtn" type="button">project_overview_view</button>
     <button id="exportPhaseDetailFullBtn" type="button">phase_detail_view full</button>
@@ -575,7 +580,28 @@ describe("mikuproject main", () => {
     expect(mermaidText).toContain("初期実装");
     expect(document.getElementById("nativeSvgPreview").innerHTML).toContain("<svg");
     expect(document.getElementById("downloadSvgBtn").disabled).toBe(false);
+    expect(document.getElementById("downloadWeeklySvgBtn").disabled).toBe(false);
     expect(document.getElementById("statusMessage").textContent).toContain("Mermaid gantt");
+  });
+
+  it("switches overview svg preview between daily, weekly, and monthly", async () => {
+    bootPage();
+
+    parseXmlViaHook();
+    await exportMermaidViaHook();
+    expect(document.getElementById("nativeSvgPreview").innerHTML).toContain("<svg");
+
+    document.getElementById("previewWeeklySvgBtn").click();
+    expect(document.getElementById("nativeSvgPreview").innerHTML).toContain("weekly overview");
+
+    document.getElementById("previewMonthlySvgBtn").click();
+    expect(document.getElementById("nativeSvgPreview").innerHTML).toContain("2026-03");
+    expect(document.getElementById("nativeSvgPreview").innerHTML).toContain("2026-04");
+
+    document.getElementById("previewDailySvgBtn").click();
+    expect(document.getElementById("nativeSvgPreview").innerHTML).toContain("<svg");
+    expect(document.getElementById("nativeSvgPreview").innerHTML).not.toContain("weekly overview");
+    expect(document.getElementById("nativeSvgPreview").innerHTML).not.toContain("project range 2026-03-16 - 2026-04-01");
   });
 
   it("keeps complex mermaid dependencies as comments", () => {
@@ -1423,11 +1449,11 @@ describe("mikuproject main", () => {
     expect(URL.createObjectURL).toHaveBeenCalled();
     expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
     const clickedAnchor = HTMLAnchorElement.prototype.click.mock.instances.at(-1);
-    expect(clickedAnchor.download).toBe("mikuproject-wbs-202603162312.svg");
+    expect(clickedAnchor.download).toBe("mikuproject-wbs-daily-202603162312.svg");
     expect(document.getElementById("xmlInput").value).not.toContain("<!-- edited -->");
     expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 保存済み (2026-03-16 23:12)");
     expect(document.getElementById("mermaidOutput").value).toContain("gantt");
-    expect(document.getElementById("statusMessage").textContent).toContain("SVG を保存しました");
+    expect(document.getElementById("statusMessage").textContent).toContain("Daily SVG を保存しました");
   });
 
   it("downloads monthly wbs calendar svg zip", async () => {
@@ -1467,10 +1493,82 @@ describe("mikuproject main", () => {
       expect(marchSvg).toContain("<svg");
       expect(marchSvg).toContain("mikuproject開発");
       expect(marchSvg).toContain("2026-03");
-      expect(document.getElementById("statusMessage").textContent).toContain("Monthly WBS SVG を保存しました");
+      expect(document.getElementById("statusMessage").textContent).toContain("Monthly Calendar SVG を保存しました");
     } finally {
       globalThis.Blob = OriginalBlob;
     }
+  });
+
+  it("downloads all outputs as zip", () => {
+    bootPage();
+
+    parseXmlViaHook();
+    const OriginalBlob = Blob;
+    class InspectableBlob extends OriginalBlob {
+      constructor(parts = [], options = {}) {
+        super(parts, options);
+        this._parts = parts;
+      }
+    }
+    globalThis.Blob = InspectableBlob;
+    URL.createObjectURL.mockClear();
+    HTMLAnchorElement.prototype.click.mockClear();
+    try {
+      document.getElementById("downloadAllOutputsBtn").click();
+
+      expect(URL.createObjectURL).toHaveBeenCalled();
+      expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
+      const clickedAnchor = HTMLAnchorElement.prototype.click.mock.instances.at(-1);
+      expect(clickedAnchor.download).toBe("mikuproject-all-202603162312.zip");
+
+      const zipBlob = URL.createObjectURL.mock.calls.at(-1)?.[0];
+      expect(zipBlob).toBeTruthy();
+      expect(zipBlob.type).toBe("application/zip");
+
+      const rawPart = zipBlob._parts?.[0];
+      expect(rawPart).toBeInstanceOf(Uint8Array);
+      const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+      const entries = codec.unpackEntries(rawPart);
+      const entryNames = Object.keys(entries).sort();
+      expect(entryNames).toContain("mikuproject-export-202603162312.xml");
+      expect(entryNames).toContain("mikuproject-export-202603162312.xlsx");
+      expect(entryNames).toContain("mikuproject-workbook-202603162312.json");
+      expect(entryNames).toContain("mikuproject-export-202603162312.csv");
+      expect(entryNames).toContain("mikuproject-wbs-202603162312.xlsx");
+      expect(entryNames).toContain("mikuproject-wbs-20260316.md");
+      expect(entryNames).toContain("mikuproject-wbs-daily-202603162312.svg");
+      expect(entryNames).toContain("mikuproject-wbs-weekly-202603162312.svg");
+      expect(entryNames).toContain("monthly-calendar/2026-03.svg");
+      expect(entryNames).toContain("mikuproject-wbs-mermaid-202603162312.md");
+      expect(entryNames).toContain("mikuproject-project-overview-view.editjson");
+      expect(entryNames).toContain("mikuproject-full-bundle.editjson");
+      expect(entryNames).toContain("mikuproject-phase-detail-view-full.editjson");
+
+      const monthlySvg = new TextDecoder().decode(entries["monthly-calendar/2026-03.svg"]);
+      expect(monthlySvg).toContain("<svg");
+      expect(monthlySvg).toContain("mikuproject開発");
+      expect(document.getElementById("statusMessage").textContent).toContain("All 出力を保存しました");
+    } finally {
+      globalThis.Blob = OriginalBlob;
+    }
+  });
+
+  it("downloads weekly svg", () => {
+    bootPage();
+
+    parseXmlViaHook();
+    URL.createObjectURL.mockClear();
+    HTMLAnchorElement.prototype.click.mockClear();
+    document.getElementById("downloadWeeklySvgBtn").click();
+
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
+    const clickedAnchor = HTMLAnchorElement.prototype.click.mock.instances.at(-1);
+    expect(clickedAnchor.download).toBe("mikuproject-wbs-weekly-202603162312.svg");
+    const svgBlob = URL.createObjectURL.mock.calls.at(-1)?.[0];
+    expect(svgBlob).toBeTruthy();
+    expect(svgBlob.type).toBe("image/svg+xml;charset=utf-8");
+    expect(document.getElementById("statusMessage").textContent).toContain("Weekly SVG を保存しました");
   });
 
   it("downloads mermaid markdown", () => {


### PR DESCRIPTION
## 概要

WBS 系の SVG 出力と Output / Overview の導線を拡張します。

主な変更は次のとおりです。

- `Daily SVG` / `Weekly SVG` / `Monthly Calendar SVG` の整理
- `Overview` で `Daily` / `Weekly` / `Monthly Calendar` を切り替えられるプレビューを追加
- `Output` に主要成果物をまとめて取得できる `ALL` ZIP ダウンロードを追加
- Windows 11 上での `Monthly SVG` / `SVG` 取扱いメモを README に追記

## 変更内容

### WBS SVG 出力の拡張

- 既存の `SVG` 出力を `Daily SVG` として明確化
- `Weekly SVG` 出力を追加
- `Monthly SVG` の表示名を `Monthly Calendar SVG` に変更

`Daily SVG` の変更点:

- ダウンロードファイル名を `mikuproject-wbs-daily-<YYYYMMDDHHmm>.svg` に変更
- 保存時のメッセージを `Daily SVG を保存しました` に変更
- 全表示幅を占める task / phase について、バー上にラベルを重ねる描画を追加

`Weekly SVG` の追加内容:

- `exportWeeklyNativeSvg(...)` を追加
- 週単位の横軸で WBS を俯瞰できる SVG を生成
- 近接ラベル方式で task 名を表示
- ダウンロードファイル名は `mikuproject-wbs-weekly-<YYYYMMDDHHmm>.svg`

`Monthly Calendar SVG` の変更点:

- 保存時メッセージを `Monthly Calendar SVG を保存しました` に変更
- 月別 SVG 群を ZIP で出力する既存方式は維持

### Overview プレビューの切替追加

`Overview` に SVG プレビュー切替ボタンを追加しました。

追加されたボタン:

- `Daily`
- `Weekly`
- `Monthly Calendar`

挙動:

- `Daily` は日単位 SVG を表示
- `Weekly` は週単位 SVG を表示
- `Monthly Calendar` は月別 SVG を縦に連結した長いプレビューを表示

### Output の ALL ZIP ダウンロード追加

`Output` に `ALL` ボタンを追加しました。

内容:

- 主要出力をまとめた `mikuproject-all-<YYYYMMDDHHmm>.zip` を生成
- ZIP は `main.ts` 内で直接組み立て

コミット差分から確認できる収録対象:

- XML
- XLSX
- workbook JSON
- CSV
- WBS XLSX
- WBS Markdown
- Daily SVG
- Weekly SVG
- Mermaid Markdown
- `project_overview_view.editjson`
- `full-bundle.editjson`
- `phase_detail_view_full.editjson`
- 月別カレンダー SVG

月別カレンダー SVG の格納方法:

- `ALL` ZIP 内では `monthly-calendar/` 配下へ展開して格納
- 例: `monthly-calendar/2026-03.svg`

### UI 文言・ボタン構成の調整

`mikuproject-src.html` では次を更新しています。

- `Output` に `ALL` ボタンを追加
- `WBS Report` 内の `SVG` 表記を `Daily SVG` に変更
- `Weekly SVG` ボタンを追加
- `Monthly SVG` 表記を `Monthly Calendar SVG` に変更
- `Overview` にプレビュー切替ボタン群を追加

## テスト

`tests/mikuproject-main.test.js` に以下の検証を追加・更新しています。

- `Daily / Weekly / Monthly` の Overview プレビュー切替
- `Daily SVG` の新しい保存名とステータス文言
- `Monthly Calendar SVG` のステータス文言
- `ALL` ZIP ダウンロード
- `Weekly SVG` ダウンロード