### PR TITLE
Input / Overview / Output のデバッグUIを整理し、設定説明をツールチップへ移動

### DIFF
--- a/mikuproject-src.html
+++ b/mikuproject-src.html
@@ -144,14 +144,9 @@
           </div>
         </details>
 
-        <details class="md-debug-accordion">
-          <summary class="md-debug-accordion__summary">デバッグ情報</summary>
-          <div class="md-debug-accordion__body">
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="xmlInput" label="MS Project XML" rows="16" placeholder="ここに XML を入力" help-text="MS Project XML を読み込みます。"></lht-text-field-help>
-            </div>
-          </div>
-        </details>
+        <div hidden aria-hidden="true">
+          <textarea id="xmlInput"></textarea>
+        </div>
 
         <div id="xmlSaveState" class="md-save-state md-save-state--dirty" aria-live="polite">XML 保存状態: 未保存</div>
       </section>
@@ -219,10 +214,6 @@
               <lht-text-field-help field-id="modelOutput" label="内部モデル(JSON)" rows="16" readonly></lht-text-field-help>
             </div>
 
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="mermaidOutput" label="Mermaid gantt" rows="12" readonly></lht-text-field-help>
-            </div>
-
             <div class="md-preview-grid">
               <section class="md-preview-card">
                 <h3 class="md-preview-card__title">Project</h3>
@@ -247,6 +238,10 @@
             </div>
           </div>
         </details>
+
+        <div hidden aria-hidden="true">
+          <textarea id="mermaidOutput"></textarea>
+        </div>
 
         <div class="md-feedback-stack md-hidden" aria-label="import feedback">
           <div class="md-feedback-stack__title">取込結果</div>
@@ -395,13 +390,14 @@
             <summary class="ms-settings-summary">設定</summary>
             <div class="ms-settings-body">
               <section class="ms-settings-block" aria-label="WBS xlsx export options">
-                <h3 class="ms-settings-subtitle">WBS XLSX 表示設定</h3>
-              <p class="md-note-card__text">
-                `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日を WBS 日付帯へ反映します。
-              </p>
-              <p class="md-note-card__text">
-                既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から内部で直接補完します。画面では `Calendars / Exceptions` を直接編集せず、必要な変更は `MS Project XML` または `XLSX Import` 側で扱います。表示期間を空欄にすると全期間、数値を入れると `BaseDate` 前後の営業日で切り出します。進捗帯も営業日基準で計算します。
-              </p>
+                <h3 class="ms-settings-subtitle">
+                  <span>WBS XLSX 表示設定</span>
+                  <lht-help-tooltip label="WBS XLSX 表示設定の説明" placement="right" wide>
+                    `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日を WBS 日付帯へ反映します。
+
+                    既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から内部で直接補完します。画面では `Calendars / Exceptions` を直接編集せず、必要な変更は `MS Project XML` または `XLSX Import` 側で扱います。表示期間を空欄にすると全期間、数値を入れると `BaseDate` 前後の営業日で切り出します。進捗帯も営業日基準で計算します。
+                  </lht-help-tooltip>
+                </h3>
               <div class="md-form-grid md-form-grid--two">
                 <lht-text-field-help
                   field-id="wbsDisplayDaysBeforeInput"
@@ -421,24 +417,15 @@
           </details>
         </section>
 
-        <details class="md-debug-accordion">
-          <summary class="md-debug-accordion__summary">デバッグ情報</summary>
-          <div class="md-debug-accordion__body">
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="workbookJsonOutput" label="mikuproject_workbook_json" rows="16" readonly></lht-text-field-help>
-            </div>
-
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="aiBundleOutput" label="ai_projection_bundle" rows="16" readonly></lht-text-field-help>
-            </div>
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="projectOverviewOutput" label="project_overview_view" rows="14" readonly></lht-text-field-help>
-            </div>
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="phaseDetailOutput" label="phase_detail_view" rows="16" readonly></lht-text-field-help>
-            </div>
-          </div>
-        </details>
+        <div hidden aria-hidden="true">
+          <textarea id="workbookJsonOutput"></textarea>
+          <textarea id="aiBundleOutput"></textarea>
+          <textarea id="projectOverviewOutput"></textarea>
+          <input id="phaseDetailUidInput" type="text" />
+          <input id="phaseDetailRootUidInput" type="text" />
+          <input id="phaseDetailMaxDepthInput" type="text" />
+          <textarea id="phaseDetailOutput"></textarea>
+        </div>
       </section>
     </section>
 

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -2667,14 +2667,9 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
           </div>
         </details>
 
-        <details class="md-debug-accordion">
-          <summary class="md-debug-accordion__summary">デバッグ情報</summary>
-          <div class="md-debug-accordion__body">
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="xmlInput" label="MS Project XML" rows="16" placeholder="ここに XML を入力" help-text="MS Project XML を読み込みます。"></lht-text-field-help>
-            </div>
-          </div>
-        </details>
+        <div hidden aria-hidden="true">
+          <textarea id="xmlInput"></textarea>
+        </div>
 
         <div id="xmlSaveState" class="md-save-state md-save-state--dirty" aria-live="polite">XML 保存状態: 未保存</div>
       </section>
@@ -2742,10 +2737,6 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
               <lht-text-field-help field-id="modelOutput" label="内部モデル(JSON)" rows="16" readonly></lht-text-field-help>
             </div>
 
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="mermaidOutput" label="Mermaid gantt" rows="12" readonly></lht-text-field-help>
-            </div>
-
             <div class="md-preview-grid">
               <section class="md-preview-card">
                 <h3 class="md-preview-card__title">Project</h3>
@@ -2770,6 +2761,10 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
             </div>
           </div>
         </details>
+
+        <div hidden aria-hidden="true">
+          <textarea id="mermaidOutput"></textarea>
+        </div>
 
         <div class="md-feedback-stack md-hidden" aria-label="import feedback">
           <div class="md-feedback-stack__title">取込結果</div>
@@ -2918,13 +2913,14 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
             <summary class="ms-settings-summary">設定</summary>
             <div class="ms-settings-body">
               <section class="ms-settings-block" aria-label="WBS xlsx export options">
-                <h3 class="ms-settings-subtitle">WBS XLSX 表示設定</h3>
-              <p class="md-note-card__text">
-                `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日を WBS 日付帯へ反映します。
-              </p>
-              <p class="md-note-card__text">
-                既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から内部で直接補完します。画面では `Calendars / Exceptions` を直接編集せず、必要な変更は `MS Project XML` または `XLSX Import` 側で扱います。表示期間を空欄にすると全期間、数値を入れると `BaseDate` 前後の営業日で切り出します。進捗帯も営業日基準で計算します。
-              </p>
+                <h3 class="ms-settings-subtitle">
+                  <span>WBS XLSX 表示設定</span>
+                  <lht-help-tooltip label="WBS XLSX 表示設定の説明" placement="right" wide>
+                    `WBS XLSX Export` では、`ProjectModel` から補完した既定祝日を WBS 日付帯へ反映します。
+
+                    既定祝日は、現在の `ProjectModel` に含まれる `Calendar.Exceptions` の非稼働日例外から内部で直接補完します。画面では `Calendars / Exceptions` を直接編集せず、必要な変更は `MS Project XML` または `XLSX Import` 側で扱います。表示期間を空欄にすると全期間、数値を入れると `BaseDate` 前後の営業日で切り出します。進捗帯も営業日基準で計算します。
+                  </lht-help-tooltip>
+                </h3>
               <div class="md-form-grid md-form-grid--two">
                 <lht-text-field-help
                   field-id="wbsDisplayDaysBeforeInput"
@@ -2944,24 +2940,15 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
           </details>
         </section>
 
-        <details class="md-debug-accordion">
-          <summary class="md-debug-accordion__summary">デバッグ情報</summary>
-          <div class="md-debug-accordion__body">
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="workbookJsonOutput" label="mikuproject_workbook_json" rows="16" readonly></lht-text-field-help>
-            </div>
-
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="aiBundleOutput" label="ai_projection_bundle" rows="16" readonly></lht-text-field-help>
-            </div>
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="projectOverviewOutput" label="project_overview_view" rows="14" readonly></lht-text-field-help>
-            </div>
-            <div class="md-form-grid">
-              <lht-text-field-help field-id="phaseDetailOutput" label="phase_detail_view" rows="16" readonly></lht-text-field-help>
-            </div>
-          </div>
-        </details>
+        <div hidden aria-hidden="true">
+          <textarea id="workbookJsonOutput"></textarea>
+          <textarea id="aiBundleOutput"></textarea>
+          <textarea id="projectOverviewOutput"></textarea>
+          <input id="phaseDetailUidInput" type="text" />
+          <input id="phaseDetailRootUidInput" type="text" />
+          <input id="phaseDetailMaxDepthInput" type="text" />
+          <textarea id="phaseDetailOutput"></textarea>
+        </div>
       </section>
     </section>
 

--- a/tests/mikuproject-main.test.js
+++ b/tests/mikuproject-main.test.js
@@ -131,12 +131,9 @@ function mountDom() {
           </lht-help-tooltip>
         </span>
       </span>
-      <details class="md-debug-accordion">
-        <summary class="md-debug-accordion__summary">デバッグ情報</summary>
-        <div class="md-debug-accordion__body">
+      <div hidden>
           <textarea id="xmlInput"></textarea>
-        </div>
-      </details>
+      </div>
       <details class="md-note-accordion">
         <summary class="md-note-accordion__summary">新規生成AI連携</summary>
         <div class="md-note-accordion__body">
@@ -181,7 +178,6 @@ function mountDom() {
         <div class="md-debug-accordion__body">
           <button id="roundTripBtn" type="button">再読込テスト</button>
           <textarea id="modelOutput"></textarea>
-          <textarea id="mermaidOutput"></textarea>
           <div id="projectPreview"></div>
           <div id="taskPreview"></div>
           <div id="resourcePreview"></div>
@@ -189,6 +185,9 @@ function mountDom() {
           <div id="calendarPreview"></div>
         </div>
       </details>
+      <div hidden>
+        <textarea id="mermaidOutput"></textarea>
+      </div>
       <div class="md-feedback-stack md-hidden">
         <div class="md-feedback-stack__title">取込結果</div>
         <div class="md-feedback-stack__text">取込後は、ここで差分反映・warning・検証結果を確認します。</div>
@@ -214,9 +213,13 @@ function mountDom() {
         <summary class="md-debug-accordion__summary">設定</summary>
         <div class="md-debug-accordion__body">
           <section class="md-note-card">
-            <h3 class="md-note-card__title">WBS XLSX 表示設定</h3>
-            <p class="md-note-card__text">WBS XLSX Export では、ProjectModel から補完した既定祝日を WBS 日付帯へ反映します。</p>
-            <p class="md-note-card__text">既定祝日は、現在の ProjectModel に含まれる Calendar.Exceptions の非稼働日例外から内部で直接補完します。画面では Calendars / Exceptions を直接編集せず、必要な変更は MS Project XML または XLSX Import 側で扱います。表示期間を空欄にすると全期間、数値を入れると BaseDate 前後の営業日で切り出します。進捗帯も営業日基準で計算します。</p>
+            <h3 class="md-note-card__title">
+              <span>WBS XLSX 表示設定</span>
+              <lht-help-tooltip label="WBS XLSX 表示設定の説明" placement="right" wide>
+                <p>WBS XLSX Export では、ProjectModel から補完した既定祝日を WBS 日付帯へ反映します。</p>
+                <p>既定祝日は、現在の ProjectModel に含まれる Calendar.Exceptions の非稼働日例外から内部で直接補完します。画面では Calendars / Exceptions を直接編集せず、必要な変更は MS Project XML または XLSX Import 側で扱います。表示期間を空欄にすると全期間、数値を入れると BaseDate 前後の営業日で切り出します。進捗帯も営業日基準で計算します。</p>
+              </lht-help-tooltip>
+            </h3>
           </section>
           <input id="wbsDisplayDaysBeforeInput" />
           <input id="wbsDisplayDaysAfterInput" />
@@ -224,9 +227,7 @@ function mountDom() {
           <input id="wbsBusinessDayProgressInput" type="checkbox" />
         </div>
       </details>
-      <details class="md-debug-accordion">
-        <summary class="md-debug-accordion__summary">デバッグ情報</summary>
-        <div class="md-debug-accordion__body">
+      <div hidden>
           <textarea id="workbookJsonOutput"></textarea>
           <textarea id="aiBundleOutput"></textarea>
           <textarea id="projectOverviewOutput"></textarea>
@@ -234,8 +235,7 @@ function mountDom() {
           <input id="phaseDetailRootUidInput" />
           <input id="phaseDetailMaxDepthInput" />
           <textarea id="phaseDetailOutput"></textarea>
-        </div>
-      </details>
+      </div>
     </section>
     <div id="toast"></div>
   `;
@@ -333,13 +333,13 @@ describe("mikuproject main", () => {
     expect(document.body.textContent).not.toContain("内部モデル、要約、検証結果、プレビューをここで確認します。");
     expect(document.body.textContent).not.toContain("出力設定と生成結果の確認をここにまとめます。");
     expect(document.body.textContent).toContain("デバッグ情報");
+    expect(document.querySelectorAll(".md-debug-accordion")).toHaveLength(2);
     expect(document.querySelector(".md-debug-accordion")?.hasAttribute("open")).toBe(false);
-    expect(document.querySelectorAll(".md-debug-accordion")[1]?.hasAttribute("open")).toBe(false);
     expect(document.querySelector(".md-note-accordion")?.hasAttribute("open")).toBe(false);
     expect(document.body.textContent).toContain("WBS XLSX 表示設定");
     expect(document.body.textContent).toContain("設定");
-    expect(document.querySelectorAll(".md-debug-accordion")[2]?.hasAttribute("open")).toBe(false);
-    expect(document.querySelectorAll(".md-debug-accordion")[3]?.hasAttribute("open")).toBe(false);
+    expect(document.querySelectorAll(".md-debug-accordion")[1]?.hasAttribute("open")).toBe(false);
+    expect(document.querySelector('lht-help-tooltip[label="WBS XLSX 表示設定の説明"]')).not.toBeNull();
     expect(document.body.textContent).toContain("ProjectModel から補完した既定祝日");
     expect(document.body.textContent).toContain("非稼働日例外から内部で直接補完");
     expect(document.body.textContent).toContain("必要な変更は MS Project XML または XLSX Import 側で扱います");


### PR DESCRIPTION
## 概要

指定コミットでは、`Input` / `Overview` / `Output` の各画面に残っていたデバッグ用途の表示を整理し、通常利用時に見える UI を簡素化しています。 あわせて、`WBS XLSX 表示設定` の説明文を見出し右側の `(i)` ツールチップへ移動し、関連テストを更新しています。

## 変更内容

- `mikuproject-src.html`
  - `Input` の見える `デバッグ情報` アコーディオンを削除
  - `xmlInput` を hidden の内部要素へ移動
  - `Overview` の `Mermaid gantt` textarea を見える UI から削除
  - `mermaidOutput` を hidden の内部要素へ移動
  - `Output` の見える `デバッグ情報` アコーディオンを削除
  - `workbookJsonOutput`、`aiBundleOutput`、`projectOverviewOutput`、`phaseDetailOutput` などの内部要素は hidden で保持
  - `WBS XLSX 表示設定` の説明文を見出し右側のツールチップへ移動

- `mikuproject.html`
  - 上記 HTML 変更の生成物更新

- `tests/mikuproject-main.test.js`
  - `デバッグ情報` アコーディオン数や hidden 要素化に合わせてテストを更新

## 目的

- 通常利用で不要なデバッグ表示を UI から外すこと
- 内部バッファや既存処理に必要な要素は hidden のまま維持すること
- `WBS XLSX 表示設定` の説明を、設定画面を圧迫しない形へ整理すること

## 影響範囲

- `Input` / `Overview` / `Output` タブの表示
- `WBS XLSX 表示設定` の説明表示方法
- 画面構造を前提にした `main` テスト