### PR TITLE
WBS 祝日指定 UI を撤去し、既定祝日反映を内部ロジックへ統一

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -9,7 +9,6 @@
 - WBS workbook と `mikuproject-sample.xlsx` のタイトル行で、フォントサイズ指定をどこまで使うか整理する
 - `Mermaid` 出力は Markdown / 設計資料向けに残しつつ、見た目を制御しやすい `WBS SVG` 描画を別系統で追加するか検討する
 - `WBS SVG` について、今の既定である `近接ラベル` 表示だけを残し、左側にテキストを描画する `一覧ラベル` モードは将来的に廃止したい
-- `WBS XLSX` の祝日指定 UI は削除し、holiday 反映ロジックは内部で直接使う形へ寄せる。あわせて、関連テストは UI 前提から機能前提へ整理する
 - `mikuproject` の主要入出力を CLI からも扱えるようにするか検討する
 - 作成するテキストファイルについて、BOM 付き / なしを切り替えるスイッチを追加する
 - `local-data/` 配下のファイルを、参照用・検証用・生成物で整理する
@@ -36,8 +35,6 @@
 - UI の微調整として、`Input / Overview / Output` の各カードの余白・見出し・ボタン階層を見直し、`miku` 系テーマの統一感をさらに整える
 - `Overview` タブの summary / validation / preview の情報密度を見直し、どこを見る画面なのかをより直感的に伝わる構成へ調整する
 - `Output` タブの生成AI連携と各種 export ボタンの優先度表現を見直し、主操作と補助操作の区別をより明確にする
-- calendar 未設定時に自動補完する既定 calendar の祝日 `Exceptions` を、project 期間内だけに限定する
-- WBS 上で土日と祝日を別色表示する場合も、`MS Project XML` 正本へ独自の非稼働日種別を追加せず、`WeekDays / Exceptions` の由来で描き分ける
 - `build:xlsx-sample` の所要時間を個別計測し、sample workbook 生成処理の支配要因を確認する
 - `main.test.js` の初期化 DOM をケース別に最小化できるか見直す
 - CI 向けに `test:fast` と `test:full` のような実行導線を分けるか検討する

--- a/mikuproject-src.html
+++ b/mikuproject-src.html
@@ -395,12 +395,12 @@
             <summary class="ms-settings-summary">設定</summary>
             <div class="ms-settings-body">
               <section class="ms-settings-block" aria-label="WBS xlsx export options">
-                <h3 class="ms-settings-subtitle">WBS XLSX の祝日指定</h3>
+                <h3 class="ms-settings-subtitle">WBS XLSX 表示設定</h3>
               <p class="md-note-card__text">
                 `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日を WBS 日付帯へ反映します。
               </p>
               <p class="md-note-card__text">
-                既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から補完します。画面では `Calendars / Exceptions` を直接編集せず、必要な変更は `MS Project XML` または `XLSX Import` 側で扱います。表示期間を空欄にすると全期間、数値を入れると `BaseDate` 前後の営業日で切り出します。進捗帯も営業日基準で計算します。
+                既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から内部で直接補完します。画面では `Calendars / Exceptions` を直接編集せず、必要な変更は `MS Project XML` または `XLSX Import` 側で扱います。表示期間を空欄にすると全期間、数値を入れると `BaseDate` 前後の営業日で切り出します。進捗帯も営業日基準で計算します。
               </p>
               <div class="md-form-grid md-form-grid--two">
                 <lht-text-field-help
@@ -415,18 +415,6 @@
                   rows="1"
                   placeholder="7"
                   help-text="空欄なら全期間表示のままです。"></lht-text-field-help>
-              </div>
-              <div class="md-form-grid">
-                <div id="wbsHolidaySummary" class="md-status">既定祝日: 未読込</div>
-                <label class="md-label" for="wbsHolidayDatesInput">WBS 既定祝日</label>
-                <textarea
-                  id="wbsHolidayDatesInput"
-                  class="md-textarea"
-                  rows="3"
-                  placeholder="2026-03-20"
-                  readonly
-                ></textarea>
-                <div class="md-caption">現在の ProjectModel から自動補完します。画面上では直接編集しません。</div>
               </div>
               </section>
             </div>

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -2918,12 +2918,12 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
             <summary class="ms-settings-summary">設定</summary>
             <div class="ms-settings-body">
               <section class="ms-settings-block" aria-label="WBS xlsx export options">
-                <h3 class="ms-settings-subtitle">WBS XLSX の祝日指定</h3>
+                <h3 class="ms-settings-subtitle">WBS XLSX 表示設定</h3>
               <p class="md-note-card__text">
                 `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日を WBS 日付帯へ反映します。
               </p>
               <p class="md-note-card__text">
-                既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から補完します。画面では `Calendars / Exceptions` を直接編集せず、必要な変更は `MS Project XML` または `XLSX Import` 側で扱います。表示期間を空欄にすると全期間、数値を入れると `BaseDate` 前後の営業日で切り出します。進捗帯も営業日基準で計算します。
+                既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から内部で直接補完します。画面では `Calendars / Exceptions` を直接編集せず、必要な変更は `MS Project XML` または `XLSX Import` 側で扱います。表示期間を空欄にすると全期間、数値を入れると `BaseDate` 前後の営業日で切り出します。進捗帯も営業日基準で計算します。
               </p>
               <div class="md-form-grid md-form-grid--two">
                 <lht-text-field-help
@@ -2938,18 +2938,6 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
                   rows="1"
                   placeholder="7"
                   help-text="空欄なら全期間表示のままです。"></lht-text-field-help>
-              </div>
-              <div class="md-form-grid">
-                <div id="wbsHolidaySummary" class="md-status">既定祝日: 未読込</div>
-                <label class="md-label" for="wbsHolidayDatesInput">WBS 既定祝日</label>
-                <textarea
-                  id="wbsHolidayDatesInput"
-                  class="md-textarea"
-                  rows="3"
-                  placeholder="2026-03-20"
-                  readonly
-                ></textarea>
-                <div class="md-caption">現在の ProjectModel から自動補完します。画面上では直接編集しません。</div>
               </div>
               </section>
             </div>
@@ -13773,33 +13761,6 @@ if (!customElements.get("lht-page-menu")) {
         }
         setActiveTab(currentTabId);
     }
-    function parseHolidayDateList(raw) {
-        if (!raw) {
-            return [];
-        }
-        const seen = new Set();
-        const holidays = [];
-        for (const token of raw.split(/[\s,、;]+/)) {
-            const value = token.trim();
-            if (!value) {
-                continue;
-            }
-            const match = value.match(/^(\d{4}-\d{2}-\d{2})/);
-            if (!match) {
-                continue;
-            }
-            const dateText = match[1];
-            if (seen.has(dateText)) {
-                continue;
-            }
-            seen.add(dateText);
-            holidays.push(dateText);
-        }
-        return holidays;
-    }
-    function parseWbsDefaultHolidayDates() {
-        return parseHolidayDateList(getTextArea("wbsHolidayDatesInput").value.trim());
-    }
     function parseOptionalNonNegativeInteger(raw) {
         const value = raw.trim();
         if (!value) {
@@ -13822,37 +13783,6 @@ if (!customElements.get("lht-page-menu")) {
     }
     function useBusinessDaysForWbsProgressBand() {
         return true;
-    }
-    function updateWbsHolidaySummary(holidayDates) {
-        const summary = getElement("wbsHolidaySummary");
-        if (holidayDates.length === 0) {
-            summary.textContent = "既定祝日: 0 件";
-            return;
-        }
-        summary.textContent = `既定祝日: ${holidayDates.length} 件 (${holidayDates.join(", ")})`;
-    }
-    function syncWbsHolidayDatesInput(model) {
-        const input = getTextArea("wbsHolidayDatesInput");
-        if (!model) {
-            input.value = "";
-            updateWbsHolidaySummary([]);
-            return;
-        }
-        const holidayDates = mikuprojectWbsXlsx.collectWbsHolidayDates(model);
-        const nextValue = holidayDates.join("\n");
-        const fieldHost = document.querySelector(`lht-text-field-help[field-id="wbsHolidayDatesInput"]`);
-        if (fieldHost) {
-            window.requestAnimationFrame(() => {
-                const latestInput = document.getElementById("wbsHolidayDatesInput");
-                if (latestInput) {
-                    latestInput.value = nextValue;
-                }
-            });
-        }
-        else {
-            input.value = nextValue;
-        }
-        updateWbsHolidaySummary(holidayDates);
     }
     function showToast(message) {
         const toast = document.getElementById("toast");
@@ -13941,9 +13871,8 @@ if (!customElements.get("lht-page-menu")) {
         monthlyWbsButton.disabled = disabled;
     }
     function buildCurrentWbsOptions(model) {
-        syncWbsHolidayDatesInput(model);
         return {
-            holidayDates: parseWbsDefaultHolidayDates(),
+            holidayDates: mikuprojectWbsXlsx.collectWbsHolidayDates(model),
             displayDaysBeforeBaseDate: parseWbsDisplayDaysBeforeBaseDate(),
             displayDaysAfterBaseDate: parseWbsDisplayDaysAfterBaseDate(),
             useBusinessDaysForDisplayRange: useBusinessDaysForWbsDisplayRange(),
@@ -14488,7 +14417,6 @@ if (!customElements.get("lht-page-menu")) {
     }
     function updateSummary(model) {
         updateSvgButton();
-        syncWbsHolidayDatesInput(model);
         getElement("summaryProjectName").textContent = (model === null || model === void 0 ? void 0 : model.project.name) || "-";
         getElement("summaryTaskCount").textContent = String((model === null || model === void 0 ? void 0 : model.tasks.length) || 0);
         getElement("summaryResourceCount").textContent = String((model === null || model === void 0 ? void 0 : model.resources.length) || 0);
@@ -14885,18 +14813,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     function exportCurrentWbsXlsx() {
         const model = ensureCurrentModel();
         syncXmlTextFromModel(model);
-        const defaultHolidayDates = parseWbsDefaultHolidayDates();
-        const displayDaysBeforeBaseDate = parseWbsDisplayDaysBeforeBaseDate();
-        const displayDaysAfterBaseDate = parseWbsDisplayDaysAfterBaseDate();
-        const useBusinessDaysForDisplayRange = useBusinessDaysForWbsDisplayRange();
-        const useBusinessDaysForProgressBand = useBusinessDaysForWbsProgressBand();
-        const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, {
-            holidayDates: defaultHolidayDates,
-            displayDaysBeforeBaseDate,
-            displayDaysAfterBaseDate,
-            useBusinessDaysForDisplayRange,
-            useBusinessDaysForProgressBand
-        });
+        const options = buildCurrentWbsOptions(model);
+        const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, options);
         const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
         const bytes = codec.exportWorkbook(workbook);
         const now = new Date();
@@ -14908,11 +14826,11 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             String(now.getMinutes()).padStart(2, "0")
         ].join("");
         downloadBlob(new Blob([bytes], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }), `mikuproject-wbs-${stamp}.xlsx`);
-        const displayRangeText = displayDaysBeforeBaseDate !== undefined || displayDaysAfterBaseDate !== undefined
-            ? ` / 表示期間 営業日 基準日前 ${displayDaysBeforeBaseDate || 0} 日, 基準日後 ${displayDaysAfterBaseDate || 0} 日`
+        const displayRangeText = options.displayDaysBeforeBaseDate !== undefined || options.displayDaysAfterBaseDate !== undefined
+            ? ` / 表示期間 営業日 基準日前 ${options.displayDaysBeforeBaseDate || 0} 日, 基準日後 ${options.displayDaysAfterBaseDate || 0} 日`
             : "";
         const progressBandText = " / 進捗帯 営業日";
-        setStatus(`WBS XLSX ファイルをエクスポートしました${defaultHolidayDates.length > 0 ? ` (祝日 ${defaultHolidayDates.length} 件)` : ""}${displayRangeText}${progressBandText}`);
+        setStatus(`WBS XLSX ファイルをエクスポートしました${options.holidayDates.length > 0 ? ` (祝日 ${options.holidayDates.length} 件)` : ""}${displayRangeText}${progressBandText}`);
         showToast("WBS XLSX を保存しました");
         setActiveTab("output");
     }
@@ -15078,19 +14996,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     function downloadCurrentWbsMarkdown() {
         const model = ensureCurrentModel();
         syncXmlTextFromModel(model);
-        const defaultHolidayDates = mikuprojectWbsXlsx.collectWbsHolidayDates(model);
-        syncWbsHolidayDatesInput(model);
-        const displayDaysBeforeBaseDate = parseOptionalNonNegativeInteger(getInput("wbsDisplayDaysBeforeInput").value);
-        const displayDaysAfterBaseDate = parseOptionalNonNegativeInteger(getInput("wbsDisplayDaysAfterInput").value);
-        const useBusinessDaysForDisplayRange = useBusinessDaysForWbsDisplayRange();
-        const useBusinessDaysForProgressBand = useBusinessDaysForWbsProgressBand();
-        const markdownText = mikuprojectWbsMarkdown.exportWbsMarkdown(model, {
-            holidayDates: defaultHolidayDates,
-            displayDaysBeforeBaseDate,
-            displayDaysAfterBaseDate,
-            useBusinessDaysForDisplayRange,
-            useBusinessDaysForProgressBand
-        });
+        const options = buildCurrentWbsOptions(model);
+        const markdownText = mikuprojectWbsMarkdown.exportWbsMarkdown(model, options);
         const now = new Date();
         const stamp = [
             now.getFullYear(),

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -151,33 +151,6 @@
         }
         setActiveTab(currentTabId);
     }
-    function parseHolidayDateList(raw) {
-        if (!raw) {
-            return [];
-        }
-        const seen = new Set();
-        const holidays = [];
-        for (const token of raw.split(/[\s,、;]+/)) {
-            const value = token.trim();
-            if (!value) {
-                continue;
-            }
-            const match = value.match(/^(\d{4}-\d{2}-\d{2})/);
-            if (!match) {
-                continue;
-            }
-            const dateText = match[1];
-            if (seen.has(dateText)) {
-                continue;
-            }
-            seen.add(dateText);
-            holidays.push(dateText);
-        }
-        return holidays;
-    }
-    function parseWbsDefaultHolidayDates() {
-        return parseHolidayDateList(getTextArea("wbsHolidayDatesInput").value.trim());
-    }
     function parseOptionalNonNegativeInteger(raw) {
         const value = raw.trim();
         if (!value) {
@@ -200,37 +173,6 @@
     }
     function useBusinessDaysForWbsProgressBand() {
         return true;
-    }
-    function updateWbsHolidaySummary(holidayDates) {
-        const summary = getElement("wbsHolidaySummary");
-        if (holidayDates.length === 0) {
-            summary.textContent = "既定祝日: 0 件";
-            return;
-        }
-        summary.textContent = `既定祝日: ${holidayDates.length} 件 (${holidayDates.join(", ")})`;
-    }
-    function syncWbsHolidayDatesInput(model) {
-        const input = getTextArea("wbsHolidayDatesInput");
-        if (!model) {
-            input.value = "";
-            updateWbsHolidaySummary([]);
-            return;
-        }
-        const holidayDates = mikuprojectWbsXlsx.collectWbsHolidayDates(model);
-        const nextValue = holidayDates.join("\n");
-        const fieldHost = document.querySelector(`lht-text-field-help[field-id="wbsHolidayDatesInput"]`);
-        if (fieldHost) {
-            window.requestAnimationFrame(() => {
-                const latestInput = document.getElementById("wbsHolidayDatesInput");
-                if (latestInput) {
-                    latestInput.value = nextValue;
-                }
-            });
-        }
-        else {
-            input.value = nextValue;
-        }
-        updateWbsHolidaySummary(holidayDates);
     }
     function showToast(message) {
         const toast = document.getElementById("toast");
@@ -319,9 +261,8 @@
         monthlyWbsButton.disabled = disabled;
     }
     function buildCurrentWbsOptions(model) {
-        syncWbsHolidayDatesInput(model);
         return {
-            holidayDates: parseWbsDefaultHolidayDates(),
+            holidayDates: mikuprojectWbsXlsx.collectWbsHolidayDates(model),
             displayDaysBeforeBaseDate: parseWbsDisplayDaysBeforeBaseDate(),
             displayDaysAfterBaseDate: parseWbsDisplayDaysAfterBaseDate(),
             useBusinessDaysForDisplayRange: useBusinessDaysForWbsDisplayRange(),
@@ -866,7 +807,6 @@
     }
     function updateSummary(model) {
         updateSvgButton();
-        syncWbsHolidayDatesInput(model);
         getElement("summaryProjectName").textContent = (model === null || model === void 0 ? void 0 : model.project.name) || "-";
         getElement("summaryTaskCount").textContent = String((model === null || model === void 0 ? void 0 : model.tasks.length) || 0);
         getElement("summaryResourceCount").textContent = String((model === null || model === void 0 ? void 0 : model.resources.length) || 0);
@@ -1263,18 +1203,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     function exportCurrentWbsXlsx() {
         const model = ensureCurrentModel();
         syncXmlTextFromModel(model);
-        const defaultHolidayDates = parseWbsDefaultHolidayDates();
-        const displayDaysBeforeBaseDate = parseWbsDisplayDaysBeforeBaseDate();
-        const displayDaysAfterBaseDate = parseWbsDisplayDaysAfterBaseDate();
-        const useBusinessDaysForDisplayRange = useBusinessDaysForWbsDisplayRange();
-        const useBusinessDaysForProgressBand = useBusinessDaysForWbsProgressBand();
-        const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, {
-            holidayDates: defaultHolidayDates,
-            displayDaysBeforeBaseDate,
-            displayDaysAfterBaseDate,
-            useBusinessDaysForDisplayRange,
-            useBusinessDaysForProgressBand
-        });
+        const options = buildCurrentWbsOptions(model);
+        const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, options);
         const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
         const bytes = codec.exportWorkbook(workbook);
         const now = new Date();
@@ -1286,11 +1216,11 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             String(now.getMinutes()).padStart(2, "0")
         ].join("");
         downloadBlob(new Blob([bytes], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }), `mikuproject-wbs-${stamp}.xlsx`);
-        const displayRangeText = displayDaysBeforeBaseDate !== undefined || displayDaysAfterBaseDate !== undefined
-            ? ` / 表示期間 営業日 基準日前 ${displayDaysBeforeBaseDate || 0} 日, 基準日後 ${displayDaysAfterBaseDate || 0} 日`
+        const displayRangeText = options.displayDaysBeforeBaseDate !== undefined || options.displayDaysAfterBaseDate !== undefined
+            ? ` / 表示期間 営業日 基準日前 ${options.displayDaysBeforeBaseDate || 0} 日, 基準日後 ${options.displayDaysAfterBaseDate || 0} 日`
             : "";
         const progressBandText = " / 進捗帯 営業日";
-        setStatus(`WBS XLSX ファイルをエクスポートしました${defaultHolidayDates.length > 0 ? ` (祝日 ${defaultHolidayDates.length} 件)` : ""}${displayRangeText}${progressBandText}`);
+        setStatus(`WBS XLSX ファイルをエクスポートしました${options.holidayDates.length > 0 ? ` (祝日 ${options.holidayDates.length} 件)` : ""}${displayRangeText}${progressBandText}`);
         showToast("WBS XLSX を保存しました");
         setActiveTab("output");
     }
@@ -1456,19 +1386,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     function downloadCurrentWbsMarkdown() {
         const model = ensureCurrentModel();
         syncXmlTextFromModel(model);
-        const defaultHolidayDates = mikuprojectWbsXlsx.collectWbsHolidayDates(model);
-        syncWbsHolidayDatesInput(model);
-        const displayDaysBeforeBaseDate = parseOptionalNonNegativeInteger(getInput("wbsDisplayDaysBeforeInput").value);
-        const displayDaysAfterBaseDate = parseOptionalNonNegativeInteger(getInput("wbsDisplayDaysAfterInput").value);
-        const useBusinessDaysForDisplayRange = useBusinessDaysForWbsDisplayRange();
-        const useBusinessDaysForProgressBand = useBusinessDaysForWbsProgressBand();
-        const markdownText = mikuprojectWbsMarkdown.exportWbsMarkdown(model, {
-            holidayDates: defaultHolidayDates,
-            displayDaysBeforeBaseDate,
-            displayDaysAfterBaseDate,
-            useBusinessDaysForDisplayRange,
-            useBusinessDaysForProgressBand
-        });
+        const options = buildCurrentWbsOptions(model);
+        const markdownText = mikuprojectWbsMarkdown.exportWbsMarkdown(model, options);
         const now = new Date();
         const stamp = [
             now.getFullYear(),

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -315,35 +315,6 @@
     setActiveTab(currentTabId);
   }
 
-  function parseHolidayDateList(raw: string): string[] {
-    if (!raw) {
-      return [];
-    }
-    const seen = new Set<string>();
-    const holidays: string[] = [];
-    for (const token of raw.split(/[\s,、;]+/)) {
-      const value = token.trim();
-      if (!value) {
-        continue;
-      }
-      const match = value.match(/^(\d{4}-\d{2}-\d{2})/);
-      if (!match) {
-        continue;
-      }
-      const dateText = match[1];
-      if (seen.has(dateText)) {
-        continue;
-      }
-      seen.add(dateText);
-      holidays.push(dateText);
-    }
-    return holidays;
-  }
-
-  function parseWbsDefaultHolidayDates(): string[] {
-    return parseHolidayDateList(getTextArea("wbsHolidayDatesInput").value.trim());
-  }
-
   function parseOptionalNonNegativeInteger(raw: string): number | undefined {
     const value = raw.trim();
     if (!value) {
@@ -370,38 +341,6 @@
 
   function useBusinessDaysForWbsProgressBand(): boolean {
     return true;
-  }
-
-  function updateWbsHolidaySummary(holidayDates: string[]): void {
-    const summary = getElement<HTMLElement>("wbsHolidaySummary");
-    if (holidayDates.length === 0) {
-      summary.textContent = "既定祝日: 0 件";
-      return;
-    }
-    summary.textContent = `既定祝日: ${holidayDates.length} 件 (${holidayDates.join(", ")})`;
-  }
-
-  function syncWbsHolidayDatesInput(model: ProjectModel | null): void {
-    const input = getTextArea("wbsHolidayDatesInput");
-    if (!model) {
-      input.value = "";
-      updateWbsHolidaySummary([]);
-      return;
-    }
-    const holidayDates = mikuprojectWbsXlsx.collectWbsHolidayDates(model);
-    const nextValue = holidayDates.join("\n");
-    const fieldHost = document.querySelector(`lht-text-field-help[field-id="wbsHolidayDatesInput"]`);
-    if (fieldHost) {
-      window.requestAnimationFrame(() => {
-        const latestInput = document.getElementById("wbsHolidayDatesInput") as HTMLTextAreaElement | null;
-        if (latestInput) {
-          latestInput.value = nextValue;
-        }
-      });
-    } else {
-      input.value = nextValue;
-    }
-    updateWbsHolidaySummary(holidayDates);
   }
 
   function showToast(message: string): void {
@@ -507,9 +446,8 @@
     useBusinessDaysForDisplayRange?: boolean;
     useBusinessDaysForProgressBand?: boolean;
   } {
-    syncWbsHolidayDatesInput(model);
     return {
-      holidayDates: parseWbsDefaultHolidayDates(),
+      holidayDates: mikuprojectWbsXlsx.collectWbsHolidayDates(model),
       displayDaysBeforeBaseDate: parseWbsDisplayDaysBeforeBaseDate(),
       displayDaysAfterBaseDate: parseWbsDisplayDaysAfterBaseDate(),
       useBusinessDaysForDisplayRange: useBusinessDaysForWbsDisplayRange(),
@@ -1128,7 +1066,6 @@
 
   function updateSummary(model: ProjectModel | null): void {
     updateSvgButton();
-    syncWbsHolidayDatesInput(model);
     getElement<HTMLElement>("summaryProjectName").textContent = model?.project.name || "-";
     getElement<HTMLElement>("summaryTaskCount").textContent = String(model?.tasks.length || 0);
     getElement<HTMLElement>("summaryResourceCount").textContent = String(model?.resources.length || 0);
@@ -1569,18 +1506,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
   function exportCurrentWbsXlsx(): void {
     const model = ensureCurrentModel();
     syncXmlTextFromModel(model);
-    const defaultHolidayDates = parseWbsDefaultHolidayDates();
-    const displayDaysBeforeBaseDate = parseWbsDisplayDaysBeforeBaseDate();
-    const displayDaysAfterBaseDate = parseWbsDisplayDaysAfterBaseDate();
-    const useBusinessDaysForDisplayRange = useBusinessDaysForWbsDisplayRange();
-    const useBusinessDaysForProgressBand = useBusinessDaysForWbsProgressBand();
-    const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, {
-      holidayDates: defaultHolidayDates,
-      displayDaysBeforeBaseDate,
-      displayDaysAfterBaseDate,
-      useBusinessDaysForDisplayRange,
-      useBusinessDaysForProgressBand
-    });
+    const options = buildCurrentWbsOptions(model);
+    const workbook = mikuprojectWbsXlsx.exportWbsWorkbook(model, options);
     const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
     const bytes = codec.exportWorkbook(workbook);
     const now = new Date();
@@ -1595,11 +1522,11 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
       new Blob([bytes], { type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }),
       `mikuproject-wbs-${stamp}.xlsx`
     );
-    const displayRangeText = displayDaysBeforeBaseDate !== undefined || displayDaysAfterBaseDate !== undefined
-      ? ` / 表示期間 営業日 基準日前 ${displayDaysBeforeBaseDate || 0} 日, 基準日後 ${displayDaysAfterBaseDate || 0} 日`
+    const displayRangeText = options.displayDaysBeforeBaseDate !== undefined || options.displayDaysAfterBaseDate !== undefined
+      ? ` / 表示期間 営業日 基準日前 ${options.displayDaysBeforeBaseDate || 0} 日, 基準日後 ${options.displayDaysAfterBaseDate || 0} 日`
       : "";
     const progressBandText = " / 進捗帯 営業日";
-    setStatus(`WBS XLSX ファイルをエクスポートしました${defaultHolidayDates.length > 0 ? ` (祝日 ${defaultHolidayDates.length} 件)` : ""}${displayRangeText}${progressBandText}`);
+    setStatus(`WBS XLSX ファイルをエクスポートしました${options.holidayDates.length > 0 ? ` (祝日 ${options.holidayDates.length} 件)` : ""}${displayRangeText}${progressBandText}`);
     showToast("WBS XLSX を保存しました");
     setActiveTab("output");
   }
@@ -1785,19 +1712,8 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
   function downloadCurrentWbsMarkdown(): void {
     const model = ensureCurrentModel();
     syncXmlTextFromModel(model);
-    const defaultHolidayDates = mikuprojectWbsXlsx.collectWbsHolidayDates(model);
-    syncWbsHolidayDatesInput(model);
-    const displayDaysBeforeBaseDate = parseOptionalNonNegativeInteger(getInput("wbsDisplayDaysBeforeInput").value);
-    const displayDaysAfterBaseDate = parseOptionalNonNegativeInteger(getInput("wbsDisplayDaysAfterInput").value);
-    const useBusinessDaysForDisplayRange = useBusinessDaysForWbsDisplayRange();
-    const useBusinessDaysForProgressBand = useBusinessDaysForWbsProgressBand();
-    const markdownText = mikuprojectWbsMarkdown.exportWbsMarkdown(model, {
-      holidayDates: defaultHolidayDates,
-      displayDaysBeforeBaseDate,
-      displayDaysAfterBaseDate,
-      useBusinessDaysForDisplayRange,
-      useBusinessDaysForProgressBand
-    });
+    const options = buildCurrentWbsOptions(model);
+    const markdownText = mikuprojectWbsMarkdown.exportWbsMarkdown(model, options);
     const now = new Date();
     const stamp = [
       now.getFullYear(),

--- a/tests/mikuproject-main.test.js
+++ b/tests/mikuproject-main.test.js
@@ -214,16 +214,14 @@ function mountDom() {
         <summary class="md-debug-accordion__summary">設定</summary>
         <div class="md-debug-accordion__body">
           <section class="md-note-card">
-            <h3 class="md-note-card__title">WBS XLSX の祝日指定</h3>
+            <h3 class="md-note-card__title">WBS XLSX 表示設定</h3>
             <p class="md-note-card__text">WBS XLSX Export では、ProjectModel から補完した既定祝日を WBS 日付帯へ反映します。</p>
-            <p class="md-note-card__text">既定祝日は、現在の ProjectModel に含まれる Calendar.Exceptions の非稼働日例外から補完します。画面では Calendars / Exceptions を直接編集せず、必要な変更は MS Project XML または XLSX Import 側で扱います。表示期間を空欄にすると全期間、数値を入れると BaseDate 前後の営業日で切り出します。進捗帯も営業日基準で計算します。</p>
+            <p class="md-note-card__text">既定祝日は、現在の ProjectModel に含まれる Calendar.Exceptions の非稼働日例外から内部で直接補完します。画面では Calendars / Exceptions を直接編集せず、必要な変更は MS Project XML または XLSX Import 側で扱います。表示期間を空欄にすると全期間、数値を入れると BaseDate 前後の営業日で切り出します。進捗帯も営業日基準で計算します。</p>
           </section>
           <input id="wbsDisplayDaysBeforeInput" />
           <input id="wbsDisplayDaysAfterInput" />
           <input id="wbsBusinessDayRangeInput" type="checkbox" />
           <input id="wbsBusinessDayProgressInput" type="checkbox" />
-          <div id="wbsHolidaySummary"></div>
-          <textarea id="wbsHolidayDatesInput"></textarea>
         </div>
       </details>
       <details class="md-debug-accordion">
@@ -338,17 +336,15 @@ describe("mikuproject main", () => {
     expect(document.querySelector(".md-debug-accordion")?.hasAttribute("open")).toBe(false);
     expect(document.querySelectorAll(".md-debug-accordion")[1]?.hasAttribute("open")).toBe(false);
     expect(document.querySelector(".md-note-accordion")?.hasAttribute("open")).toBe(false);
-    expect(document.body.textContent).toContain("WBS XLSX の祝日指定");
+    expect(document.body.textContent).toContain("WBS XLSX 表示設定");
     expect(document.body.textContent).toContain("設定");
     expect(document.querySelectorAll(".md-debug-accordion")[2]?.hasAttribute("open")).toBe(false);
     expect(document.querySelectorAll(".md-debug-accordion")[3]?.hasAttribute("open")).toBe(false);
     expect(document.body.textContent).toContain("ProjectModel から補完した既定祝日");
-    expect(document.body.textContent).toContain("非稼働日例外から補完");
+    expect(document.body.textContent).toContain("非稼働日例外から内部で直接補完");
     expect(document.body.textContent).toContain("必要な変更は MS Project XML または XLSX Import 側で扱います");
     expect(document.body.textContent).toContain("BaseDate 前後の営業日で切り出します");
     expect(document.body.textContent).toContain("進捗帯も営業日基準で計算します");
-    expect(document.getElementById("wbsHolidayDatesInput").value).toBe("2026-03-20");
-    expect(document.getElementById("wbsHolidaySummary").textContent).toBe("既定祝日: 1 件 (2026-03-20)");
     expect(document.getElementById("wbsDisplayDaysBeforeInput").value).toBe("");
     expect(document.getElementById("wbsDisplayDaysAfterInput").value).toBe("");
     expect(document.querySelector(".md-feedback-stack")?.classList.contains("md-hidden")).toBe(true);
@@ -499,6 +495,56 @@ describe("mikuproject main", () => {
     expect(document.getElementById("modelOutput").value).toContain("\"uid\": \"4\"");
     expect(document.getElementById("modelOutput").value).not.toContain("\"uid\": \"draft-4\"");
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Standard\"");
+  });
+
+  it("limits default calendar holiday exceptions to the project date range", () => {
+    const xmlTools = bootXmlModule();
+
+    const model = {
+      project: {
+        name: "祝日範囲確認",
+        title: "祝日範囲確認",
+        startDate: "2026-03-18T09:00:00",
+        finishDate: "2026-03-22T18:00:00",
+        scheduleFromStart: true,
+        currentDate: "2026-03-20T09:00:00",
+        calendarUID: undefined,
+        outlineCodes: [],
+        wbsMasks: [],
+        extendedAttributes: []
+      },
+      tasks: [
+        {
+          uid: "1",
+          id: "1",
+          name: "確認タスク",
+          outlineLevel: 1,
+          outlineNumber: "1",
+          start: "2026-03-18T09:00:00",
+          finish: "2026-03-22T18:00:00",
+          duration: "PT40H0M0S",
+          milestone: false,
+          summary: false,
+          percentComplete: 0,
+          extendedAttributes: [],
+          baselines: [],
+          timephasedData: [],
+          predecessors: []
+        }
+      ],
+      resources: [],
+      assignments: [],
+      calendars: []
+    };
+
+    const exportedXml = xmlTools.exportMsProjectXml(model);
+    const reparsedModel = xmlTools.importMsProjectXml(exportedXml);
+
+    expect(reparsedModel.calendars).toHaveLength(1);
+    const holidayDates = reparsedModel.calendars[0].exceptions.map((exception) => exception.fromDate?.slice(0, 10));
+    expect(holidayDates).toContain("2026-03-20");
+    expect(holidayDates).not.toContain("2026-02-11");
+    expect(holidayDates).not.toContain("2026-04-29");
   });
 
   it("loads sample project_draft_view into the input area", () => {
@@ -886,7 +932,6 @@ describe("mikuproject main", () => {
     expect(HTMLAnchorElement.prototype.click).toHaveBeenCalled();
     const clickedAnchor = HTMLAnchorElement.prototype.click.mock.instances.at(-1);
     expect(clickedAnchor.download).toBe("mikuproject-wbs-202603162312.xlsx");
-    expect(document.getElementById("wbsHolidayDatesInput").value.split("\n")).toEqual(defaultHolidayDates);
     expect(exportSpy.mock.calls.at(-1)?.[1]).toEqual({
       holidayDates: defaultHolidayDates,
       displayDaysBeforeBaseDate: undefined,
@@ -957,17 +1002,6 @@ describe("mikuproject main", () => {
       useBusinessDaysForProgressBand: true
     });
     expect(document.getElementById("statusMessage").textContent).toContain("進捗帯 営業日");
-  });
-
-  it("fills wbs holiday input from model defaults when xml is parsed", () => {
-    bootPage();
-
-    parseXmlViaHook();
-    const defaultHolidayDates = getDefaultSampleHolidayDates();
-
-    expect(document.getElementById("wbsHolidayDatesInput").value.split("\n")).toEqual(defaultHolidayDates);
-    expect(document.getElementById("wbsHolidaySummary").textContent).toContain(`既定祝日: ${SAMPLE_HOLIDAY_COUNT} 件`);
-    expect(document.getElementById("wbsHolidaySummary").textContent).toContain("2026-03-20");
   });
 
   it("imports xlsx edits back into the current model and xml", async () => {

--- a/tests/mikuproject-wbs-xlsx.test.js
+++ b/tests/mikuproject-wbs-xlsx.test.js
@@ -590,6 +590,32 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.rows[headerRowIndex + 1].cells[24].fillColor).toBe("#FCE4EC");
   });
 
+  it("uses different fills for holiday-derived and weekday-derived non-working days", () => {
+    const { xml, wbsXlsx } = bootModules();
+    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+
+    model.project.startDate = "2026-03-20T09:00:00";
+    model.project.finishDate = "2026-03-22T18:00:00";
+    model.project.currentDate = "2026-03-19T09:00:00";
+
+    const workbook = wbsXlsx.exportWbsWorkbook(model, {
+      holidayDates: ["2026-03-20"]
+    });
+    const sheet = workbook.sheets[0];
+    const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
+    const dateRow = sheet.rows[headerRowIndex - 1];
+    const weekdayRow = sheet.rows[headerRowIndex];
+
+    expect(dateRow.cells[20].value).toBe("3/20");
+    expect(dateRow.cells[21].value).toBe("3/21");
+    expect(weekdayRow.cells[20].value).toBe("Fri");
+    expect(weekdayRow.cells[21].value).toBe("Sat");
+    expect(dateRow.cells[20].fillColor).toBe("#FCE4EC");
+    expect(dateRow.cells[21].fillColor).toBe("#EEF3F8");
+    expect(weekdayRow.cells[20].fillColor).toBe("#FCE4EC");
+    expect(weekdayRow.cells[21].fillColor).toBe("#EEF3F8");
+  });
+
   it("can limit the displayed date band around base date", () => {
     const { xml, wbsXlsx } = bootModules();
     const model = xml.importMsProjectXml(xml.SAMPLE_XML);


### PR DESCRIPTION
## 概要

指定コミットでは、`WBS XLSX` の祝日指定 UI を削除し、既定祝日の扱いを `ProjectModel` 由来の内部ロジックへ寄せています。 あわせて、関連する TODO を整理し、`main` テストと `wbs-xlsx` テストを更新しています。

## 変更内容

- `src/ts/main.ts`
  - `wbsHolidayDatesInput` / `wbsHolidaySummary` を前提にした処理を削除
  - `buildCurrentWbsOptions()` が `ProjectModel` から直接 `holidayDates` を組み立てるよう変更
  - `WBS XLSX` / `WBS Markdown` 出力で、UI 入力ではなく内部の祝日収集結果を使うよう整理
  - `updateSummary()` から祝日入力同期処理を削除

- `src/js/main.js`
  - 上記 TypeScript 変更の生成物更新

- `mikuproject-src.html`
- `mikuproject.html`
  - `WBS XLSX の祝日指定` UI を削除
  - 設定見出しを `WBS XLSX 表示設定` に変更
  - 既定祝日を「内部で直接補完する」旨の説明に更新

- `docs/TODO.md`
  - `WBS XLSX` の祝日指定 UI 削除に関する TODO を削除
  - 既定 calendar の祝日 `Exceptions` の期間制限
  - `WeekDays / Exceptions` の由来で描き分ける件
  - 上記の完了済み項目もあわせて削除

- `tests/mikuproject-main.test.js`
  - 祝日入力 UI を前提とした検証を削除
  - 内部補完前提の文言・挙動に合わせてテストを更新

- `tests/mikuproject-wbs-xlsx.test.js`
  - 祝日由来の非稼働日と週末由来の非稼働日で、異なる fill が使われることを確認するテストを追加

## 目的

- 祝日反映を UI 入力ではなく `ProjectModel` ベースに統一すること
- `WBS XLSX` 出力設定から不要な祝日指定導線を取り除くこと
- 実装済みの祝日関連 TODO を整理すること
- 祝日と週末の描き分けをテストで固定すること

## 影響範囲

- `WBS XLSX` / `WBS Markdown` 出力時の祝日オプション組み立て
- Output 設定 UI
- 祝日関連のドキュメントとテスト