### PR TITLE
ロゴ検討用に追加の文字ロゴと記号アセットを拡充

### DIFF
--- a/docs/assets/2-logo.svg
+++ b/docs/assets/2-logo.svg
@@ -1,0 +1,27 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">2 wordmark dark</title>
+  <desc id="desc">The number 2 as a neutral connector mark for xlsx2md.</desc>
+  <g filter="url(#shadow)">
+    <text
+      x="800"
+      y="520"
+      text-anchor="middle"
+      fill="#2F3440"
+      font-family="'Avenir Next', 'Futura', 'Trebuchet MS', sans-serif"
+      font-size="320"
+      font-weight="800"
+      letter-spacing="4">2</text>
+  </g>
+  <defs>
+    <filter id="shadow" x="574" y="190" width="452" height="420" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="16"/>
+      <feGaussianBlur stdDeviation="18"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.184314 0 0 0 0 0.203922 0 0 0 0 0.25098 0 0 0 0.22 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1_1"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1_1" result="shape"/>
+    </filter>
+  </defs>
+</svg>

--- a/docs/assets/ai-symbol.svg
+++ b/docs/assets/ai-symbol.svg
@@ -1,0 +1,70 @@
+<svg width="1200" height="1200" viewBox="0 0 1200 1200" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">AI integration symbol</title>
+  <desc id="desc">An AI integration symbol with a dialog panel, structured nodes, and generated links inspired by mikuproject AI workflow.</desc>
+  <defs>
+    <linearGradient id="panel" x1="214" y1="194" x2="987" y2="1010" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#6D63D7"/>
+      <stop offset="1" stop-color="#3E3797"/>
+    </linearGradient>
+    <linearGradient id="sheet" x1="326" y1="324" x2="864" y2="892" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FCFBFF"/>
+      <stop offset="1" stop-color="#E8E3FA"/>
+    </linearGradient>
+    <linearGradient id="node" x1="448" y1="560" x2="742" y2="792" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#B1A8FF"/>
+      <stop offset="1" stop-color="#7F73E6"/>
+    </linearGradient>
+    <filter id="shadow" x="164" y="156" width="872" height="900" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="20"/>
+      <feGaussianBlur stdDeviation="26"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.243137 0 0 0 0 0.215686 0 0 0 0 0.592157 0 0 0 0.22 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1_1"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1_1" result="shape"/>
+    </filter>
+  </defs>
+
+  <g filter="url(#shadow)">
+    <rect x="216" y="208" width="768" height="784" rx="154" fill="url(#panel)"/>
+    <rect x="314" y="296" width="572" height="612" rx="72" fill="url(#sheet)"/>
+
+    <rect x="314" y="296" width="572" height="136" rx="72" fill="#4A41B3"/>
+    <rect x="382" y="348" width="210" height="30" rx="15" fill="#F0EDFF" fill-opacity="0.96"/>
+    <circle cx="794" cy="364" r="20" fill="#F0EDFF"/>
+    <circle cx="730" cy="364" r="20" fill="#D3CCFF"/>
+
+    <path d="M382 504C382 476.386 404.386 454 432 454H626C653.614 454 676 476.386 676 504V574C676 601.614 653.614 624 626 624H512L446 680V624H432C404.386 624 382 601.614 382 574V504Z" fill="#E7E2FB"/>
+    <rect x="430" y="506" width="188" height="24" rx="12" fill="#9D91ED"/>
+    <rect x="430" y="552" width="146" height="24" rx="12" fill="#C0B6F5"/>
+
+    <g stroke="#8B7FE8" stroke-width="14" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M524 664V726"/>
+      <path d="M524 726H430"/>
+      <path d="M524 726H618"/>
+      <path d="M618 726H730"/>
+      <path d="M430 726H358"/>
+    </g>
+
+    <g fill="url(#node)">
+      <rect x="320" y="692" width="110" height="98" rx="28"/>
+      <rect x="469" y="692" width="110" height="98" rx="28"/>
+      <rect x="618" y="692" width="156" height="98" rx="28"/>
+    </g>
+
+    <g fill="#453C9F">
+      <circle cx="375" cy="741" r="12"/>
+      <circle cx="524" cy="741" r="12"/>
+      <circle cx="666" cy="741" r="12"/>
+      <circle cx="718" cy="741" r="12"/>
+    </g>
+
+    <g fill="#EDE9FF">
+      <rect x="345" y="726" width="58" height="14" rx="7"/>
+      <rect x="494" y="726" width="58" height="14" rx="7"/>
+      <rect x="688" y="726" width="52" height="14" rx="7"/>
+      <rect x="653" y="752" width="86" height="14" rx="7"/>
+    </g>
+  </g>
+</svg>

--- a/docs/assets/csv-symbol.svg
+++ b/docs/assets/csv-symbol.svg
@@ -1,0 +1,70 @@
+<svg width="1200" height="1200" viewBox="0 0 1200 1200" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">CSV symbol</title>
+  <desc id="desc">A CSV symbol with delimited rows inspired by mikuproject CSV output.</desc>
+  <defs>
+    <linearGradient id="panel" x1="214" y1="194" x2="987" y2="1010" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#4F9A8A"/>
+      <stop offset="1" stop-color="#2F6C61"/>
+    </linearGradient>
+    <linearGradient id="sheet" x1="328" y1="324" x2="858" y2="892" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F9FFFD"/>
+      <stop offset="1" stop-color="#DDEFEA"/>
+    </linearGradient>
+    <filter id="shadow" x="164" y="156" width="872" height="900" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="20"/>
+      <feGaussianBlur stdDeviation="26"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.184314 0 0 0 0 0.423529 0 0 0 0 0.380392 0 0 0 0.2 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1_1"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1_1" result="shape"/>
+    </filter>
+  </defs>
+
+  <g filter="url(#shadow)">
+    <rect x="216" y="208" width="768" height="784" rx="154" fill="url(#panel)"/>
+    <rect x="318" y="300" width="564" height="600" rx="68" fill="url(#sheet)"/>
+
+    <rect x="318" y="300" width="564" height="130" rx="68" fill="#2F6C61"/>
+    <rect x="384" y="352" width="154" height="28" rx="14" fill="#E8F7F3"/>
+    <circle cx="790" cy="366" r="20" fill="#E8F7F3"/>
+    <circle cx="726" cy="366" r="20" fill="#BFE2D8"/>
+
+    <g stroke="#8FBEB1" stroke-width="10" stroke-linecap="round" opacity="0.8">
+      <path d="M474 474V836"/>
+      <path d="M632 474V836"/>
+      <path d="M790 474V836"/>
+      <path d="M374 588H826"/>
+      <path d="M374 702H826"/>
+    </g>
+
+    <g fill="#2F6C61">
+      <circle cx="424" cy="530" r="12"/>
+      <circle cx="582" cy="530" r="12"/>
+      <circle cx="740" cy="530" r="12"/>
+
+      <circle cx="424" cy="644" r="12"/>
+      <circle cx="582" cy="644" r="12"/>
+      <circle cx="740" cy="644" r="12"/>
+
+      <circle cx="424" cy="758" r="12"/>
+      <circle cx="582" cy="758" r="12"/>
+      <circle cx="740" cy="758" r="12"/>
+    </g>
+
+    <g fill="#67A596">
+      <rect x="438" y="512" width="86" height="36" rx="18"/>
+      <rect x="596" y="512" width="86" height="36" rx="18"/>
+      <rect x="754" y="512" width="44" height="36" rx="18"/>
+
+      <rect x="438" y="626" width="112" height="36" rx="18"/>
+      <rect x="596" y="626" width="60" height="36" rx="18"/>
+      <rect x="754" y="626" width="44" height="36" rx="18"/>
+
+      <rect x="438" y="740" width="70" height="36" rx="18"/>
+      <rect x="596" y="740" width="112" height="36" rx="18"/>
+      <rect x="754" y="740" width="44" height="36" rx="18"/>
+    </g>
+  </g>
+</svg>

--- a/docs/assets/json-symbol.svg
+++ b/docs/assets/json-symbol.svg
@@ -1,0 +1,57 @@
+<svg width="1200" height="1200" viewBox="0 0 1200 1200" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">JSON symbol</title>
+  <desc id="desc">A JSON symbol with braces and nested data lines inspired by mikuproject JSON output.</desc>
+  <defs>
+    <linearGradient id="panel" x1="214" y1="194" x2="987" y2="1010" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#C98A2E"/>
+      <stop offset="1" stop-color="#8A5E1E"/>
+    </linearGradient>
+    <linearGradient id="sheet" x1="328" y1="324" x2="858" y2="892" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFFDF8"/>
+      <stop offset="1" stop-color="#F2E5CF"/>
+    </linearGradient>
+    <filter id="shadow" x="164" y="156" width="872" height="900" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="20"/>
+      <feGaussianBlur stdDeviation="26"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.541176 0 0 0 0 0.368627 0 0 0 0 0.117647 0 0 0 0.2 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1_1"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1_1" result="shape"/>
+    </filter>
+  </defs>
+
+  <g filter="url(#shadow)">
+    <rect x="216" y="208" width="768" height="784" rx="154" fill="url(#panel)"/>
+    <rect x="318" y="300" width="564" height="600" rx="68" fill="url(#sheet)"/>
+
+    <rect x="318" y="300" width="564" height="130" rx="68" fill="#8A5E1E"/>
+    <rect x="384" y="352" width="136" height="28" rx="14" fill="#FFF4DE"/>
+    <circle cx="790" cy="366" r="20" fill="#FFF4DE"/>
+    <circle cx="726" cy="366" r="20" fill="#E8D2A8"/>
+
+    <g stroke="#8A5E1E" stroke-width="20" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M438 498C405 498 386 521 386 556V574C386 605 372 622 344 628C372 634 386 651 386 682V700C386 735 405 758 438 758"/>
+      <path d="M762 498C795 498 814 521 814 556V574C814 605 828 622 856 628C828 634 814 651 814 682V700C814 735 795 758 762 758"/>
+    </g>
+
+    <g fill="#B07B2C">
+      <rect x="462" y="510" width="124" height="28" rx="14"/>
+      <rect x="462" y="604" width="160" height="28" rx="14"/>
+      <rect x="462" y="698" width="118" height="28" rx="14"/>
+    </g>
+
+    <g fill="#D2B07A">
+      <rect x="610" y="510" width="128" height="28" rx="14"/>
+      <rect x="646" y="604" width="92" height="28" rx="14"/>
+      <rect x="604" y="698" width="134" height="28" rx="14"/>
+    </g>
+
+    <g fill="#8A5E1E">
+      <circle cx="432" cy="524" r="10"/>
+      <circle cx="432" cy="618" r="10"/>
+      <circle cx="432" cy="712" r="10"/>
+    </g>
+  </g>
+</svg>

--- a/docs/assets/markdown-symbol.svg
+++ b/docs/assets/markdown-symbol.svg
@@ -1,0 +1,51 @@
+<svg width="1200" height="1200" viewBox="0 0 1200 1200" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Markdown symbol</title>
+  <desc id="desc">A document-like markdown symbol inspired by mikuproject WBS Markdown output.</desc>
+  <defs>
+    <linearGradient id="panel" x1="214" y1="194" x2="987" y2="1010" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#7D6EA8"/>
+      <stop offset="1" stop-color="#4F4478"/>
+    </linearGradient>
+    <linearGradient id="sheet" x1="320" y1="316" x2="862" y2="892" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFFFFF"/>
+      <stop offset="1" stop-color="#ECE8F6"/>
+    </linearGradient>
+    <filter id="shadow" x="164" y="156" width="872" height="900" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="20"/>
+      <feGaussianBlur stdDeviation="26"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.309804 0 0 0 0 0.266667 0 0 0 0 0.470588 0 0 0 0.2 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1_1"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1_1" result="shape"/>
+    </filter>
+  </defs>
+
+  <g filter="url(#shadow)">
+    <rect x="216" y="208" width="768" height="784" rx="154" fill="url(#panel)"/>
+    <path d="M332 304C332 281.909 349.909 264 372 264H722.118C732.726 264 742.9 268.214 750.402 275.716L863.284 388.598C870.786 396.1 875 406.274 875 416.882V896C875 918.091 857.091 936 835 936H372C349.909 936 332 918.091 332 896V304Z" fill="url(#sheet)"/>
+    <path d="M744 264V374C744 396.091 761.909 414 784 414H875" fill="#D8D1EA"/>
+
+    <rect x="404" y="384" width="168" height="40" rx="20" fill="#5A4A86"/>
+    <rect x="404" y="468" width="404" height="28" rx="14" fill="#A698CB"/>
+    <rect x="404" y="522" width="318" height="28" rx="14" fill="#C0B6DA"/>
+
+    <g fill="#5A4A86">
+      <rect x="406" y="612" width="18" height="18" rx="9"/>
+      <rect x="406" y="684" width="18" height="18" rx="9"/>
+      <rect x="406" y="756" width="18" height="18" rx="9"/>
+    </g>
+
+    <g fill="#B8AED5">
+      <rect x="448" y="602" width="330" height="28" rx="14"/>
+      <rect x="448" y="674" width="270" height="28" rx="14"/>
+      <rect x="448" y="746" width="312" height="28" rx="14"/>
+    </g>
+
+    <g stroke="#6B5A98" stroke-width="22" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M462 840L520 782L462 724"/>
+      <path d="M600 840H748"/>
+    </g>
+  </g>
+</svg>

--- a/docs/assets/md-logo.svg
+++ b/docs/assets/md-logo.svg
@@ -1,0 +1,27 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">md wordmark purple</title>
+  <desc id="desc">The letters md in a markdown inspired purple color.</desc>
+  <g filter="url(#shadow)">
+    <text
+      x="800"
+      y="520"
+      text-anchor="middle"
+      fill="#5A4A86"
+      font-family="'Avenir Next', 'Futura', 'Trebuchet MS', sans-serif"
+      font-size="320"
+      font-weight="800"
+      letter-spacing="8">md</text>
+  </g>
+  <defs>
+    <filter id="shadow" x="390" y="190" width="820" height="420" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="16"/>
+      <feGaussianBlur stdDeviation="18"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.352941 0 0 0 0 0.290196 0 0 0 0 0.52549 0 0 0 0.22 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1_1"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1_1" result="shape"/>
+    </filter>
+  </defs>
+</svg>

--- a/docs/assets/mermaid-symbol.svg
+++ b/docs/assets/mermaid-symbol.svg
@@ -1,0 +1,66 @@
+<svg width="1200" height="1200" viewBox="0 0 1200 1200" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Mermaid symbol</title>
+  <desc id="desc">A diagram-style mermaid symbol with connected nodes inspired by mikuproject Mermaid output.</desc>
+  <defs>
+    <linearGradient id="panel" x1="214" y1="194" x2="987" y2="1010" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#2F8AA0"/>
+      <stop offset="1" stop-color="#1E5F73"/>
+    </linearGradient>
+    <linearGradient id="sheet" x1="324" y1="322" x2="864" y2="894" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#F8FEFF"/>
+      <stop offset="1" stop-color="#DCEFF4"/>
+    </linearGradient>
+    <linearGradient id="node" x1="422" y1="510" x2="770" y2="782" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#A8DCE8"/>
+      <stop offset="1" stop-color="#6AB2C6"/>
+    </linearGradient>
+    <filter id="shadow" x="164" y="156" width="872" height="900" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="20"/>
+      <feGaussianBlur stdDeviation="26"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.117647 0 0 0 0 0.372549 0 0 0 0 0.45098 0 0 0 0.2 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1_1"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1_1" result="shape"/>
+    </filter>
+  </defs>
+
+  <g filter="url(#shadow)">
+    <rect x="216" y="208" width="768" height="784" rx="154" fill="url(#panel)"/>
+    <rect x="314" y="296" width="572" height="612" rx="72" fill="url(#sheet)"/>
+
+    <rect x="314" y="296" width="572" height="136" rx="72" fill="#206579"/>
+    <rect x="382" y="348" width="182" height="30" rx="15" fill="#E8F8FB" fill-opacity="0.96"/>
+    <circle cx="794" cy="364" r="20" fill="#E8F8FB"/>
+    <circle cx="730" cy="364" r="20" fill="#BEE3EC"/>
+
+    <g stroke="#5D9FB0" stroke-width="16" stroke-linecap="round" stroke-linejoin="round">
+      <path d="M450 560H750"/>
+      <path d="M450 560L390 674"/>
+      <path d="M750 560L810 674"/>
+      <path d="M600 560V762"/>
+      <path d="M390 674H810"/>
+    </g>
+
+    <g fill="url(#node)">
+      <rect x="454" y="504" width="292" height="112" rx="34"/>
+      <rect x="312" y="618" width="156" height="112" rx="34"/>
+      <rect x="522" y="706" width="156" height="112" rx="34"/>
+      <rect x="732" y="618" width="156" height="112" rx="34"/>
+    </g>
+
+    <g fill="#205C6D">
+      <rect x="514" y="548" width="172" height="24" rx="12"/>
+      <rect x="348" y="662" width="84" height="24" rx="12"/>
+      <rect x="558" y="750" width="84" height="24" rx="12"/>
+      <rect x="768" y="662" width="84" height="24" rx="12"/>
+    </g>
+
+    <g fill="#EAF8FB">
+      <circle cx="408" cy="674" r="12"/>
+      <circle cx="600" cy="762" r="12"/>
+      <circle cx="792" cy="674" r="12"/>
+    </g>
+  </g>
+</svg>

--- a/docs/assets/xlsx-logo.svg
+++ b/docs/assets/xlsx-logo.svg
@@ -1,0 +1,27 @@
+<svg width="1600" height="900" viewBox="0 0 1600 900" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">xlsx wordmark green</title>
+  <desc id="desc">The word xlsx in an Excel inspired green color.</desc>
+  <g filter="url(#shadow)">
+    <text
+      x="800"
+      y="520"
+      text-anchor="middle"
+      fill="#217346"
+      font-family="'Avenir Next', 'Futura', 'Trebuchet MS', sans-serif"
+      font-size="300"
+      font-weight="800"
+      letter-spacing="10">xlsx</text>
+  </g>
+  <defs>
+    <filter id="shadow" x="264" y="190" width="1072" height="414" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
+      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+      <feOffset dy="16"/>
+      <feGaussianBlur stdDeviation="18"/>
+      <feComposite in2="hardAlpha" operator="out"/>
+      <feColorMatrix type="matrix" values="0 0 0 0 0.129412 0 0 0 0 0.45098 0 0 0 0 0.27451 0 0 0 0.22 0"/>
+      <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1_1"/>
+      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1_1" result="shape"/>
+    </filter>
+  </defs>
+</svg>


### PR DESCRIPTION
## 概要

指定コミットでは、ロゴ検討用アセットとして、追加の文字ロゴと記号シンボル SVG を `docs/assets/` に追加しています。

## 変更内容

- `docs/assets/xlsx-logo.svg` を追加
  - `xlsx` の文字ロゴを追加

- `docs/assets/md-logo.svg` を追加
  - `md` の文字ロゴを追加

- `docs/assets/2-logo.svg` を追加
  - `xlsx2md` の中間に置く `2` の文字ロゴを追加

- `docs/assets/markdown-symbol.svg` を追加
  - `Markdown` をイメージした記号シンボルを追加

- `docs/assets/csv-symbol.svg` を追加
  - `CSV` をイメージした記号シンボルを追加

- `docs/assets/json-symbol.svg` を追加
  - `JSON` をイメージした記号シンボルを追加

- `docs/assets/ai-symbol.svg` を追加
  - 生成AI連携をイメージした記号シンボルを追加

- `docs/assets/mermaid-symbol.svg` を追加
  - `Mermaid` をイメージした記号シンボルを追加

## 目的

- ロゴ検討用の文字ロゴバリエーションを増やすこと
- `Markdown`、`CSV`、`JSON`、生成AI、`Mermaid` といった周辺形式・連携要素の記号シンボルを揃えること
- `xlsx2md` のような兄弟プロダクト表記にも使える文字パーツを用意すること

## 影響範囲

- `docs/assets/` 配下のロゴ・記号アセット