### PR TITLE
README 先頭に OGP 画像を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mikuproject
 
+![mikuproject OGP](docs/screenshots/mikuproject-ogp.png)
+
 GitHub: https://github.com/igapyon/mikuproject
 
 `mikuproject` は、`MS Project XML` を基軸に、変換・可視化・限定編集を行うローカル HTML ツールです。


### PR DESCRIPTION
## 概要

指定コミットでは、`README.md` のタイトル直下に `mikuproject` の OGP 画像を追加しています。

## 変更内容

- `README.md`
  - タイトル直下に `docs/screenshots/mikuproject-ogp.png` を追加

## 目的

- README を開いた直後に、`mikuproject` の紹介画像が見えるようにすること
- プロジェクトの全体像を、冒頭で視覚的に伝えやすくすること

## 影響範囲

- `README.md` の先頭表示