### PR TITLE
workbook import 対象列を拡張し、サンプルの `project_draft_view` と関連ドキュメントを更新

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -21,7 +21,16 @@
   - 同じファイル名で保存し直した `.xlsx` を連続 import できる
   - 空 editable セルを埋めた変更を import できる
   - `Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes` など主要 editable 列が戻る
-  - `Milestone / Summary / Critical` など表示専用列は戻らない
+  - `Milestone / Summary / Critical` など現在の task 真偽値列が戻る
+- `Tasks.Predecessors` を workbook import 対象に広げ、別インスタンスへ `XLSX` を受け渡しても task 依存関係の最小 round-trip が成立するようにする
+  - まずは `predecessorUid` の最小表現を `,` 区切りで安全に読み戻す MVP を検討する
+  - `type / linkLag` など複雑な依存表現は後段に分けてよい
+- MVP の workbook import 対象候補として、少なくとも次の列を優先順位つきで整理する
+  - 最優先候補: `Tasks.Duration`
+  - 最優先候補: `Tasks.CalendarUID`
+  - 次点候補: `Resources.CalendarUID`
+  - 次点候補: `Resources.StandardRate / OvertimeRate / CostPerUse`
+  - 次点候補: `Assignments.Start / Finish`
 - `main.ts` の summary / validation / preview 描画を別モジュール化し、DOM テストをさらに軽くする
 - `phase_detail_view scoped` の `phase UID / root UID / max depth` 指定を、より選びやすい UI に改善する
 - `task_edit_view` の projection を実装する
@@ -56,9 +65,14 @@
 - `mikuproject-sample.xlsx` の `Resources / Assignments / NonWorkingDays` で、強調色が過剰にならない最終バランスを調整する
 - `WBS` の `プロジェクト情報` / `凡例` などと、`Project` シートの `Basic Info` に入っているドット編みかけ表現を除去する
 - WBS workbook の表示改善を継続する
+- `Daily` 表示の日ごとの横幅を、もう少し狭くできるか検討する
+  - まずは変更仕様の整理から始め、可読性、文字詰まり、祝日/週境界の見え方、`Weekly / Monthly` とのバランスを確認する
 - WBS workbook の見た目改善と、構造忠実 workbook との責務分離を保つ
 - WBS について、完了タスクの表示 / 非表示を切り替えるオプションを追加する
 - 将来検討: WBS workbook について、表示専用列と Excel 再利用向けの機械利用列（hidden 列）の分離が必要か整理する
+- 低優先度: 週別または日別の `24h` 表記タイムチャートを追加するか検討する
+  - イメージは `4直3交代` のシフト表に近い表示とする
+  - まずは仕様検討から始め、対象データ、表示粒度、稼働日/非稼働日との関係、`WBS` 系出力との責務分離を整理する
 - WBS Markdown の `プロジェクト情報` / `サマリ` / `WBS ツリー` / `WBS テーブル` をどう出すか sample ベースで固める
 - `project summary markdown` のような、WBS 以外の Markdown 出力拡張を検討する
 - `phase summary markdown` のような scoped Markdown 出力を追加するか検討する

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -183,3 +183,27 @@ npm run build
 - `docs/architecture.md`: 全体構成、配布形態、ビルド、運用ルール
 - `docs/spec.md`: 仕様と設計判断の置き場
 - `docs/TODO.md`: 未完了作業の管理
+
+## 実装 FAQ
+
+### workbook JSON と `project_draft_view` は同じですか
+
+違う。
+
+- workbook JSON は、通常 workbook (`XLSX`) のテキスト版である
+- `Project / Tasks / Resources / Assignments / Calendars / NonWorkingDays` を持つ
+- import 時も、基本的には `XLSX Import` と同じ限定列の部分更新として扱う
+
+一方で `project_draft_view` は、生成AI などが返す「新規 project 草案」である。
+
+- 主に `project` と `tasks` を持つ草案用 JSON である
+- 既存 project の限定更新ではなく、新しい `ProjectModel` を組み立てる入口である
+- `Resources / Assignments / Calendars / NonWorkingDays` を workbook JSON と同じ形では持たない
+
+つまり、`workbook JSON` は「既存 project を workbook 相当で扱うための JSON」、`project_draft_view` は「新規草案を取り込むための JSON」として分離している。
+
+### 画面の `サンプル` は XML を読んでいますか、それとも JSON を読んでいますか
+
+画面の通常 `サンプル` は `SAMPLE_XML` を読み込む。
+
+ただし、その `SAMPLE_XML` 自体は内部では `SAMPLE_PROJECT_DRAFT_VIEW` から生成している。つまり、画面上の導線は XML 読込だが、サンプルの元データは `project_draft_view` 系である。

--- a/docs/mikuproject-ai-json-spec.md
+++ b/docs/mikuproject-ai-json-spec.md
@@ -218,6 +218,16 @@
     "name": "新規基幹刷新",
     "planned_start": "2026-04-01"
   },
+  "resources": [
+    {
+      "uid": "res-1",
+      "name": "Mikuku",
+      "initials": "M",
+      "group": "PMO",
+      "max_units": 1,
+      "calendar_uid": "1"
+    }
+  ],
   "tasks": [
     {
       "uid": "draft-1",
@@ -225,6 +235,15 @@
       "parent_uid": null,
       "position": 0,
       "is_summary": true
+    }
+  ],
+  "assignments": [
+    {
+      "uid": "asg-1",
+      "task_uid": "draft-1",
+      "resource_uid": "res-1",
+      "units": 1,
+      "work": "PT8H0M0S"
     }
   ]
 }

--- a/docs/msprojectxml-ai-integration.md
+++ b/docs/msprojectxml-ai-integration.md
@@ -321,6 +321,16 @@ AI 入力は 1 種類の簡約 JSON で統一するより、用途別 projection
     "name": "新規基幹刷新",
     "planned_start": "2026-04-01"
   },
+  "resources": [
+    {
+      "uid": "res-1",
+      "name": "Mikuku",
+      "initials": "M",
+      "group": "PMO",
+      "max_units": 1,
+      "calendar_uid": "1"
+    }
+  ],
   "tasks": [
     {
       "uid": "draft-1",
@@ -328,6 +338,15 @@ AI 入力は 1 種類の簡約 JSON で統一するより、用途別 projection
       "parent_uid": null,
       "position": 0,
       "is_summary": true
+    }
+  ],
+  "assignments": [
+    {
+      "uid": "asg-1",
+      "task_uid": "draft-1",
+      "resource_uid": "res-1",
+      "units": 1,
+      "work": "PT8H0M0S"
     }
   ]
 }

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -327,8 +327,8 @@ import 時の扱いも `XLSX Import` と完全に揃える。
 現時点で `XLSX Import` の反映対象としている列は次のとおり。
 
 - `Project`: `Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart`
-- `Tasks`: `Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes`
-- `Resources`: `Name / Group / MaxUnits`
+- `Tasks`: `Name / Start / Finish / Duration / PercentComplete / PercentWorkComplete / Milestone / Summary / Critical / CalendarUID / Predecessors / Notes`
+- `Resources`: `Name / Group / MaxUnits / CalendarUID`
 - `Assignments`: `Units / Work / PercentWorkComplete`
 - `Calendars`: `Name / IsBaseCalendar / BaseCalendarUID`
 - `NonWorkingDays`: `Name / Date / FromDate / ToDate / DayWorking`
@@ -338,8 +338,8 @@ import 時の扱いも `XLSX Import` と完全に揃える。
 | Sheet | Editable Columns | Notes |
 | --- | --- | --- |
 | `Project` | `Name / Title / Author / Company / StartDate / FinishDate / CurrentDate / StatusDate / CalendarUID / MinutesPerDay / MinutesPerWeek / DaysPerMonth / ScheduleFromStart` | project 単位の部分更新として扱う |
-| `Tasks` | `Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes` | `UID` をキーに部分更新する |
-| `Resources` | `Name / Group / MaxUnits` | `UID` をキーに部分更新する |
+| `Tasks` | `Name / Start / Finish / Duration / PercentComplete / PercentWorkComplete / Milestone / Summary / Critical / CalendarUID / Predecessors / Notes` | `UID` をキーに部分更新する |
+| `Resources` | `Name / Group / MaxUnits / CalendarUID` | `UID` をキーに部分更新する |
 | `Assignments` | `Units / Work / PercentWorkComplete` | `UID` をキーに部分更新する |
 | `Calendars` | `Name / IsBaseCalendar / BaseCalendarUID` | `UID` をキーに部分更新する |
 | `NonWorkingDays` | `Name / Date / FromDate / ToDate / DayWorking` | `CalendarUID + Index` をキーに部分更新する |
@@ -358,15 +358,17 @@ import 時の扱いも `XLSX Import` と完全に揃える。
 | `WBS` | 表示のみ |
 | `Start` | import 可 |
 | `Finish` | import 可 |
-| `Duration` | 表示のみ |
+| `Duration` | import 可 |
 | `PercentComplete` | import 可 |
 | `PercentWorkComplete` | import 可 |
-| `Milestone` | 表示のみ |
-| `Summary` | 表示のみ |
-| `Critical` | 表示のみ |
-| `CalendarUID` | 表示のみ |
-| `Predecessors` | 表示のみ |
+| `Milestone` | import 可 |
+| `Summary` | import 可 |
+| `Critical` | import 可 |
+| `CalendarUID` | import 可 |
+| `Predecessors` | import 可 |
 | `Notes` | import 可 |
+
+`Predecessors` の workbook import は、現時点では `predecessorUid` の `,` 区切り一覧を読む最小対応とする。`type / linkLag` などの詳細な依存表現は将来拡張とする。
 
 `Resources` と `Assignments` が 0 件の workbook では、どの列が import 対象か分かるように、editable 列だけ着色されたダミー行を 1 行出してよい。これは表示補助であり、`UID` 等のキーが空なので import 時には無視される。
 
@@ -981,11 +983,11 @@ STEP 1 では、次は非目標とする。
 - 通常 task で `planned_start` / `planned_finish` が date-only の場合、内部化時に勤務時間帯として `09:00:00` / `18:00:00` を補完して扱うことがある
 - `planned_finish` だけが与えられた通常 task は、まず同日の `planned_start` を補完し、その後に上記の勤務時間帯補完を適用する
 - `is_milestone=true` の task には、この勤務時間帯補完を適用しない
+- 必要に応じて、最小の `resources` と `assignments` を併記してよい
+- 現時点の `assignments` は `task_uid / resource_uid / start / finish / units / work / percent_work_complete` 程度の最小表現を想定する
 
 現時点で意図的に落とすもの:
 
-- `Resources`
-- `Assignments`
 - `Calendars`
 - `Baseline`
 - `TimephasedData`

--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@
   <main class="card">
     <div class="eyebrow">Local Browser Tool</div>
     <h1>mikuproject</h1>
-    <div class="md-app-meta">Updated: 2026-03-31</div>
+    <div class="md-app-meta">Updated: 2026-04-02</div>
 
     <section aria-label="What is this">
       <h2>What is this?</h2>

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -2482,6 +2482,16 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
     "name": "新規基幹刷新",
     "planned_start": "2026-04-01"
   },
+  "resources": [
+    {
+      "uid": "res-1",
+      "name": "Mikuku",
+      "initials": "M",
+      "group": "PMO",
+      "max_units": 1,
+      "calendar_uid": "1"
+    }
+  ],
   "tasks": [
     {
       "uid": "draft-1",
@@ -2489,6 +2499,15 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
       "parent_uid": null,
       "position": 0,
       "is_summary": true
+    }
+  ],
+  "assignments": [
+    {
+      "uid": "asg-1",
+      "task_uid": "draft-1",
+      "resource_uid": "res-1",
+      "units": 1,
+      "work": "PT8H0M0S"
     }
   ]
 }
@@ -5349,6 +5368,9 @@ if (!customElements.get("lht-page-menu")) {
                     columns: Array.isArray(sheet.columns) ? sheet.columns.map((column) => normalizeColumn(column)) : undefined,
                     freezePane: normalizeFreezePane(sheet.freezePane),
                     mergedRanges: Array.isArray(sheet.mergedRanges) ? sheet.mergedRanges.map((range) => normalizeMergedRange(range)) : undefined,
+                    dataValidations: Array.isArray(sheet.dataValidations)
+                        ? sheet.dataValidations.map((dataValidation) => normalizeDataValidation(dataValidation))
+                        : undefined,
                     rows: Array.isArray(sheet.rows)
                         ? sheet.rows.map((row) => ({
                             height: normalizeOptionalPositiveNumber(row === null || row === void 0 ? void 0 : row.height, "Row height"),
@@ -5371,6 +5393,24 @@ if (!customElements.get("lht-page-menu")) {
         return {
             width: normalizeOptionalPositiveNumber(column.width, "Column width"),
             hidden: column.hidden === true ? true : undefined
+        };
+    }
+    function normalizeDataValidation(dataValidation) {
+        if (!dataValidation) {
+            throw new Error("Data validation must be defined");
+        }
+        if (dataValidation.type !== "list") {
+            throw new Error(`Unsupported data validation type: ${String(dataValidation.type)}`);
+        }
+        const sqref = normalizeSqref(dataValidation.sqref);
+        if (!dataValidation.formula1 || typeof dataValidation.formula1 !== "string") {
+            throw new Error("Data validation formula1 must be a non-empty string");
+        }
+        return {
+            type: "list",
+            sqref,
+            formula1: dataValidation.formula1,
+            allowBlank: dataValidation.allowBlank === true ? true : undefined
         };
     }
     function normalizeFreezePane(freezePane) {
@@ -5437,6 +5477,31 @@ if (!customElements.get("lht-page-menu")) {
             throw new Error(`Invalid merged range: ${range}`);
         }
         return trimmed;
+    }
+    function normalizeSqref(sqref) {
+        if (typeof sqref !== "string") {
+            throw new Error("Data validation sqref must be a string");
+        }
+        const normalized = sqref
+            .trim()
+            .toUpperCase()
+            .split(/\s+/)
+            .filter(Boolean)
+            .map((part) => normalizeSqrefPart(part))
+            .join(" ");
+        if (!normalized) {
+            throw new Error("Data validation sqref must not be empty");
+        }
+        return normalized;
+    }
+    function normalizeSqrefPart(part) {
+        if (/^[A-Z]+\d+$/.test(part)) {
+            return part;
+        }
+        if (/^[A-Z]+\d+:[A-Z]+\d+$/.test(part)) {
+            return part;
+        }
+        throw new Error(`Invalid data validation sqref: ${part}`);
     }
     function normalizeOptionalPositiveNumber(value, label) {
         if (value === undefined) {
@@ -5534,6 +5599,7 @@ if (!customElements.get("lht-page-menu")) {
         const sheetViewsXml = buildSheetViewsXml(sheet.freezePane);
         const colsXml = buildColumnsXml(sheet.columns);
         const mergeCellsXml = buildMergeCellsXml(sheet.mergedRanges);
+        const dataValidationsXml = buildDataValidationsXml(sheet.dataValidations);
         const rows = sheet.rows.map((row, rowIndex) => buildWorksheetRowXml(row, rowIndex, styleBook)).filter(Boolean).join("");
         return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
@@ -5541,6 +5607,7 @@ if (!customElements.get("lht-page-menu")) {
   ${colsXml}
   <sheetData>${rows}</sheetData>
   ${mergeCellsXml}
+  ${dataValidationsXml}
 </worksheet>`;
     }
     function buildSheetViewsXml(freezePane) {
@@ -5571,6 +5638,13 @@ if (!customElements.get("lht-page-menu")) {
             .map((range) => `<mergeCell ref="${range}"/>`)
             .join("");
         return `<mergeCells count="${mergedRanges.length}">${mergeCells}</mergeCells>`;
+    }
+    function buildDataValidationsXml(dataValidations) {
+        if (!dataValidations || dataValidations.length === 0) {
+            return "";
+        }
+        const nodes = dataValidations.map((dataValidation) => (`<dataValidation type="${dataValidation.type}" allowBlank="${dataValidation.allowBlank === true ? "1" : "0"}" showErrorMessage="1" sqref="${escapeXml(dataValidation.sqref)}"><formula1>${escapeXml(dataValidation.formula1)}</formula1></dataValidation>`)).join("");
+        return `<dataValidations count="${dataValidations.length}">${nodes}</dataValidations>`;
     }
     function buildWorksheetRowXml(row, rowIndex, styleBook) {
         const cells = row.cells
@@ -6413,7 +6487,11 @@ if (!customElements.get("lht-page-menu")) {
         project: {
             name: "mikuproject開発",
             planned_start: "2026-03-16",
-            planned_finish: "2026-04-01"
+            planned_finish: "2026-04-01",
+            schedule_from_start: true,
+            minutes_per_day: 480,
+            minutes_per_week: 2400,
+            days_per_month: 20
         },
         tasks: [
             {
@@ -6532,6 +6610,38 @@ if (!customElements.get("lht-page-menu")) {
                 is_milestone: true,
                 planned_start: "2026-03-29",
                 planned_finish: "2026-03-29"
+            }
+        ],
+        resources: [
+            {
+                uid: "res-1",
+                name: "Mikuku",
+                initials: "M",
+                group: "Development",
+                max_units: 1,
+                calendar_uid: "1"
+            }
+        ],
+        assignments: [
+            {
+                uid: "asg-1",
+                task_uid: "draft-120",
+                resource_uid: "res-1",
+                start: "2026-03-16T09:00:00",
+                finish: "2026-03-16T18:00:00",
+                units: 1,
+                work: "PT8H0M0S",
+                percent_work_complete: 100
+            },
+            {
+                uid: "asg-2",
+                task_uid: "draft-130",
+                resource_uid: "res-1",
+                start: "2026-03-17T09:00:00",
+                finish: "2026-03-17T18:00:00",
+                units: 1,
+                work: "PT8H0M0S",
+                percent_work_complete: 100
             }
         ]
     };
@@ -8063,6 +8173,8 @@ if (!customElements.get("lht-page-menu")) {
             throw new Error("project.name がありません");
         }
         const inputTasks = Array.isArray(data.tasks) ? data.tasks : [];
+        const inputResources = Array.isArray(data.resources) ? data.resources : [];
+        const inputAssignments = Array.isArray(data.assignments) ? data.assignments : [];
         const seenUids = new Set();
         for (const task of inputTasks) {
             const uid = String(task.uid || "").trim();
@@ -8083,10 +8195,42 @@ if (!customElements.get("lht-page-menu")) {
                 throw new Error(`draft task の parent_uid が既存 uid を指していません: ${String(task.uid || "")} -> ${parentUid}`);
             }
         }
+        const seenResourceUids = new Set();
+        for (const resource of inputResources) {
+            const uid = String(resource.uid || "").trim();
+            if (!uid) {
+                throw new Error("draft resource の uid がありません");
+            }
+            if (seenResourceUids.has(uid)) {
+                throw new Error(`draft resource の uid が重複しています: ${uid}`);
+            }
+            seenResourceUids.add(uid);
+            if (!String(resource.name || "").trim()) {
+                throw new Error(`draft resource の name がありません: ${uid}`);
+            }
+        }
+        for (const assignment of inputAssignments) {
+            const uid = String(assignment.uid || "").trim();
+            if (!uid) {
+                throw new Error("draft assignment の uid がありません");
+            }
+            const taskUid = String(assignment.task_uid || "").trim();
+            const resourceUid = String(assignment.resource_uid || "").trim();
+            if (!taskUid || !seenUids.has(taskUid)) {
+                throw new Error(`draft assignment の task_uid が既存 uid を指していません: ${uid} -> ${taskUid}`);
+            }
+            if (!resourceUid || !seenResourceUids.has(resourceUid)) {
+                throw new Error(`draft assignment の resource_uid が既存 uid を指していません: ${uid} -> ${resourceUid}`);
+            }
+        }
         const projectStart = data.project.planned_start || data.project.planned_finish || toIsoLocalString(new Date());
         const draftUidMap = new Map();
         inputTasks.forEach((task, index) => {
             draftUidMap.set(String(task.uid || "").trim(), String(index + 1));
+        });
+        const draftResourceUidMap = new Map();
+        inputResources.forEach((resource, index) => {
+            draftResourceUidMap.set(String(resource.uid || "").trim(), String(index + 1));
         });
         const normalizedTasks = inputTasks.map((task, index) => ({
             uid: draftUidMap.get(String(task.uid || "").trim()) || String(index + 1),
@@ -8167,20 +8311,56 @@ if (!customElements.get("lht-page-menu")) {
         }
         walk(null, []);
         const taskFinishes = orderedTasks.map((task) => task.finish).filter(Boolean).sort();
+        const orderedResources = inputResources.map((resource, index) => ({
+            uid: draftResourceUidMap.get(String(resource.uid || "").trim()) || String(index + 1),
+            id: draftResourceUidMap.get(String(resource.uid || "").trim()) || String(index + 1),
+            name: String(resource.name || "").trim(),
+            initials: String(resource.initials || "").trim() || undefined,
+            group: String(resource.group || "").trim() || undefined,
+            maxUnits: typeof resource.max_units === "number" && Number.isFinite(resource.max_units) ? resource.max_units : undefined,
+            calendarUID: String(resource.calendar_uid || "").trim() || undefined,
+            extendedAttributes: [],
+            baselines: [],
+            timephasedData: []
+        }));
+        const orderedAssignments = inputAssignments.map((assignment, index) => ({
+            uid: String(index + 1),
+            taskUid: draftUidMap.get(String(assignment.task_uid || "").trim()) || String(assignment.task_uid || "").trim(),
+            resourceUid: draftResourceUidMap.get(String(assignment.resource_uid || "").trim()) || String(assignment.resource_uid || "").trim(),
+            start: String(assignment.start || "").trim() || undefined,
+            finish: String(assignment.finish || "").trim() || undefined,
+            units: typeof assignment.units === "number" && Number.isFinite(assignment.units) ? assignment.units : undefined,
+            work: String(assignment.work || "").trim() || undefined,
+            percentWorkComplete: typeof assignment.percent_work_complete === "number" && Number.isFinite(assignment.percent_work_complete)
+                ? Math.max(0, Math.min(100, assignment.percent_work_complete))
+                : undefined,
+            extendedAttributes: [],
+            baselines: [],
+            timephasedData: []
+        }));
         return normalizeProjectModel(ensureDefaultProjectCalendar({
             project: {
                 name: data.project.name.trim(),
                 title: data.project.name.trim(),
                 startDate: projectStart,
                 finishDate: data.project.planned_finish || taskFinishes.at(-1) || projectStart,
-                scheduleFromStart: true,
+                scheduleFromStart: data.project.schedule_from_start !== undefined ? Boolean(data.project.schedule_from_start) : true,
+                minutesPerDay: typeof data.project.minutes_per_day === "number" && Number.isFinite(data.project.minutes_per_day)
+                    ? data.project.minutes_per_day
+                    : undefined,
+                minutesPerWeek: typeof data.project.minutes_per_week === "number" && Number.isFinite(data.project.minutes_per_week)
+                    ? data.project.minutes_per_week
+                    : undefined,
+                daysPerMonth: typeof data.project.days_per_month === "number" && Number.isFinite(data.project.days_per_month)
+                    ? data.project.days_per_month
+                    : undefined,
                 outlineCodes: [],
                 wbsMasks: [],
                 extendedAttributes: []
             },
             tasks: orderedTasks,
-            resources: [],
-            assignments: [],
+            resources: orderedResources,
+            assignments: orderedAssignments,
             calendars: []
         }));
     }
@@ -10046,8 +10226,8 @@ if (!customElements.get("lht-page-menu")) {
     };
     const IMPORTABLE_FIELDS = {
         Project: PROJECT_EDITABLE_FIELDS,
-        Tasks: ["Name", "Start", "Finish", "PercentComplete", "PercentWorkComplete", "Notes"],
-        Resources: ["Name", "Group", "MaxUnits"],
+        Tasks: ["Name", "Start", "Finish", "Duration", "PercentComplete", "PercentWorkComplete", "Milestone", "Summary", "Critical", "CalendarUID", "Predecessors", "Notes"],
+        Resources: ["Name", "Group", "MaxUnits", "CalendarUID"],
         Assignments: ["Units", "Work", "PercentWorkComplete"],
         Calendars: ["Name", "IsBaseCalendar", "BaseCalendarUID"],
         NonWorkingDays: ["Name", "Date", "FromDate", "ToDate", "DayWorking"]
@@ -10088,6 +10268,9 @@ if (!customElements.get("lht-page-menu")) {
     const NOTES_FILL = "#FFFBEA";
     const NAME_FILL = "#FAF6FF";
     const WORK_FILL = "#F1F8FD";
+    const BOOLEAN_TRUE_LABEL = "○";
+    const BOOLEAN_FALSE_LABEL = "ー";
+    const OPTIONS_SHEET_NAME = "Options";
     const SUMMARY_FILL = "#E6F2E0";
     const MILESTONE_FILL = "#FFF0CF";
     const CRITICAL_FILL = "#F8DDE6";
@@ -10100,14 +10283,21 @@ if (!customElements.get("lht-page-menu")) {
         nonWorkingDays: { section: "#E9C7D5", header: "#F4DDE6", label: "#FBEEF3" }
     };
     function exportProjectWorkbook(model) {
+        const projectSheet = buildProjectSheet(model);
+        const tasksSheet = buildTasksSheet(model);
+        const resourcesSheet = buildResourcesSheet(model);
+        const assignmentsSheet = buildAssignmentsSheet(model);
+        const calendarsSheet = buildCalendarsSheet(model);
+        const nonWorkingDaysSheet = buildNonWorkingDaysSheet(model);
         return {
             sheets: [
-                buildProjectSheet(model),
-                buildTasksSheet(model),
-                buildResourcesSheet(model),
-                buildAssignmentsSheet(model),
-                buildCalendarsSheet(model),
-                buildNonWorkingDaysSheet(model)
+                projectSheet,
+                tasksSheet,
+                resourcesSheet,
+                assignmentsSheet,
+                calendarsSheet,
+                nonWorkingDaysSheet,
+                buildOptionsSheet()
             ]
         };
     }
@@ -10166,10 +10356,21 @@ if (!customElements.get("lht-page-menu")) {
             titleRow("Settings", SHEET_THEMES.project.section),
             ...PROJECT_FIELD_ORDER.slice(8).map((field) => keyValueRow(field, readProjectFieldValue(project, field), SHEET_THEMES.project.label))
         ];
+        const rowNumberByField = new Map();
+        rows.forEach((row, index) => {
+            var _a;
+            const field = typeof ((_a = row.cells[0]) === null || _a === void 0 ? void 0 : _a.value) === "string" ? row.cells[0].value : undefined;
+            if (field) {
+                rowNumberByField.set(field, index + 1);
+            }
+        });
         return {
             name: "Project",
             columns: [{ width: 26 }, { width: 42 }],
             mergedRanges: ["A11:B11"],
+            dataValidations: buildBooleanDataValidations([
+                buildSingleCellReference(1, rowNumberByField.get("ScheduleFromStart"))
+            ]),
             rows
         };
     }
@@ -10184,6 +10385,11 @@ if (!customElements.get("lht-page-menu")) {
                 { width: 34 }
             ],
             mergedRanges: [],
+            dataValidations: buildBooleanDataValidations([
+                buildColumnRange(11, DATA_ROW_START_INDEX + 1, DATA_ROW_START_INDEX + model.tasks.length),
+                buildColumnRange(12, DATA_ROW_START_INDEX + 1, DATA_ROW_START_INDEX + model.tasks.length),
+                buildColumnRange(13, DATA_ROW_START_INDEX + 1, DATA_ROW_START_INDEX + model.tasks.length)
+            ]),
             rows: [
                 sectionTitleRow("Tasks", 17, SHEET_THEMES.tasks.section),
                 sectionTitleRow("Task List", 17, SHEET_THEMES.tasks.section),
@@ -10198,14 +10404,14 @@ if (!customElements.get("lht-page-menu")) {
                         textCell(task.wbs, index),
                         editableCell(dateTimeCell(task.start, index)),
                         editableCell(dateTimeCell(task.finish, index)),
-                        durationCell(task.duration, index),
+                        editableCell(durationCell(task.duration, index)),
                         editableCell(percentCell(task.percentComplete, index)),
                         editableCell(percentCell(task.percentWorkComplete, index)),
                         taskFlagCell(task.milestone, index, MILESTONE_FILL),
                         taskFlagCell(task.summary, index, SUMMARY_FILL),
                         taskFlagCell(task.critical, index, CRITICAL_FILL),
-                        referenceCell(task.calendarUID, index),
-                        predecessorCell(task.predecessors.map((item) => item.predecessorUid).join(", "), index),
+                        editableCell(referenceCell(task.calendarUID, index)),
+                        editableCell(predecessorCell(task.predecessors.map((item) => item.predecessorUid).join(", "), index)),
                         editableCell(notesCell(task.notes, index))
                     ]
                 }))
@@ -10223,7 +10429,7 @@ if (!customElements.get("lht-page-menu")) {
                     textCell(resource.initials, index),
                     editableCell(textCell(resource.group, index)),
                     editableCell(countCell(resource.maxUnits, index)),
-                    referenceCell(resource.calendarUID, index),
+                    editableCell(referenceCell(resource.calendarUID, index)),
                     textCell(resource.standardRate, index),
                     textCell(resource.overtimeRate, index),
                     countCell(resource.costPerUse, index),
@@ -10241,7 +10447,7 @@ if (!customElements.get("lht-page-menu")) {
                         textCell(undefined, 0),
                         editableCell(textCell(undefined, 0)),
                         editableCell(countCell(undefined, 0)),
-                        referenceCell(undefined, 0),
+                        editableCell(referenceCell(undefined, 0)),
                         textCell(undefined, 0),
                         textCell(undefined, 0),
                         countCell(undefined, 0),
@@ -10327,6 +10533,9 @@ if (!customElements.get("lht-page-menu")) {
                 { width: 10 }, { width: 12 }, { width: 10 }
             ],
             mergedRanges: [],
+            dataValidations: buildBooleanDataValidations([
+                buildColumnRange(2, DATA_ROW_START_INDEX + 1, DATA_ROW_START_INDEX + model.calendars.length)
+            ]),
             rows: [
                 sectionTitleRow("Calendars", 7, SHEET_THEMES.calendars.section),
                 sectionTitleRow("Calendar List", 7, SHEET_THEMES.calendars.section),
@@ -10365,6 +10574,9 @@ if (!customElements.get("lht-page-menu")) {
                 { width: 14 }, { width: 22 }, { width: 22 }, { width: 12 }
             ],
             mergedRanges: [],
+            dataValidations: buildBooleanDataValidations([
+                buildColumnRange(7, DATA_ROW_START_INDEX + 1, DATA_ROW_START_INDEX + rows.length)
+            ]),
             rows: [
                 sectionTitleRow("NonWorkingDays", 8, SHEET_THEMES.nonWorkingDays.section),
                 sectionTitleRow("Calendar Exceptions", 8, SHEET_THEMES.nonWorkingDays.section),
@@ -10442,6 +10654,9 @@ if (!customElements.get("lht-page-menu")) {
         };
     }
     function stringifyCellValue(value) {
+        if (typeof value === "boolean") {
+            return value ? BOOLEAN_TRUE_LABEL : BOOLEAN_FALSE_LABEL;
+        }
         return typeof value === "string" ? value : String(value);
     }
     function keyValueCell(label, value) {
@@ -10500,11 +10715,13 @@ if (!customElements.get("lht-page-menu")) {
         };
     }
     function taskFlagCell(value, rowIndex, activeFillColor) {
-        const isActive = value === true || value === 1 || value === "1";
-        return styledCell(value, rowIndex, {
-            fillColor: isActive ? activeFillColor : COUNT_FILL,
+        const displayValue = value === undefined ? undefined : stringifyCellValue(value);
+        return {
+            value: displayValue,
+            border: "thin",
+            fillColor: EDITABLE_FILL,
             horizontalAlign: "center"
-        });
+        };
     }
     function referenceCell(value, rowIndex) {
         return styledCell(value, rowIndex, {
@@ -10660,8 +10877,14 @@ if (!customElements.get("lht-page-menu")) {
             assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "name", "Name", readStringCellAt(row.cells, columnIndexByLabel.get("Name")));
             assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "start", "Start", normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Start"))));
             assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "finish", "Finish", normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Finish"))));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "duration", "Duration", readStringCellAt(row.cells, columnIndexByLabel.get("Duration")));
             assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "percentComplete", "PercentComplete", readNumberCellAt(row.cells, columnIndexByLabel.get("PercentComplete")));
             assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "percentWorkComplete", "PercentWorkComplete", readNumberCellAt(row.cells, columnIndexByLabel.get("PercentWorkComplete")));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "milestone", "Milestone", readBooleanCellAt(row.cells, columnIndexByLabel.get("Milestone")));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "summary", "Summary", readBooleanCellAt(row.cells, columnIndexByLabel.get("Summary")));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "critical", "Critical", readBooleanCellAt(row.cells, columnIndexByLabel.get("Critical")));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "calendarUID", "CalendarUID", readStringCellAt(row.cells, columnIndexByLabel.get("CalendarUID")));
+            assignPredecessorsIfChanged(changes, task.uid, taskLabel, task, parsePredecessorCell(readStringCellAt(row.cells, columnIndexByLabel.get("Predecessors"))));
             assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "notes", "Notes", readStringCellAt(row.cells, columnIndexByLabel.get("Notes")));
         }
     }
@@ -10689,6 +10912,7 @@ if (!customElements.get("lht-page-menu")) {
             assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "name", "Name", readStringCellAt(row.cells, columnIndexByLabel.get("Name")));
             assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "group", "Group", readStringCellAt(row.cells, columnIndexByLabel.get("Group")));
             assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "maxUnits", "MaxUnits", readNumberCellAt(row.cells, columnIndexByLabel.get("MaxUnits")));
+            assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "calendarUID", "CalendarUID", readStringCellAt(row.cells, columnIndexByLabel.get("CalendarUID")));
         }
     }
     function importAssignmentsSheet(workbook, model, changes) {
@@ -10887,14 +11111,64 @@ if (!customElements.get("lht-page-menu")) {
             return cell.value !== 0;
         }
         if (typeof cell.value === "string") {
-            if (cell.value === "true" || cell.value === "TRUE" || cell.value === "1") {
+            if (cell.value === "true" || cell.value === "TRUE" || cell.value === "1" || cell.value === BOOLEAN_TRUE_LABEL || cell.value === "〇" || cell.value === "○") {
                 return true;
             }
-            if (cell.value === "false" || cell.value === "FALSE" || cell.value === "0") {
+            if (cell.value === "false" || cell.value === "FALSE" || cell.value === "0" || cell.value === BOOLEAN_FALSE_LABEL || cell.value === "-" || cell.value === "－") {
                 return false;
             }
         }
         return undefined;
+    }
+    function isTrueLike(value) {
+        return value === true || value === 1 || value === "1" || value === BOOLEAN_TRUE_LABEL || value === "○" || value === "〇";
+    }
+    function buildOptionsSheet() {
+        return {
+            name: OPTIONS_SHEET_NAME,
+            columns: [{ width: 18 }, { width: 14 }],
+            mergedRanges: [],
+            rows: [
+                headerRow(["BooleanChoice", "Meaning"], HEADER_FILL),
+                { cells: [textCell(BOOLEAN_TRUE_LABEL, 0), textCell("true", 0)] },
+                { cells: [textCell(BOOLEAN_FALSE_LABEL, 1), textCell("false", 1)] }
+            ]
+        };
+    }
+    function buildBooleanDataValidations(ranges) {
+        const sqref = ranges.filter((value) => Boolean(value)).join(" ");
+        if (!sqref) {
+            return undefined;
+        }
+        return [{
+                type: "list",
+                sqref,
+                formula1: `${OPTIONS_SHEET_NAME}!$A$2:$A$3`,
+                allowBlank: true
+            }];
+    }
+    function buildColumnRange(columnIndex, startRow, endRow) {
+        if (endRow < startRow) {
+            return undefined;
+        }
+        const columnName = encodeColumnName(columnIndex);
+        return `${columnName}${startRow}:${columnName}${endRow}`;
+    }
+    function buildSingleCellReference(columnIndex, rowNumber) {
+        if (!rowNumber) {
+            return undefined;
+        }
+        return `${encodeColumnName(columnIndex)}${rowNumber}`;
+    }
+    function encodeColumnName(columnIndex) {
+        let current = columnIndex + 1;
+        let name = "";
+        while (current > 0) {
+            const remainder = (current - 1) % 26;
+            name = String.fromCharCode(65 + remainder) + name;
+            current = Math.floor((current - 1) / 26);
+        }
+        return name;
     }
     function assignIfChanged(changes, scope, uid, label, target, key, field, value) {
         if (value === undefined) {
@@ -10912,6 +11186,38 @@ if (!customElements.get("lht-page-menu")) {
             field,
             before: before,
             after: value
+        });
+    }
+    function parsePredecessorCell(value) {
+        if (value === undefined) {
+            return undefined;
+        }
+        const normalized = value
+            .split(",")
+            .map((item) => item.trim())
+            .filter(Boolean);
+        return normalized.map((predecessorUid) => ({ predecessorUid }));
+    }
+    function formatPredecessorList(predecessors) {
+        return predecessors.map((item) => item.predecessorUid).join(", ");
+    }
+    function assignPredecessorsIfChanged(changes, uid, label, task, predecessors) {
+        if (predecessors === undefined) {
+            return;
+        }
+        const beforeText = formatPredecessorList(task.predecessors);
+        const afterText = formatPredecessorList(predecessors);
+        if (beforeText === afterText) {
+            return;
+        }
+        task.predecessors = predecessors;
+        changes.push({
+            scope: "tasks",
+            uid,
+            label,
+            field: "Predecessors",
+            before: beforeText || undefined,
+            after: afterText
         });
     }
     globalThis.__mikuprojectProjectXlsx = {

--- a/src/js/excel-io.js
+++ b/src/js/excel-io.js
@@ -102,6 +102,9 @@
                     columns: Array.isArray(sheet.columns) ? sheet.columns.map((column) => normalizeColumn(column)) : undefined,
                     freezePane: normalizeFreezePane(sheet.freezePane),
                     mergedRanges: Array.isArray(sheet.mergedRanges) ? sheet.mergedRanges.map((range) => normalizeMergedRange(range)) : undefined,
+                    dataValidations: Array.isArray(sheet.dataValidations)
+                        ? sheet.dataValidations.map((dataValidation) => normalizeDataValidation(dataValidation))
+                        : undefined,
                     rows: Array.isArray(sheet.rows)
                         ? sheet.rows.map((row) => ({
                             height: normalizeOptionalPositiveNumber(row === null || row === void 0 ? void 0 : row.height, "Row height"),
@@ -124,6 +127,24 @@
         return {
             width: normalizeOptionalPositiveNumber(column.width, "Column width"),
             hidden: column.hidden === true ? true : undefined
+        };
+    }
+    function normalizeDataValidation(dataValidation) {
+        if (!dataValidation) {
+            throw new Error("Data validation must be defined");
+        }
+        if (dataValidation.type !== "list") {
+            throw new Error(`Unsupported data validation type: ${String(dataValidation.type)}`);
+        }
+        const sqref = normalizeSqref(dataValidation.sqref);
+        if (!dataValidation.formula1 || typeof dataValidation.formula1 !== "string") {
+            throw new Error("Data validation formula1 must be a non-empty string");
+        }
+        return {
+            type: "list",
+            sqref,
+            formula1: dataValidation.formula1,
+            allowBlank: dataValidation.allowBlank === true ? true : undefined
         };
     }
     function normalizeFreezePane(freezePane) {
@@ -190,6 +211,31 @@
             throw new Error(`Invalid merged range: ${range}`);
         }
         return trimmed;
+    }
+    function normalizeSqref(sqref) {
+        if (typeof sqref !== "string") {
+            throw new Error("Data validation sqref must be a string");
+        }
+        const normalized = sqref
+            .trim()
+            .toUpperCase()
+            .split(/\s+/)
+            .filter(Boolean)
+            .map((part) => normalizeSqrefPart(part))
+            .join(" ");
+        if (!normalized) {
+            throw new Error("Data validation sqref must not be empty");
+        }
+        return normalized;
+    }
+    function normalizeSqrefPart(part) {
+        if (/^[A-Z]+\d+$/.test(part)) {
+            return part;
+        }
+        if (/^[A-Z]+\d+:[A-Z]+\d+$/.test(part)) {
+            return part;
+        }
+        throw new Error(`Invalid data validation sqref: ${part}`);
     }
     function normalizeOptionalPositiveNumber(value, label) {
         if (value === undefined) {
@@ -287,6 +333,7 @@
         const sheetViewsXml = buildSheetViewsXml(sheet.freezePane);
         const colsXml = buildColumnsXml(sheet.columns);
         const mergeCellsXml = buildMergeCellsXml(sheet.mergedRanges);
+        const dataValidationsXml = buildDataValidationsXml(sheet.dataValidations);
         const rows = sheet.rows.map((row, rowIndex) => buildWorksheetRowXml(row, rowIndex, styleBook)).filter(Boolean).join("");
         return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
@@ -294,6 +341,7 @@
   ${colsXml}
   <sheetData>${rows}</sheetData>
   ${mergeCellsXml}
+  ${dataValidationsXml}
 </worksheet>`;
     }
     function buildSheetViewsXml(freezePane) {
@@ -324,6 +372,13 @@
             .map((range) => `<mergeCell ref="${range}"/>`)
             .join("");
         return `<mergeCells count="${mergedRanges.length}">${mergeCells}</mergeCells>`;
+    }
+    function buildDataValidationsXml(dataValidations) {
+        if (!dataValidations || dataValidations.length === 0) {
+            return "";
+        }
+        const nodes = dataValidations.map((dataValidation) => (`<dataValidation type="${dataValidation.type}" allowBlank="${dataValidation.allowBlank === true ? "1" : "0"}" showErrorMessage="1" sqref="${escapeXml(dataValidation.sqref)}"><formula1>${escapeXml(dataValidation.formula1)}</formula1></dataValidation>`)).join("");
+        return `<dataValidations count="${dataValidations.length}">${nodes}</dataValidations>`;
     }
     function buildWorksheetRowXml(row, rowIndex, styleBook) {
         const cells = row.cells

--- a/src/js/msproject-xml.js
+++ b/src/js/msproject-xml.js
@@ -8,7 +8,11 @@
         project: {
             name: "mikuproject開発",
             planned_start: "2026-03-16",
-            planned_finish: "2026-04-01"
+            planned_finish: "2026-04-01",
+            schedule_from_start: true,
+            minutes_per_day: 480,
+            minutes_per_week: 2400,
+            days_per_month: 20
         },
         tasks: [
             {
@@ -127,6 +131,38 @@
                 is_milestone: true,
                 planned_start: "2026-03-29",
                 planned_finish: "2026-03-29"
+            }
+        ],
+        resources: [
+            {
+                uid: "res-1",
+                name: "Mikuku",
+                initials: "M",
+                group: "Development",
+                max_units: 1,
+                calendar_uid: "1"
+            }
+        ],
+        assignments: [
+            {
+                uid: "asg-1",
+                task_uid: "draft-120",
+                resource_uid: "res-1",
+                start: "2026-03-16T09:00:00",
+                finish: "2026-03-16T18:00:00",
+                units: 1,
+                work: "PT8H0M0S",
+                percent_work_complete: 100
+            },
+            {
+                uid: "asg-2",
+                task_uid: "draft-130",
+                resource_uid: "res-1",
+                start: "2026-03-17T09:00:00",
+                finish: "2026-03-17T18:00:00",
+                units: 1,
+                work: "PT8H0M0S",
+                percent_work_complete: 100
             }
         ]
     };
@@ -1658,6 +1694,8 @@
             throw new Error("project.name がありません");
         }
         const inputTasks = Array.isArray(data.tasks) ? data.tasks : [];
+        const inputResources = Array.isArray(data.resources) ? data.resources : [];
+        const inputAssignments = Array.isArray(data.assignments) ? data.assignments : [];
         const seenUids = new Set();
         for (const task of inputTasks) {
             const uid = String(task.uid || "").trim();
@@ -1678,10 +1716,42 @@
                 throw new Error(`draft task の parent_uid が既存 uid を指していません: ${String(task.uid || "")} -> ${parentUid}`);
             }
         }
+        const seenResourceUids = new Set();
+        for (const resource of inputResources) {
+            const uid = String(resource.uid || "").trim();
+            if (!uid) {
+                throw new Error("draft resource の uid がありません");
+            }
+            if (seenResourceUids.has(uid)) {
+                throw new Error(`draft resource の uid が重複しています: ${uid}`);
+            }
+            seenResourceUids.add(uid);
+            if (!String(resource.name || "").trim()) {
+                throw new Error(`draft resource の name がありません: ${uid}`);
+            }
+        }
+        for (const assignment of inputAssignments) {
+            const uid = String(assignment.uid || "").trim();
+            if (!uid) {
+                throw new Error("draft assignment の uid がありません");
+            }
+            const taskUid = String(assignment.task_uid || "").trim();
+            const resourceUid = String(assignment.resource_uid || "").trim();
+            if (!taskUid || !seenUids.has(taskUid)) {
+                throw new Error(`draft assignment の task_uid が既存 uid を指していません: ${uid} -> ${taskUid}`);
+            }
+            if (!resourceUid || !seenResourceUids.has(resourceUid)) {
+                throw new Error(`draft assignment の resource_uid が既存 uid を指していません: ${uid} -> ${resourceUid}`);
+            }
+        }
         const projectStart = data.project.planned_start || data.project.planned_finish || toIsoLocalString(new Date());
         const draftUidMap = new Map();
         inputTasks.forEach((task, index) => {
             draftUidMap.set(String(task.uid || "").trim(), String(index + 1));
+        });
+        const draftResourceUidMap = new Map();
+        inputResources.forEach((resource, index) => {
+            draftResourceUidMap.set(String(resource.uid || "").trim(), String(index + 1));
         });
         const normalizedTasks = inputTasks.map((task, index) => ({
             uid: draftUidMap.get(String(task.uid || "").trim()) || String(index + 1),
@@ -1762,20 +1832,56 @@
         }
         walk(null, []);
         const taskFinishes = orderedTasks.map((task) => task.finish).filter(Boolean).sort();
+        const orderedResources = inputResources.map((resource, index) => ({
+            uid: draftResourceUidMap.get(String(resource.uid || "").trim()) || String(index + 1),
+            id: draftResourceUidMap.get(String(resource.uid || "").trim()) || String(index + 1),
+            name: String(resource.name || "").trim(),
+            initials: String(resource.initials || "").trim() || undefined,
+            group: String(resource.group || "").trim() || undefined,
+            maxUnits: typeof resource.max_units === "number" && Number.isFinite(resource.max_units) ? resource.max_units : undefined,
+            calendarUID: String(resource.calendar_uid || "").trim() || undefined,
+            extendedAttributes: [],
+            baselines: [],
+            timephasedData: []
+        }));
+        const orderedAssignments = inputAssignments.map((assignment, index) => ({
+            uid: String(index + 1),
+            taskUid: draftUidMap.get(String(assignment.task_uid || "").trim()) || String(assignment.task_uid || "").trim(),
+            resourceUid: draftResourceUidMap.get(String(assignment.resource_uid || "").trim()) || String(assignment.resource_uid || "").trim(),
+            start: String(assignment.start || "").trim() || undefined,
+            finish: String(assignment.finish || "").trim() || undefined,
+            units: typeof assignment.units === "number" && Number.isFinite(assignment.units) ? assignment.units : undefined,
+            work: String(assignment.work || "").trim() || undefined,
+            percentWorkComplete: typeof assignment.percent_work_complete === "number" && Number.isFinite(assignment.percent_work_complete)
+                ? Math.max(0, Math.min(100, assignment.percent_work_complete))
+                : undefined,
+            extendedAttributes: [],
+            baselines: [],
+            timephasedData: []
+        }));
         return normalizeProjectModel(ensureDefaultProjectCalendar({
             project: {
                 name: data.project.name.trim(),
                 title: data.project.name.trim(),
                 startDate: projectStart,
                 finishDate: data.project.planned_finish || taskFinishes.at(-1) || projectStart,
-                scheduleFromStart: true,
+                scheduleFromStart: data.project.schedule_from_start !== undefined ? Boolean(data.project.schedule_from_start) : true,
+                minutesPerDay: typeof data.project.minutes_per_day === "number" && Number.isFinite(data.project.minutes_per_day)
+                    ? data.project.minutes_per_day
+                    : undefined,
+                minutesPerWeek: typeof data.project.minutes_per_week === "number" && Number.isFinite(data.project.minutes_per_week)
+                    ? data.project.minutes_per_week
+                    : undefined,
+                daysPerMonth: typeof data.project.days_per_month === "number" && Number.isFinite(data.project.days_per_month)
+                    ? data.project.days_per_month
+                    : undefined,
                 outlineCodes: [],
                 wbsMasks: [],
                 extendedAttributes: []
             },
             tasks: orderedTasks,
-            resources: [],
-            assignments: [],
+            resources: orderedResources,
+            assignments: orderedAssignments,
             calendars: []
         }));
     }

--- a/src/js/project-workbook-schema.js
+++ b/src/js/project-workbook-schema.js
@@ -70,8 +70,8 @@
     };
     const IMPORTABLE_FIELDS = {
         Project: PROJECT_EDITABLE_FIELDS,
-        Tasks: ["Name", "Start", "Finish", "PercentComplete", "PercentWorkComplete", "Notes"],
-        Resources: ["Name", "Group", "MaxUnits"],
+        Tasks: ["Name", "Start", "Finish", "Duration", "PercentComplete", "PercentWorkComplete", "Milestone", "Summary", "Critical", "CalendarUID", "Predecessors", "Notes"],
+        Resources: ["Name", "Group", "MaxUnits", "CalendarUID"],
         Assignments: ["Units", "Work", "PercentWorkComplete"],
         Calendars: ["Name", "IsBaseCalendar", "BaseCalendarUID"],
         NonWorkingDays: ["Name", "Date", "FromDate", "ToDate", "DayWorking"]

--- a/src/js/project-xlsx.js
+++ b/src/js/project-xlsx.js
@@ -21,6 +21,9 @@
     const NOTES_FILL = "#FFFBEA";
     const NAME_FILL = "#FAF6FF";
     const WORK_FILL = "#F1F8FD";
+    const BOOLEAN_TRUE_LABEL = "○";
+    const BOOLEAN_FALSE_LABEL = "ー";
+    const OPTIONS_SHEET_NAME = "Options";
     const SUMMARY_FILL = "#E6F2E0";
     const MILESTONE_FILL = "#FFF0CF";
     const CRITICAL_FILL = "#F8DDE6";
@@ -33,14 +36,21 @@
         nonWorkingDays: { section: "#E9C7D5", header: "#F4DDE6", label: "#FBEEF3" }
     };
     function exportProjectWorkbook(model) {
+        const projectSheet = buildProjectSheet(model);
+        const tasksSheet = buildTasksSheet(model);
+        const resourcesSheet = buildResourcesSheet(model);
+        const assignmentsSheet = buildAssignmentsSheet(model);
+        const calendarsSheet = buildCalendarsSheet(model);
+        const nonWorkingDaysSheet = buildNonWorkingDaysSheet(model);
         return {
             sheets: [
-                buildProjectSheet(model),
-                buildTasksSheet(model),
-                buildResourcesSheet(model),
-                buildAssignmentsSheet(model),
-                buildCalendarsSheet(model),
-                buildNonWorkingDaysSheet(model)
+                projectSheet,
+                tasksSheet,
+                resourcesSheet,
+                assignmentsSheet,
+                calendarsSheet,
+                nonWorkingDaysSheet,
+                buildOptionsSheet()
             ]
         };
     }
@@ -99,10 +109,21 @@
             titleRow("Settings", SHEET_THEMES.project.section),
             ...PROJECT_FIELD_ORDER.slice(8).map((field) => keyValueRow(field, readProjectFieldValue(project, field), SHEET_THEMES.project.label))
         ];
+        const rowNumberByField = new Map();
+        rows.forEach((row, index) => {
+            var _a;
+            const field = typeof ((_a = row.cells[0]) === null || _a === void 0 ? void 0 : _a.value) === "string" ? row.cells[0].value : undefined;
+            if (field) {
+                rowNumberByField.set(field, index + 1);
+            }
+        });
         return {
             name: "Project",
             columns: [{ width: 26 }, { width: 42 }],
             mergedRanges: ["A11:B11"],
+            dataValidations: buildBooleanDataValidations([
+                buildSingleCellReference(1, rowNumberByField.get("ScheduleFromStart"))
+            ]),
             rows
         };
     }
@@ -117,6 +138,11 @@
                 { width: 34 }
             ],
             mergedRanges: [],
+            dataValidations: buildBooleanDataValidations([
+                buildColumnRange(11, DATA_ROW_START_INDEX + 1, DATA_ROW_START_INDEX + model.tasks.length),
+                buildColumnRange(12, DATA_ROW_START_INDEX + 1, DATA_ROW_START_INDEX + model.tasks.length),
+                buildColumnRange(13, DATA_ROW_START_INDEX + 1, DATA_ROW_START_INDEX + model.tasks.length)
+            ]),
             rows: [
                 sectionTitleRow("Tasks", 17, SHEET_THEMES.tasks.section),
                 sectionTitleRow("Task List", 17, SHEET_THEMES.tasks.section),
@@ -131,14 +157,14 @@
                         textCell(task.wbs, index),
                         editableCell(dateTimeCell(task.start, index)),
                         editableCell(dateTimeCell(task.finish, index)),
-                        durationCell(task.duration, index),
+                        editableCell(durationCell(task.duration, index)),
                         editableCell(percentCell(task.percentComplete, index)),
                         editableCell(percentCell(task.percentWorkComplete, index)),
                         taskFlagCell(task.milestone, index, MILESTONE_FILL),
                         taskFlagCell(task.summary, index, SUMMARY_FILL),
                         taskFlagCell(task.critical, index, CRITICAL_FILL),
-                        referenceCell(task.calendarUID, index),
-                        predecessorCell(task.predecessors.map((item) => item.predecessorUid).join(", "), index),
+                        editableCell(referenceCell(task.calendarUID, index)),
+                        editableCell(predecessorCell(task.predecessors.map((item) => item.predecessorUid).join(", "), index)),
                         editableCell(notesCell(task.notes, index))
                     ]
                 }))
@@ -156,7 +182,7 @@
                     textCell(resource.initials, index),
                     editableCell(textCell(resource.group, index)),
                     editableCell(countCell(resource.maxUnits, index)),
-                    referenceCell(resource.calendarUID, index),
+                    editableCell(referenceCell(resource.calendarUID, index)),
                     textCell(resource.standardRate, index),
                     textCell(resource.overtimeRate, index),
                     countCell(resource.costPerUse, index),
@@ -174,7 +200,7 @@
                         textCell(undefined, 0),
                         editableCell(textCell(undefined, 0)),
                         editableCell(countCell(undefined, 0)),
-                        referenceCell(undefined, 0),
+                        editableCell(referenceCell(undefined, 0)),
                         textCell(undefined, 0),
                         textCell(undefined, 0),
                         countCell(undefined, 0),
@@ -260,6 +286,9 @@
                 { width: 10 }, { width: 12 }, { width: 10 }
             ],
             mergedRanges: [],
+            dataValidations: buildBooleanDataValidations([
+                buildColumnRange(2, DATA_ROW_START_INDEX + 1, DATA_ROW_START_INDEX + model.calendars.length)
+            ]),
             rows: [
                 sectionTitleRow("Calendars", 7, SHEET_THEMES.calendars.section),
                 sectionTitleRow("Calendar List", 7, SHEET_THEMES.calendars.section),
@@ -298,6 +327,9 @@
                 { width: 14 }, { width: 22 }, { width: 22 }, { width: 12 }
             ],
             mergedRanges: [],
+            dataValidations: buildBooleanDataValidations([
+                buildColumnRange(7, DATA_ROW_START_INDEX + 1, DATA_ROW_START_INDEX + rows.length)
+            ]),
             rows: [
                 sectionTitleRow("NonWorkingDays", 8, SHEET_THEMES.nonWorkingDays.section),
                 sectionTitleRow("Calendar Exceptions", 8, SHEET_THEMES.nonWorkingDays.section),
@@ -375,6 +407,9 @@
         };
     }
     function stringifyCellValue(value) {
+        if (typeof value === "boolean") {
+            return value ? BOOLEAN_TRUE_LABEL : BOOLEAN_FALSE_LABEL;
+        }
         return typeof value === "string" ? value : String(value);
     }
     function keyValueCell(label, value) {
@@ -433,11 +468,13 @@
         };
     }
     function taskFlagCell(value, rowIndex, activeFillColor) {
-        const isActive = value === true || value === 1 || value === "1";
-        return styledCell(value, rowIndex, {
-            fillColor: isActive ? activeFillColor : COUNT_FILL,
+        const displayValue = value === undefined ? undefined : stringifyCellValue(value);
+        return {
+            value: displayValue,
+            border: "thin",
+            fillColor: EDITABLE_FILL,
             horizontalAlign: "center"
-        });
+        };
     }
     function referenceCell(value, rowIndex) {
         return styledCell(value, rowIndex, {
@@ -593,8 +630,14 @@
             assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "name", "Name", readStringCellAt(row.cells, columnIndexByLabel.get("Name")));
             assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "start", "Start", normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Start"))));
             assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "finish", "Finish", normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Finish"))));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "duration", "Duration", readStringCellAt(row.cells, columnIndexByLabel.get("Duration")));
             assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "percentComplete", "PercentComplete", readNumberCellAt(row.cells, columnIndexByLabel.get("PercentComplete")));
             assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "percentWorkComplete", "PercentWorkComplete", readNumberCellAt(row.cells, columnIndexByLabel.get("PercentWorkComplete")));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "milestone", "Milestone", readBooleanCellAt(row.cells, columnIndexByLabel.get("Milestone")));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "summary", "Summary", readBooleanCellAt(row.cells, columnIndexByLabel.get("Summary")));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "critical", "Critical", readBooleanCellAt(row.cells, columnIndexByLabel.get("Critical")));
+            assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "calendarUID", "CalendarUID", readStringCellAt(row.cells, columnIndexByLabel.get("CalendarUID")));
+            assignPredecessorsIfChanged(changes, task.uid, taskLabel, task, parsePredecessorCell(readStringCellAt(row.cells, columnIndexByLabel.get("Predecessors"))));
             assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "notes", "Notes", readStringCellAt(row.cells, columnIndexByLabel.get("Notes")));
         }
     }
@@ -622,6 +665,7 @@
             assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "name", "Name", readStringCellAt(row.cells, columnIndexByLabel.get("Name")));
             assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "group", "Group", readStringCellAt(row.cells, columnIndexByLabel.get("Group")));
             assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "maxUnits", "MaxUnits", readNumberCellAt(row.cells, columnIndexByLabel.get("MaxUnits")));
+            assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "calendarUID", "CalendarUID", readStringCellAt(row.cells, columnIndexByLabel.get("CalendarUID")));
         }
     }
     function importAssignmentsSheet(workbook, model, changes) {
@@ -820,14 +864,64 @@
             return cell.value !== 0;
         }
         if (typeof cell.value === "string") {
-            if (cell.value === "true" || cell.value === "TRUE" || cell.value === "1") {
+            if (cell.value === "true" || cell.value === "TRUE" || cell.value === "1" || cell.value === BOOLEAN_TRUE_LABEL || cell.value === "〇" || cell.value === "○") {
                 return true;
             }
-            if (cell.value === "false" || cell.value === "FALSE" || cell.value === "0") {
+            if (cell.value === "false" || cell.value === "FALSE" || cell.value === "0" || cell.value === BOOLEAN_FALSE_LABEL || cell.value === "-" || cell.value === "－") {
                 return false;
             }
         }
         return undefined;
+    }
+    function isTrueLike(value) {
+        return value === true || value === 1 || value === "1" || value === BOOLEAN_TRUE_LABEL || value === "○" || value === "〇";
+    }
+    function buildOptionsSheet() {
+        return {
+            name: OPTIONS_SHEET_NAME,
+            columns: [{ width: 18 }, { width: 14 }],
+            mergedRanges: [],
+            rows: [
+                headerRow(["BooleanChoice", "Meaning"], HEADER_FILL),
+                { cells: [textCell(BOOLEAN_TRUE_LABEL, 0), textCell("true", 0)] },
+                { cells: [textCell(BOOLEAN_FALSE_LABEL, 1), textCell("false", 1)] }
+            ]
+        };
+    }
+    function buildBooleanDataValidations(ranges) {
+        const sqref = ranges.filter((value) => Boolean(value)).join(" ");
+        if (!sqref) {
+            return undefined;
+        }
+        return [{
+                type: "list",
+                sqref,
+                formula1: `${OPTIONS_SHEET_NAME}!$A$2:$A$3`,
+                allowBlank: true
+            }];
+    }
+    function buildColumnRange(columnIndex, startRow, endRow) {
+        if (endRow < startRow) {
+            return undefined;
+        }
+        const columnName = encodeColumnName(columnIndex);
+        return `${columnName}${startRow}:${columnName}${endRow}`;
+    }
+    function buildSingleCellReference(columnIndex, rowNumber) {
+        if (!rowNumber) {
+            return undefined;
+        }
+        return `${encodeColumnName(columnIndex)}${rowNumber}`;
+    }
+    function encodeColumnName(columnIndex) {
+        let current = columnIndex + 1;
+        let name = "";
+        while (current > 0) {
+            const remainder = (current - 1) % 26;
+            name = String.fromCharCode(65 + remainder) + name;
+            current = Math.floor((current - 1) / 26);
+        }
+        return name;
     }
     function assignIfChanged(changes, scope, uid, label, target, key, field, value) {
         if (value === undefined) {
@@ -845,6 +939,38 @@
             field,
             before: before,
             after: value
+        });
+    }
+    function parsePredecessorCell(value) {
+        if (value === undefined) {
+            return undefined;
+        }
+        const normalized = value
+            .split(",")
+            .map((item) => item.trim())
+            .filter(Boolean);
+        return normalized.map((predecessorUid) => ({ predecessorUid }));
+    }
+    function formatPredecessorList(predecessors) {
+        return predecessors.map((item) => item.predecessorUid).join(", ");
+    }
+    function assignPredecessorsIfChanged(changes, uid, label, task, predecessors) {
+        if (predecessors === undefined) {
+            return;
+        }
+        const beforeText = formatPredecessorList(task.predecessors);
+        const afterText = formatPredecessorList(predecessors);
+        if (beforeText === afterText) {
+            return;
+        }
+        task.predecessors = predecessors;
+        changes.push({
+            scope: "tasks",
+            uid,
+            label,
+            field: "Predecessors",
+            before: beforeText || undefined,
+            after: afterText
         });
     }
     globalThis.__mikuprojectProjectXlsx = {

--- a/src/ts/excel-io.ts
+++ b/src/ts/excel-io.ts
@@ -37,11 +37,19 @@
     colSplit?: number;
   };
 
+  type XlsxDataValidationModel = {
+    type: "list";
+    sqref: string;
+    formula1: string;
+    allowBlank?: boolean;
+  };
+
   type XlsxSheetModel = {
     name: string;
     columns?: XlsxColumnModel[];
     freezePane?: XlsxFreezePaneModel;
     mergedRanges?: string[];
+    dataValidations?: XlsxDataValidationModel[];
     rows: XlsxRowModel[];
   };
 
@@ -196,6 +204,9 @@
           columns: Array.isArray(sheet.columns) ? sheet.columns.map((column) => normalizeColumn(column)) : undefined,
           freezePane: normalizeFreezePane(sheet.freezePane),
           mergedRanges: Array.isArray(sheet.mergedRanges) ? sheet.mergedRanges.map((range) => normalizeMergedRange(range)) : undefined,
+          dataValidations: Array.isArray(sheet.dataValidations)
+            ? sheet.dataValidations.map((dataValidation) => normalizeDataValidation(dataValidation))
+            : undefined,
           rows: Array.isArray(sheet.rows)
             ? sheet.rows.map((row) => ({
               height: normalizeOptionalPositiveNumber(row?.height, "Row height"),
@@ -219,6 +230,25 @@
     return {
       width: normalizeOptionalPositiveNumber(column.width, "Column width"),
       hidden: column.hidden === true ? true : undefined
+    };
+  }
+
+  function normalizeDataValidation(dataValidation: XlsxDataValidationModel | undefined): XlsxDataValidationModel {
+    if (!dataValidation) {
+      throw new Error("Data validation must be defined");
+    }
+    if (dataValidation.type !== "list") {
+      throw new Error(`Unsupported data validation type: ${String(dataValidation.type)}`);
+    }
+    const sqref = normalizeSqref(dataValidation.sqref);
+    if (!dataValidation.formula1 || typeof dataValidation.formula1 !== "string") {
+      throw new Error("Data validation formula1 must be a non-empty string");
+    }
+    return {
+      type: "list",
+      sqref,
+      formula1: dataValidation.formula1,
+      allowBlank: dataValidation.allowBlank === true ? true : undefined
     };
   }
 
@@ -288,6 +318,33 @@
       throw new Error(`Invalid merged range: ${range}`);
     }
     return trimmed;
+  }
+
+  function normalizeSqref(sqref: string): string {
+    if (typeof sqref !== "string") {
+      throw new Error("Data validation sqref must be a string");
+    }
+    const normalized = sqref
+      .trim()
+      .toUpperCase()
+      .split(/\s+/)
+      .filter(Boolean)
+      .map((part) => normalizeSqrefPart(part))
+      .join(" ");
+    if (!normalized) {
+      throw new Error("Data validation sqref must not be empty");
+    }
+    return normalized;
+  }
+
+  function normalizeSqrefPart(part: string): string {
+    if (/^[A-Z]+\d+$/.test(part)) {
+      return part;
+    }
+    if (/^[A-Z]+\d+:[A-Z]+\d+$/.test(part)) {
+      return part;
+    }
+    throw new Error(`Invalid data validation sqref: ${part}`);
   }
 
   function normalizeOptionalPositiveNumber(value: number | undefined, label: string): number | undefined {
@@ -410,6 +467,7 @@
     const sheetViewsXml = buildSheetViewsXml(sheet.freezePane);
     const colsXml = buildColumnsXml(sheet.columns);
     const mergeCellsXml = buildMergeCellsXml(sheet.mergedRanges);
+    const dataValidationsXml = buildDataValidationsXml(sheet.dataValidations);
     const rows = sheet.rows.map((row, rowIndex) => buildWorksheetRowXml(row, rowIndex, styleBook)).filter(Boolean).join("");
     return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
@@ -417,6 +475,7 @@
   ${colsXml}
   <sheetData>${rows}</sheetData>
   ${mergeCellsXml}
+  ${dataValidationsXml}
 </worksheet>`;
   }
 
@@ -452,6 +511,16 @@
       .map((range) => `<mergeCell ref="${range}"/>`)
       .join("");
     return `<mergeCells count="${mergedRanges.length}">${mergeCells}</mergeCells>`;
+  }
+
+  function buildDataValidationsXml(dataValidations: XlsxDataValidationModel[] | undefined): string {
+    if (!dataValidations || dataValidations.length === 0) {
+      return "";
+    }
+    const nodes = dataValidations.map((dataValidation) => (
+      `<dataValidation type="${dataValidation.type}" allowBlank="${dataValidation.allowBlank === true ? "1" : "0"}" showErrorMessage="1" sqref="${escapeXml(dataValidation.sqref)}"><formula1>${escapeXml(dataValidation.formula1)}</formula1></dataValidation>`
+    )).join("");
+    return `<dataValidations count="${dataValidations.length}">${nodes}</dataValidations>`;
   }
 
   function buildWorksheetRowXml(row: XlsxRowModel, rowIndex: number, styleBook: StyleBook): string {

--- a/src/ts/msproject-xml.ts
+++ b/src/ts/msproject-xml.ts
@@ -8,7 +8,11 @@
     project: {
       name: "mikuproject開発",
       planned_start: "2026-03-16",
-      planned_finish: "2026-04-01"
+      planned_finish: "2026-04-01",
+      schedule_from_start: true,
+      minutes_per_day: 480,
+      minutes_per_week: 2400,
+      days_per_month: 20
     },
     tasks: [
       {
@@ -127,6 +131,38 @@
         is_milestone: true,
         planned_start: "2026-03-29",
         planned_finish: "2026-03-29"
+      }
+    ],
+    resources: [
+      {
+        uid: "res-1",
+        name: "Mikuku",
+        initials: "M",
+        group: "Development",
+        max_units: 1,
+        calendar_uid: "1"
+      }
+    ],
+    assignments: [
+      {
+        uid: "asg-1",
+        task_uid: "draft-120",
+        resource_uid: "res-1",
+        start: "2026-03-16T09:00:00",
+        finish: "2026-03-16T18:00:00",
+        units: 1,
+        work: "PT8H0M0S",
+        percent_work_complete: 100
+      },
+      {
+        uid: "asg-2",
+        task_uid: "draft-130",
+        resource_uid: "res-1",
+        start: "2026-03-17T09:00:00",
+        finish: "2026-03-17T18:00:00",
+        units: 1,
+        work: "PT8H0M0S",
+        percent_work_complete: 100
       }
     ]
   } as const;
@@ -1724,6 +1760,10 @@
         name?: string;
         planned_start?: string;
         planned_finish?: string;
+        schedule_from_start?: boolean;
+        minutes_per_day?: number;
+        minutes_per_week?: number;
+        days_per_month?: number;
       };
       tasks?: Array<{
         uid?: string;
@@ -1740,6 +1780,24 @@
         predecessors?: Array<string | { task_uid?: string }>;
         predecessor_uids?: string[];
       }>;
+      resources?: Array<{
+        uid?: string;
+        name?: string;
+        initials?: string;
+        group?: string;
+        max_units?: number;
+        calendar_uid?: string;
+      }>;
+      assignments?: Array<{
+        uid?: string;
+        task_uid?: string;
+        resource_uid?: string;
+        start?: string;
+        finish?: string;
+        units?: number;
+        work?: string;
+        percent_work_complete?: number;
+      }>;
     };
     if (data.view_type !== "project_draft_view") {
       throw new Error("view_type が project_draft_view ではありません");
@@ -1748,6 +1806,8 @@
       throw new Error("project.name がありません");
     }
     const inputTasks = Array.isArray(data.tasks) ? data.tasks : [];
+    const inputResources = Array.isArray(data.resources) ? data.resources : [];
+    const inputAssignments = Array.isArray(data.assignments) ? data.assignments : [];
     const seenUids = new Set<string>();
     for (const task of inputTasks) {
       const uid = String(task.uid || "").trim();
@@ -1768,10 +1828,42 @@
         throw new Error(`draft task の parent_uid が既存 uid を指していません: ${String(task.uid || "")} -> ${parentUid}`);
       }
     }
+    const seenResourceUids = new Set<string>();
+    for (const resource of inputResources) {
+      const uid = String(resource.uid || "").trim();
+      if (!uid) {
+        throw new Error("draft resource の uid がありません");
+      }
+      if (seenResourceUids.has(uid)) {
+        throw new Error(`draft resource の uid が重複しています: ${uid}`);
+      }
+      seenResourceUids.add(uid);
+      if (!String(resource.name || "").trim()) {
+        throw new Error(`draft resource の name がありません: ${uid}`);
+      }
+    }
+    for (const assignment of inputAssignments) {
+      const uid = String(assignment.uid || "").trim();
+      if (!uid) {
+        throw new Error("draft assignment の uid がありません");
+      }
+      const taskUid = String(assignment.task_uid || "").trim();
+      const resourceUid = String(assignment.resource_uid || "").trim();
+      if (!taskUid || !seenUids.has(taskUid)) {
+        throw new Error(`draft assignment の task_uid が既存 uid を指していません: ${uid} -> ${taskUid}`);
+      }
+      if (!resourceUid || !seenResourceUids.has(resourceUid)) {
+        throw new Error(`draft assignment の resource_uid が既存 uid を指していません: ${uid} -> ${resourceUid}`);
+      }
+    }
     const projectStart = data.project.planned_start || data.project.planned_finish || toIsoLocalString(new Date());
     const draftUidMap = new Map<string, string>();
     inputTasks.forEach((task, index) => {
       draftUidMap.set(String(task.uid || "").trim(), String(index + 1));
+    });
+    const draftResourceUidMap = new Map<string, string>();
+    inputResources.forEach((resource, index) => {
+      draftResourceUidMap.set(String(resource.uid || "").trim(), String(index + 1));
     });
     const normalizedTasks = inputTasks.map((task, index) => ({
       uid: draftUidMap.get(String(task.uid || "").trim()) || String(index + 1),
@@ -1852,20 +1944,56 @@
     }
     walk(null, []);
     const taskFinishes = orderedTasks.map((task) => task.finish).filter(Boolean).sort();
+    const orderedResources: ResourceModel[] = inputResources.map((resource, index) => ({
+      uid: draftResourceUidMap.get(String(resource.uid || "").trim()) || String(index + 1),
+      id: draftResourceUidMap.get(String(resource.uid || "").trim()) || String(index + 1),
+      name: String(resource.name || "").trim(),
+      initials: String(resource.initials || "").trim() || undefined,
+      group: String(resource.group || "").trim() || undefined,
+      maxUnits: typeof resource.max_units === "number" && Number.isFinite(resource.max_units) ? resource.max_units : undefined,
+      calendarUID: String(resource.calendar_uid || "").trim() || undefined,
+      extendedAttributes: [],
+      baselines: [],
+      timephasedData: []
+    }));
+    const orderedAssignments: AssignmentModel[] = inputAssignments.map((assignment, index) => ({
+      uid: String(index + 1),
+      taskUid: draftUidMap.get(String(assignment.task_uid || "").trim()) || String(assignment.task_uid || "").trim(),
+      resourceUid: draftResourceUidMap.get(String(assignment.resource_uid || "").trim()) || String(assignment.resource_uid || "").trim(),
+      start: String(assignment.start || "").trim() || undefined,
+      finish: String(assignment.finish || "").trim() || undefined,
+      units: typeof assignment.units === "number" && Number.isFinite(assignment.units) ? assignment.units : undefined,
+      work: String(assignment.work || "").trim() || undefined,
+      percentWorkComplete: typeof assignment.percent_work_complete === "number" && Number.isFinite(assignment.percent_work_complete)
+        ? Math.max(0, Math.min(100, assignment.percent_work_complete))
+        : undefined,
+      extendedAttributes: [],
+      baselines: [],
+      timephasedData: []
+    }));
     return normalizeProjectModel(ensureDefaultProjectCalendar({
       project: {
         name: data.project.name.trim(),
         title: data.project.name.trim(),
         startDate: projectStart,
         finishDate: data.project.planned_finish || taskFinishes.at(-1) || projectStart,
-        scheduleFromStart: true,
+        scheduleFromStart: data.project.schedule_from_start !== undefined ? Boolean(data.project.schedule_from_start) : true,
+        minutesPerDay: typeof data.project.minutes_per_day === "number" && Number.isFinite(data.project.minutes_per_day)
+          ? data.project.minutes_per_day
+          : undefined,
+        minutesPerWeek: typeof data.project.minutes_per_week === "number" && Number.isFinite(data.project.minutes_per_week)
+          ? data.project.minutes_per_week
+          : undefined,
+        daysPerMonth: typeof data.project.days_per_month === "number" && Number.isFinite(data.project.days_per_month)
+          ? data.project.days_per_month
+          : undefined,
         outlineCodes: [],
         wbsMasks: [],
         extendedAttributes: []
       },
       tasks: orderedTasks,
-      resources: [],
-      assignments: [],
+      resources: orderedResources,
+      assignments: orderedAssignments,
       calendars: []
     }));
   }

--- a/src/ts/project-workbook-schema.ts
+++ b/src/ts/project-workbook-schema.ts
@@ -75,8 +75,8 @@
 
   const IMPORTABLE_FIELDS = {
     Project: PROJECT_EDITABLE_FIELDS,
-    Tasks: ["Name", "Start", "Finish", "PercentComplete", "PercentWorkComplete", "Notes"] as const,
-    Resources: ["Name", "Group", "MaxUnits"] as const,
+    Tasks: ["Name", "Start", "Finish", "Duration", "PercentComplete", "PercentWorkComplete", "Milestone", "Summary", "Critical", "CalendarUID", "Predecessors", "Notes"] as const,
+    Resources: ["Name", "Group", "MaxUnits", "CalendarUID"] as const,
     Assignments: ["Units", "Work", "PercentWorkComplete"] as const,
     Calendars: ["Name", "IsBaseCalendar", "BaseCalendarUID"] as const,
     NonWorkingDays: ["Name", "Date", "FromDate", "ToDate", "DayWorking"] as const

--- a/src/ts/project-xlsx.ts
+++ b/src/ts/project-xlsx.ts
@@ -46,6 +46,12 @@
       name: string;
       columns?: Array<{ width?: number }>;
       mergedRanges?: string[];
+      dataValidations?: Array<{
+        type: "list";
+        sqref: string;
+        formula1: string;
+        allowBlank?: boolean;
+      }>;
       rows: Array<{
         height?: number;
         cells: XlsxCellLike[];
@@ -75,6 +81,9 @@
   const NOTES_FILL = "#FFFBEA";
   const NAME_FILL = "#FAF6FF";
   const WORK_FILL = "#F1F8FD";
+  const BOOLEAN_TRUE_LABEL = "○";
+  const BOOLEAN_FALSE_LABEL = "ー";
+  const OPTIONS_SHEET_NAME = "Options";
   const SUMMARY_FILL = "#E6F2E0";
   const MILESTONE_FILL = "#FFF0CF";
   const CRITICAL_FILL = "#F8DDE6";
@@ -88,14 +97,21 @@
   } as const;
 
   function exportProjectWorkbook(model: ProjectModel): XlsxWorkbookLike {
+    const projectSheet = buildProjectSheet(model);
+    const tasksSheet = buildTasksSheet(model);
+    const resourcesSheet = buildResourcesSheet(model);
+    const assignmentsSheet = buildAssignmentsSheet(model);
+    const calendarsSheet = buildCalendarsSheet(model);
+    const nonWorkingDaysSheet = buildNonWorkingDaysSheet(model);
     return {
       sheets: [
-        buildProjectSheet(model),
-        buildTasksSheet(model),
-        buildResourcesSheet(model),
-        buildAssignmentsSheet(model),
-        buildCalendarsSheet(model),
-        buildNonWorkingDaysSheet(model)
+        projectSheet,
+        tasksSheet,
+        resourcesSheet,
+        assignmentsSheet,
+        calendarsSheet,
+        nonWorkingDaysSheet,
+        buildOptionsSheet()
       ]
     };
   }
@@ -162,10 +178,21 @@
       ...PROJECT_FIELD_ORDER.slice(8).map((field) => keyValueRow(field, readProjectFieldValue(project, field), SHEET_THEMES.project.label))
     ];
 
+    const rowNumberByField = new Map<string, number>();
+    rows.forEach((row, index) => {
+      const field = typeof row.cells[0]?.value === "string" ? row.cells[0].value : undefined;
+      if (field) {
+        rowNumberByField.set(field, index + 1);
+      }
+    });
+
     return {
       name: "Project",
       columns: [{ width: 26 }, { width: 42 }],
       mergedRanges: ["A11:B11"],
+      dataValidations: buildBooleanDataValidations([
+        buildSingleCellReference(1, rowNumberByField.get("ScheduleFromStart"))
+      ]),
       rows
     };
   }
@@ -181,6 +208,11 @@
         { width: 34 }
       ],
       mergedRanges: [],
+      dataValidations: buildBooleanDataValidations([
+        buildColumnRange(11, DATA_ROW_START_INDEX + 1, DATA_ROW_START_INDEX + model.tasks.length),
+        buildColumnRange(12, DATA_ROW_START_INDEX + 1, DATA_ROW_START_INDEX + model.tasks.length),
+        buildColumnRange(13, DATA_ROW_START_INDEX + 1, DATA_ROW_START_INDEX + model.tasks.length)
+      ]),
       rows: [
         sectionTitleRow("Tasks", 17, SHEET_THEMES.tasks.section),
         sectionTitleRow("Task List", 17, SHEET_THEMES.tasks.section),
@@ -195,14 +227,14 @@
             textCell(task.wbs, index),
             editableCell(dateTimeCell(task.start, index)),
             editableCell(dateTimeCell(task.finish, index)),
-            durationCell(task.duration, index),
+            editableCell(durationCell(task.duration, index)),
             editableCell(percentCell(task.percentComplete, index)),
             editableCell(percentCell(task.percentWorkComplete, index)),
             taskFlagCell(task.milestone, index, MILESTONE_FILL),
             taskFlagCell(task.summary, index, SUMMARY_FILL),
             taskFlagCell(task.critical, index, CRITICAL_FILL),
-            referenceCell(task.calendarUID, index),
-            predecessorCell(task.predecessors.map((item) => item.predecessorUid).join(", "), index),
+            editableCell(referenceCell(task.calendarUID, index)),
+            editableCell(predecessorCell(task.predecessors.map((item) => item.predecessorUid).join(", "), index)),
             editableCell(notesCell(task.notes, index))
           ]
         }))
@@ -221,7 +253,7 @@
           textCell(resource.initials, index),
           editableCell(textCell(resource.group, index)),
           editableCell(countCell(resource.maxUnits, index)),
-          referenceCell(resource.calendarUID, index),
+          editableCell(referenceCell(resource.calendarUID, index)),
           textCell(resource.standardRate, index),
           textCell(resource.overtimeRate, index),
           countCell(resource.costPerUse, index),
@@ -239,7 +271,7 @@
           textCell(undefined, 0),
           editableCell(textCell(undefined, 0)),
           editableCell(countCell(undefined, 0)),
-          referenceCell(undefined, 0),
+          editableCell(referenceCell(undefined, 0)),
           textCell(undefined, 0),
           textCell(undefined, 0),
           countCell(undefined, 0),
@@ -329,6 +361,9 @@
         { width: 10 }, { width: 12 }, { width: 10 }
       ],
       mergedRanges: [],
+      dataValidations: buildBooleanDataValidations([
+        buildColumnRange(2, DATA_ROW_START_INDEX + 1, DATA_ROW_START_INDEX + model.calendars.length)
+      ]),
       rows: [
         sectionTitleRow("Calendars", 7, SHEET_THEMES.calendars.section),
         sectionTitleRow("Calendar List", 7, SHEET_THEMES.calendars.section),
@@ -369,6 +404,9 @@
         { width: 14 }, { width: 22 }, { width: 22 }, { width: 12 }
       ],
       mergedRanges: [],
+      dataValidations: buildBooleanDataValidations([
+        buildColumnRange(7, DATA_ROW_START_INDEX + 1, DATA_ROW_START_INDEX + rows.length)
+      ]),
       rows: [
         sectionTitleRow("NonWorkingDays", 8, SHEET_THEMES.nonWorkingDays.section),
         sectionTitleRow("Calendar Exceptions", 8, SHEET_THEMES.nonWorkingDays.section),
@@ -452,6 +490,9 @@
   }
 
   function stringifyCellValue(value: string | number | boolean): string {
+    if (typeof value === "boolean") {
+      return value ? BOOLEAN_TRUE_LABEL : BOOLEAN_FALSE_LABEL;
+    }
     return typeof value === "string" ? value : String(value);
   }
 
@@ -515,11 +556,13 @@
   }
 
   function taskFlagCell(value: string | number | boolean | undefined, rowIndex: number, activeFillColor: string): XlsxCellLike {
-    const isActive = value === true || value === 1 || value === "1";
-    return styledCell(value, rowIndex, {
-      fillColor: isActive ? activeFillColor : COUNT_FILL,
+    const displayValue = value === undefined ? undefined : stringifyCellValue(value);
+    return {
+      value: displayValue,
+      border: "thin",
+      fillColor: EDITABLE_FILL,
       horizontalAlign: "center"
-    });
+    };
   }
 
   function referenceCell(value: string | number | boolean | undefined, rowIndex: number): XlsxCellLike {
@@ -698,8 +741,14 @@
       assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "name", "Name", readStringCellAt(row.cells, columnIndexByLabel.get("Name")));
       assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "start", "Start", normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Start"))));
       assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "finish", "Finish", normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Finish"))));
+      assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "duration", "Duration", readStringCellAt(row.cells, columnIndexByLabel.get("Duration")));
       assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "percentComplete", "PercentComplete", readNumberCellAt(row.cells, columnIndexByLabel.get("PercentComplete")));
       assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "percentWorkComplete", "PercentWorkComplete", readNumberCellAt(row.cells, columnIndexByLabel.get("PercentWorkComplete")));
+      assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "milestone", "Milestone", readBooleanCellAt(row.cells, columnIndexByLabel.get("Milestone")));
+      assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "summary", "Summary", readBooleanCellAt(row.cells, columnIndexByLabel.get("Summary")));
+      assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "critical", "Critical", readBooleanCellAt(row.cells, columnIndexByLabel.get("Critical")));
+      assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "calendarUID", "CalendarUID", readStringCellAt(row.cells, columnIndexByLabel.get("CalendarUID")));
+      assignPredecessorsIfChanged(changes, task.uid, taskLabel, task, parsePredecessorCell(readStringCellAt(row.cells, columnIndexByLabel.get("Predecessors"))));
       assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "notes", "Notes", readStringCellAt(row.cells, columnIndexByLabel.get("Notes")));
     }
   }
@@ -728,6 +777,7 @@
       assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "name", "Name", readStringCellAt(row.cells, columnIndexByLabel.get("Name")));
       assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "group", "Group", readStringCellAt(row.cells, columnIndexByLabel.get("Group")));
       assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "maxUnits", "MaxUnits", readNumberCellAt(row.cells, columnIndexByLabel.get("MaxUnits")));
+      assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "calendarUID", "CalendarUID", readStringCellAt(row.cells, columnIndexByLabel.get("CalendarUID")));
     }
   }
 
@@ -940,14 +990,70 @@
       return cell.value !== 0;
     }
     if (typeof cell.value === "string") {
-      if (cell.value === "true" || cell.value === "TRUE" || cell.value === "1") {
+      if (cell.value === "true" || cell.value === "TRUE" || cell.value === "1" || cell.value === BOOLEAN_TRUE_LABEL || cell.value === "〇" || cell.value === "○") {
         return true;
       }
-      if (cell.value === "false" || cell.value === "FALSE" || cell.value === "0") {
+      if (cell.value === "false" || cell.value === "FALSE" || cell.value === "0" || cell.value === BOOLEAN_FALSE_LABEL || cell.value === "-" || cell.value === "－") {
         return false;
       }
     }
     return undefined;
+  }
+
+  function isTrueLike(value: string | number | boolean | undefined): boolean {
+    return value === true || value === 1 || value === "1" || value === BOOLEAN_TRUE_LABEL || value === "○" || value === "〇";
+  }
+
+  function buildOptionsSheet() {
+    return {
+      name: OPTIONS_SHEET_NAME,
+      columns: [{ width: 18 }, { width: 14 }],
+      mergedRanges: [],
+      rows: [
+        headerRow(["BooleanChoice", "Meaning"], HEADER_FILL),
+        { cells: [textCell(BOOLEAN_TRUE_LABEL, 0), textCell("true", 0)] },
+        { cells: [textCell(BOOLEAN_FALSE_LABEL, 1), textCell("false", 1)] }
+      ]
+    };
+  }
+
+  function buildBooleanDataValidations(ranges: Array<string | undefined>) {
+    const sqref = ranges.filter((value): value is string => Boolean(value)).join(" ");
+    if (!sqref) {
+      return undefined;
+    }
+    return [{
+      type: "list" as const,
+      sqref,
+      formula1: `${OPTIONS_SHEET_NAME}!$A$2:$A$3`,
+      allowBlank: true
+    }];
+  }
+
+  function buildColumnRange(columnIndex: number, startRow: number, endRow: number): string | undefined {
+    if (endRow < startRow) {
+      return undefined;
+    }
+    const columnName = encodeColumnName(columnIndex);
+    return `${columnName}${startRow}:${columnName}${endRow}`;
+  }
+
+  function buildSingleCellReference(columnIndex: number, rowNumber: number | undefined): string | undefined {
+    if (!rowNumber) {
+      return undefined;
+    }
+    return `${encodeColumnName(columnIndex)}${rowNumber}`;
+  }
+
+  function encodeColumnName(columnIndex: number): string {
+    let current = columnIndex + 1;
+    let name = "";
+    while (current > 0) {
+      const remainder = (current - 1) % 26;
+      name = String.fromCharCode(65 + remainder) + name;
+      current = Math.floor((current - 1) / 26);
+    }
+    return name;
   }
 
   function assignIfChanged<T extends object, K extends keyof T>(
@@ -975,6 +1081,47 @@
       field,
       before: before as string | number | boolean | undefined,
       after: value as string | number | boolean
+    });
+  }
+
+  function parsePredecessorCell(value: string | undefined): PredecessorModel[] | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+    const normalized = value
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean);
+    return normalized.map((predecessorUid) => ({ predecessorUid }));
+  }
+
+  function formatPredecessorList(predecessors: PredecessorModel[]): string {
+    return predecessors.map((item) => item.predecessorUid).join(", ");
+  }
+
+  function assignPredecessorsIfChanged(
+    changes: ImportChange[],
+    uid: string,
+    label: string,
+    task: TaskModel,
+    predecessors: PredecessorModel[] | undefined
+  ): void {
+    if (predecessors === undefined) {
+      return;
+    }
+    const beforeText = formatPredecessorList(task.predecessors);
+    const afterText = formatPredecessorList(predecessors);
+    if (beforeText === afterText) {
+      return;
+    }
+    task.predecessors = predecessors;
+    changes.push({
+      scope: "tasks",
+      uid,
+      label,
+      field: "Predecessors",
+      before: beforeText || undefined,
+      after: afterText
     });
   }
 

--- a/tests/mikuproject-main.test.js
+++ b/tests/mikuproject-main.test.js
@@ -317,6 +317,10 @@ describe("mikuproject main", () => {
     bootPage();
 
     expect(document.getElementById("xmlInput").value).toContain("<Project");
+    expect(document.getElementById("xmlInput").value).toContain("<ScheduleFromStart>1</ScheduleFromStart>");
+    expect(document.getElementById("xmlInput").value).toContain("<MinutesPerDay>480</MinutesPerDay>");
+    expect(document.getElementById("xmlInput").value).toContain("<MinutesPerWeek>2400</MinutesPerWeek>");
+    expect(document.getElementById("xmlInput").value).toContain("<DaysPerMonth>20</DaysPerMonth>");
     expect(document.getElementById("statusMessage").textContent).toContain("サンプル XML");
     expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 未保存");
     expect(document.querySelector('lht-help-tooltip[label="Load from file の説明"]')).not.toBeNull();
@@ -456,13 +460,23 @@ describe("mikuproject main", () => {
         view_type: "project_draft_view",
         project: {
           name: "新規基幹刷新",
-          planned_start: "2026-04-01"
+          planned_start: "2026-04-01",
+          schedule_from_start: true,
+          minutes_per_day: 480,
+          minutes_per_week: 2400,
+          days_per_month: 20
         },
         tasks: [
           { uid: "draft-1", name: "要件定義", parent_uid: null, position: 0, is_summary: true, percent_complete: 100 },
           { uid: "draft-2", name: "ヒアリング", parent_uid: "draft-1", position: 0, percent_complete: 50, planned_finish: "2026-04-01" },
           { uid: "draft-3", name: "整理期間", parent_uid: "draft-1", position: 1, planned_start: "2026-04-02", planned_finish: "2026-04-03" },
           { uid: "draft-4", name: "要件確定", parent_uid: "draft-1", position: 2, is_milestone: true, predecessors: ["draft-2"], planned_start: "2026-04-08T18:00:00", planned_finish: "2026-04-08T18:00:00" }
+        ],
+        resources: [
+          { uid: "res-1", name: "Mikuku", initials: "M", group: "PMO", max_units: 1, calendar_uid: "1" }
+        ],
+        assignments: [
+          { uid: "asg-1", task_uid: "draft-2", resource_uid: "res-1", start: "2026-04-01T09:00:00", finish: "2026-04-01T18:00:00", units: 1, work: "PT8H0M0S", percent_work_complete: 50 }
         ]
       }, null, 2),
       "```"
@@ -474,13 +488,23 @@ describe("mikuproject main", () => {
 
     expect(document.getElementById("summaryProjectName").textContent).toBe("新規基幹刷新");
     expect(document.getElementById("summaryTaskCount").textContent).toBe("4");
+    expect(document.getElementById("summaryResourceCount").textContent).toBe("1");
+    expect(document.getElementById("summaryAssignmentCount").textContent).toBe("1");
     expect(document.getElementById("summaryCalendarCount").textContent).toBe("1");
     expect(document.getElementById("xmlInput").value).toContain("<Name>新規基幹刷新</Name>");
     expect(document.getElementById("xmlInput").value).toContain("<Title>新規基幹刷新</Title>");
     expect(document.getElementById("xmlInput").value).toContain("<CalendarUID>1</CalendarUID>");
+    expect(document.getElementById("xmlInput").value).toContain("<ScheduleFromStart>1</ScheduleFromStart>");
+    expect(document.getElementById("xmlInput").value).toContain("<MinutesPerDay>480</MinutesPerDay>");
+    expect(document.getElementById("xmlInput").value).toContain("<MinutesPerWeek>2400</MinutesPerWeek>");
+    expect(document.getElementById("xmlInput").value).toContain("<DaysPerMonth>20</DaysPerMonth>");
     expect(document.getElementById("xmlInput").value).toContain("<Name>Standard</Name>");
     expect(document.getElementById("xmlInput").value).toContain("<UID>3</UID>");
     expect(document.getElementById("modelOutput").value).toContain("\"title\": \"新規基幹刷新\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"scheduleFromStart\": true");
+    expect(document.getElementById("modelOutput").value).toContain("\"minutesPerDay\": 480");
+    expect(document.getElementById("modelOutput").value).toContain("\"minutesPerWeek\": 2400");
+    expect(document.getElementById("modelOutput").value).toContain("\"daysPerMonth\": 20");
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"ヒアリング\"");
     expect(document.getElementById("modelOutput").value).toContain("\"milestone\": false");
     expect(document.getElementById("modelOutput").value).toContain("\"percentComplete\": 100");
@@ -495,6 +519,10 @@ describe("mikuproject main", () => {
     expect(document.getElementById("modelOutput").value).toContain("\"uid\": \"4\"");
     expect(document.getElementById("modelOutput").value).not.toContain("\"uid\": \"draft-4\"");
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Standard\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Mikuku\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"initials\": \"M\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"taskUid\": \"2\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"resourceUid\": \"1\"");
   });
 
   it("limits default calendar holiday exceptions to the project date range", () => {
@@ -556,6 +584,9 @@ describe("mikuproject main", () => {
     expect(draftText).toContain("\"view_type\": \"project_draft_view\"");
     expect(draftText).toContain("\"name\": \"mikuproject開発\"");
     expect(draftText).toContain("架空検討フェーズ【架空】");
+    expect(draftText).toContain("\"resources\"");
+    expect(draftText).toContain("\"Mikuku\"");
+    expect(draftText).toContain("\"initials\": \"M\"");
     expect(document.getElementById("statusMessage").textContent).toContain("サンプル project_draft_view");
   });
 
@@ -577,19 +608,24 @@ describe("mikuproject main", () => {
 
     expect(document.getElementById("summaryProjectName").textContent).toBe("mikuproject開発");
     expect(document.getElementById("summaryTaskCount").textContent).toBe("13");
-    expect(document.getElementById("summaryResourceCount").textContent).toBe("0");
-    expect(document.getElementById("summaryAssignmentCount").textContent).toBe("0");
+    expect(document.getElementById("summaryResourceCount").textContent).toBe("1");
+    expect(document.getElementById("summaryAssignmentCount").textContent).toBe("2");
     expect(document.getElementById("summaryCalendarCount").textContent).toBe("1");
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"mikuproject開発\"");
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"基盤整備\"");
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"架空検討フェーズ【架空】\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Mikuku\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"initials\": \"M\"");
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Standard\"");
     expect(document.getElementById("projectPreview").textContent).toContain("mikuproject開発");
     expect(document.getElementById("projectPreview").textContent).toContain("Calendar=1 (Standard)");
     expect(document.getElementById("taskPreview").textContent).toContain("初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）");
-    expect(document.getElementById("resourcePreview").textContent).toContain("まだ表示できる項目がありません");
-    expect(document.getElementById("assignmentPreview").textContent).toContain("まだ表示できる項目がありません");
-    expect(document.getElementById("calendarPreview").textContent).toContain(`WeekDays=7 / Exceptions=${SAMPLE_HOLIDAY_COUNT} / WorkWeeks=0`);
+    expect(document.getElementById("resourcePreview").textContent).toContain("Mikuku");
+    expect(document.getElementById("resourcePreview").textContent).toContain("Initials=M");
+    expect(document.getElementById("assignmentPreview").textContent).toContain("Task=3");
+    expect(document.getElementById("assignmentPreview").textContent).toContain("Resource=1 (Mikuku)");
+    expect(document.getElementById("assignmentPreview").textContent).toContain("Task=4");
+  expect(document.getElementById("calendarPreview").textContent).toContain(`WeekDays=7 / Exceptions=${SAMPLE_HOLIDAY_COUNT} / WorkWeeks=0`);
   });
 
   it("exports xml from the current model", () => {
@@ -1016,7 +1052,10 @@ describe("mikuproject main", () => {
     );
     const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
     tasksSheet.rows[5].cells[2].value = "初期実装 Imported From XLSX";
+    tasksSheet.rows[5].cells[8].value = "PT24H0M0S";
     tasksSheet.rows[5].cells[9].value = 77;
+    tasksSheet.rows[5].cells[14].value = "2";
+    tasksSheet.rows[5].cells[15].value = "2";
     const bytes = codec.exportWorkbook(workbook);
 
     const importInput = document.getElementById("importFileInput");
@@ -1037,9 +1076,13 @@ describe("mikuproject main", () => {
     await flushAsyncWork();
 
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"初期実装 Imported From XLSX\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"duration\": \"PT24H0M0S\"");
     expect(document.getElementById("modelOutput").value).toContain("\"percentComplete\": 77");
+    expect(document.getElementById("modelOutput").value).toContain("\"calendarUID\": \"2\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"predecessorUid\": \"2\"");
     expect(document.getElementById("xmlInput").value).toContain("<Name>初期実装 Imported From XLSX</Name>");
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 2 件の変更を反映しました");
+    expect(document.getElementById("xmlInput").value).toContain("<PredecessorUID>2</PredecessorUID>");
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 5 件の変更を反映しました");
     expect(document.getElementById("statusMessage").textContent).toContain("XML Export で保存できます");
     expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 未保存");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("Tasks");
@@ -1047,10 +1090,61 @@ describe("mikuproject main", () => {
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Resources, Assignments, Calendars");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=3 初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("Name: 初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定） -> 初期実装 Imported From XLSX");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Duration: PT0H0M0S -> PT24H0M0S");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("PercentComplete: 100 -> 77");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("CalendarUID: (empty) -> 2");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Predecessors: (empty) -> 2");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("反映後の XML は更新済みです");
     expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
     expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
+  });
+
+  it("imports resource sheet edits back into the current model and xml", async () => {
+    bootPage();
+    document.getElementById("xmlInput").value = dependencyXml;
+    parseXmlViaHook();
+
+    const codec = new globalThis.__mikuprojectExcelIo.XlsxWorkbookCodec();
+    const workbook = globalThis.__mikuprojectProjectXlsx.exportProjectWorkbook(
+      globalThis.__mikuprojectXml.importMsProjectXml(document.getElementById("xmlInput").value)
+    );
+    const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
+    resourcesSheet.rows[3].cells[2].value = "Miku Updated";
+    resourcesSheet.rows[3].cells[5].value = "Dev";
+    resourcesSheet.rows[3].cells[6].value = 1;
+    resourcesSheet.rows[3].cells[7].value = "1";
+    const bytes = codec.exportWorkbook(workbook);
+
+    const importInput = document.getElementById("importFileInput");
+    const file = new File([bytes], "resource-sheet.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      configurable: true,
+      value: () => Promise.resolve(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength))
+    });
+    Object.defineProperty(importInput, "files", {
+      configurable: true,
+      value: [file]
+    });
+
+    importInput.dispatchEvent(new Event("change"));
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Miku Updated\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"group\": \"Dev\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"maxUnits\": 1");
+    expect(document.getElementById("modelOutput").value).toContain("\"calendarUID\": \"1\"");
+    expect(document.getElementById("xmlInput").value).toContain("<Name>Miku Updated</Name>");
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 4 件の変更を反映しました");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Resources 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Project, Tasks, Assignments, Calendars");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=1 Miku");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Name: Miku -> Miku Updated");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Group: (empty) -> Dev");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("MaxUnits: (empty) -> 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("CalendarUID: (empty) -> 1");
   });
 
   it("clears file input value before reselecting the same file", () => {
@@ -1201,7 +1295,7 @@ describe("mikuproject main", () => {
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("変更なし: Tasks, Resources, Assignments, Calendars");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("UID=project mikuproject開発");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("Name: mikuproject開発 -> Project From XLSX");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("MinutesPerDay: (empty) -> 420");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("MinutesPerDay: 480 -> 420");
     expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__section")).toHaveLength(1);
     expect(document.querySelectorAll("#xlsxImportSummary .md-xlsx-summary__item")).toHaveLength(1);
   });
@@ -1268,7 +1362,7 @@ describe("mikuproject main", () => {
     expect(document.getElementById("xlsxImportSummary").classList.contains("md-hidden")).toBe(true);
   });
 
-  it("ignores edits in unsupported xlsx columns and sheets", async () => {
+  it("imports duration edits and ignores unsupported xlsx columns and sheets", async () => {
     bootPage();
     parseXmlViaHook();
 
@@ -1301,13 +1395,13 @@ describe("mikuproject main", () => {
     await flushAsyncWork();
     await flushAsyncWork();
 
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX に反映対象の変更はありませんでした");
-    expect(document.getElementById("statusMessage").textContent).toContain("XML は未変更です");
-    expect(document.getElementById("modelOutput").value).not.toContain("\"duration\": \"PT99H0M0S\"");
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 1 件の変更を反映しました");
+    expect(document.getElementById("statusMessage").textContent).toContain("XML Export で保存できます");
+    expect(document.getElementById("modelOutput").value).toContain("\"duration\": \"PT99H0M0S\"");
     expect(document.getElementById("modelOutput").value).not.toContain("\"weekDays\": 99");
-    expect(document.getElementById("xmlInput").value).toBe(originalXml);
-    expect(document.getElementById("xlsxImportSummary").textContent).toBe("");
-    expect(document.getElementById("xlsxImportSummary").classList.contains("md-hidden")).toBe(true);
+    expect(document.getElementById("xmlInput").value).not.toBe(originalXml);
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Tasks 1");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Duration: PT0H0M0S -> PT99H0M0S");
   });
 
   it("ignores calendar WeekDays, Exceptions, and WorkWeeks edits in xlsx import", async () => {

--- a/tests/mikuproject-project-workbook-json.test.js
+++ b/tests/mikuproject-project-workbook-json.test.js
@@ -33,6 +33,10 @@ const projectWorkbookJsonCode = readFileSync(
   path.resolve(__dirname, "../src/js/project-workbook-json.js"),
   "utf8"
 );
+const dependencyXml = readFileSync(
+  path.resolve(__dirname, "../testdata/dependency.xml"),
+  "utf8"
+);
 
 function bootModules() {
   new Function(`${typesCode}\n${excelIoCode}\n${msProjectXmlCode}\n${projectWorkbookSchemaCode}\n${projectXlsxCode}\n${projectWorkbookJsonCode}`)();
@@ -62,24 +66,48 @@ describe("mikuproject project workbook json", () => {
     expect(documentLike.sheets.Project[0]).toEqual({ Field: "Name", Value: "mikuproject開発" });
     expect(documentLike.sheets.Tasks[0].UID).toBe("1");
     expect(documentLike.sheets.Tasks[0].Name).toBe("基盤整備");
+    expect(documentLike.sheets.Resources[0].Name).toBe("Mikuku");
+    expect(documentLike.sheets.Assignments[0].ResourceName).toBe("Mikuku");
   });
 
   it("imports limited editable fields through workbook json", () => {
     const { xml, projectWorkbookJson } = bootModules();
-    const baseModel = xml.importMsProjectXml(xml.SAMPLE_XML);
+    const baseModel = xml.importMsProjectXml(dependencyXml);
     const documentLike = projectWorkbookJson.exportProjectWorkbookJson(baseModel);
+    const executeTaskRow = documentLike.sheets.Tasks.find((row) => row.UID === "2");
+    const resourceRow = documentLike.sheets.Resources.find((row) => row.UID === "1");
 
     documentLike.sheets.Project.find((row) => row.Field === "Name").Value = "JSON import project";
-    documentLike.sheets.Tasks[2].Name = "JSON import task";
-    documentLike.sheets.Tasks[2].Start = "2026-03-16 10:00:00";
-    documentLike.sheets.Tasks[2].OutlineNumber = "999";
+    executeTaskRow.Name = "JSON import task";
+    executeTaskRow.Start = "2026-03-16 10:00:00";
+    executeTaskRow.Duration = "PT24H0M0S";
+    executeTaskRow.Milestone = "○";
+    executeTaskRow.Summary = "○";
+    executeTaskRow.Critical = "ー";
+    executeTaskRow.CalendarUID = "2";
+    executeTaskRow.Predecessors = "2";
+    executeTaskRow.OutlineNumber = "999";
+    resourceRow.Name = "Miku Updated";
+    resourceRow.Group = "Dev";
+    resourceRow.MaxUnits = 1;
+    resourceRow.CalendarUID = "1";
 
     const result = projectWorkbookJson.importProjectWorkbookJson(documentLike, baseModel);
 
     expect(result.model.project.name).toBe("JSON import project");
-    expect(result.model.tasks[2].name).toBe("JSON import task");
-    expect(result.model.tasks[2].start).toBe("2026-03-16T10:00:00");
-    expect(result.model.tasks[2].outlineNumber).toBe(baseModel.tasks[2].outlineNumber);
+    expect(result.model.tasks[1].name).toBe("JSON import task");
+    expect(result.model.tasks[1].start).toBe("2026-03-16T10:00:00");
+    expect(result.model.tasks[1].duration).toBe("PT24H0M0S");
+    expect(result.model.tasks[1].milestone).toBe(true);
+    expect(result.model.tasks[1].summary).toBe(true);
+    expect(result.model.tasks[1].critical).toBe(false);
+    expect(result.model.tasks[1].calendarUID).toBe("2");
+    expect(result.model.tasks[1].predecessors).toEqual([{ predecessorUid: "2" }]);
+    expect(result.model.resources[0].name).toBe("Miku Updated");
+    expect(result.model.resources[0].group).toBe("Dev");
+    expect(result.model.resources[0].maxUnits).toBe(1);
+    expect(result.model.resources[0].calendarUID).toBe("1");
+    expect(result.model.tasks[1].outlineNumber).toBe(baseModel.tasks[1].outlineNumber);
     expect(result.changes.some((change) => change.field === "Name")).toBe(true);
   });
 

--- a/tests/mikuproject-project-xlsx.test.js
+++ b/tests/mikuproject-project-xlsx.test.js
@@ -29,6 +29,10 @@ const projectXlsxCode = readFileSync(
   path.resolve(__dirname, "../src/js/project-xlsx.js"),
   "utf8"
 );
+const dependencyXml = readFileSync(
+  path.resolve(__dirname, "../testdata/dependency.xml"),
+  "utf8"
+);
 
 function bootModules() {
   new Function(`${typesCode}\n${excelIoCode}\n${msProjectXmlCode}\n${projectWorkbookSchemaCode}\n${projectXlsxCode}`)();
@@ -67,9 +71,13 @@ describe("mikuproject project xlsx", () => {
       "Resources",
       "Assignments",
       "Calendars",
-      "NonWorkingDays"
+      "NonWorkingDays",
+      "Options"
     ]);
     expect(workbook.sheets[0].mergedRanges).toEqual(["A11:B11"]);
+    expect(workbook.sheets[0].dataValidations).toEqual([
+      { type: "list", sqref: "B17", formula1: "Options!$A$2:$A$3", allowBlank: true }
+    ]);
     expect(workbook.sheets[0].rows[0].cells[0].value).toBe("Project");
     expect(workbook.sheets[0].rows[0].cells[0].bold).toBe(true);
     expect(workbook.sheets[0].rows[0].cells[0].fontSize).toBe(16);
@@ -100,6 +108,7 @@ describe("mikuproject project xlsx", () => {
     const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
     const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
     const nonWorkingDaysSheet = workbook.sheets.find((sheet) => sheet.name === "NonWorkingDays");
+    const optionsSheet = workbook.sheets.find((sheet) => sheet.name === "Options");
 
     expect(tasksSheet.mergedRanges).toEqual([]);
     expect(tasksSheet.rows[0].cells[0].value).toBe("Tasks");
@@ -130,15 +139,23 @@ describe("mikuproject project xlsx", () => {
     expect(tasksSheet.rows[3].cells[6].value).toBe("2026-03-16 09:00:00");
     expect(tasksSheet.rows[3].cells[2].bold).toBe(true);
     expect(tasksSheet.rows[3].cells[2].fillColor).toBe(EDITABLE_FILL);
-    expect(tasksSheet.rows[3].cells[12].fillColor).toBe("#E6F2E0");
+    expect(tasksSheet.rows[3].cells[12].fillColor).toBe(EDITABLE_FILL);
     expect(tasksSheet.rows[5].cells[2].value).toBe("初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）");
-    expect(tasksSheet.rows[5].cells[8].fillColor).toBe("#FBF6ED");
-    expect(tasksSheet.rows[5].cells[13].fillColor).toBeUndefined();
+    expect(tasksSheet.rows[5].cells[8].fillColor).toBe(EDITABLE_FILL);
+    expect(tasksSheet.rows[5].cells[8].border).toBe("thin");
+    expect(tasksSheet.rows[5].cells[13].fillColor).toBe(EDITABLE_FILL);
+    expect(tasksSheet.rows[5].cells[13].border).toBe("thin");
+    expect(tasksSheet.rows[5].cells[14].fillColor).toBe(EDITABLE_FILL);
+    expect(tasksSheet.rows[5].cells[14].border).toBe("thin");
     expect(tasksSheet.rows[5].cells[15].value).toBe("");
-    expect(tasksSheet.rows[5].cells[15].fillColor).toBe("#EEF7F4");
+    expect(tasksSheet.rows[5].cells[15].fillColor).toBe(EDITABLE_FILL);
+    expect(tasksSheet.rows[5].cells[15].border).toBe("thin");
     expect(tasksSheet.rows[5].cells[16].value).toBeUndefined();
     expect(tasksSheet.rows[5].cells[16].fillColor).toBe(EDITABLE_FILL);
     expect(tasksSheet.rows[5].cells[16].border).toBe("thin");
+    expect(tasksSheet.dataValidations).toEqual([
+      { type: "list", sqref: "L4:L16 M4:M16 N4:N16", formula1: "Options!$A$2:$A$3", allowBlank: true }
+    ]);
 
     expect(resourcesSheet.mergedRanges).toEqual([]);
     expect(resourcesSheet.rows[0].cells[0].value).toBe("Resources");
@@ -162,10 +179,13 @@ describe("mikuproject project xlsx", () => {
       "RemainingWork"
     ]);
     expect(resourcesSheet.rows).toHaveLength(4);
-    expect(resourcesSheet.rows[3].cells[0].value).toBeUndefined();
+    expect(resourcesSheet.rows[3].cells[0].value).toBe("1");
+    expect(resourcesSheet.rows[3].cells[2].value).toBe("Mikuku");
+    expect(resourcesSheet.rows[3].cells[4].value).toBe("M");
     expect(resourcesSheet.rows[3].cells[2].fillColor).toBe(EDITABLE_FILL);
     expect(resourcesSheet.rows[3].cells[5].fillColor).toBe(EDITABLE_FILL);
     expect(resourcesSheet.rows[3].cells[6].fillColor).toBe(EDITABLE_FILL);
+    expect(resourcesSheet.rows[3].cells[7].fillColor).toBe(EDITABLE_FILL);
     expect(resourcesSheet.rows[3].cells[2].border).toBe("thin");
 
     expect(assignmentsSheet.mergedRanges).toEqual([]);
@@ -187,8 +207,13 @@ describe("mikuproject project xlsx", () => {
       "RemainingWork",
       "PercentWorkComplete"
     ]);
-    expect(assignmentsSheet.rows).toHaveLength(4);
-    expect(assignmentsSheet.rows[3].cells[0].value).toBeUndefined();
+    expect(assignmentsSheet.rows).toHaveLength(5);
+    expect(assignmentsSheet.rows[3].cells[0].value).toBe("1");
+    expect(assignmentsSheet.rows[3].cells[2].value).toContain("初期実装");
+    expect(assignmentsSheet.rows[3].cells[4].value).toBe("Mikuku");
+    expect(assignmentsSheet.rows[4].cells[0].value).toBe("2");
+    expect(assignmentsSheet.rows[4].cells[2].value).toContain("round-trip拡張");
+    expect(assignmentsSheet.rows[4].cells[4].value).toBe("Mikuku");
     expect(assignmentsSheet.rows[3].cells[7].fillColor).toBe(EDITABLE_FILL);
     expect(assignmentsSheet.rows[3].cells[8].fillColor).toBe(EDITABLE_FILL);
     expect(assignmentsSheet.rows[3].cells[11].fillColor).toBe(EDITABLE_FILL);
@@ -211,6 +236,10 @@ describe("mikuproject project xlsx", () => {
     expect(calendarsSheet.rows[3].cells[1].value).toBe("Standard");
     expect(calendarsSheet.rows[3].cells[1].fillColor).toBe(EDITABLE_FILL);
     expect(calendarsSheet.rows[3].cells[2].fillColor).toBe(EDITABLE_FILL);
+    expect(calendarsSheet.rows[3].cells[2].value).toBe("○");
+    expect(calendarsSheet.dataValidations).toEqual([
+      { type: "list", sqref: "C4:C4", formula1: "Options!$A$2:$A$3", allowBlank: true }
+    ]);
 
     expect(nonWorkingDaysSheet.mergedRanges).toEqual([]);
     expect(nonWorkingDaysSheet.rows[0].cells[0].value).toBe("NonWorkingDays");
@@ -233,12 +262,19 @@ describe("mikuproject project xlsx", () => {
     expect(nonWorkingDaysSheet.rows[3].cells[4].value).toBe(SAMPLE_FIRST_HOLIDAY_DATE);
     expect(nonWorkingDaysSheet.rows[3].cells[5].value).toBe(SAMPLE_FIRST_HOLIDAY_DATE);
     expect(nonWorkingDaysSheet.rows[3].cells[6].value).toBe(SAMPLE_FIRST_HOLIDAY_DATE);
-    expect(nonWorkingDaysSheet.rows[3].cells[7].value).toBe("false");
+    expect(nonWorkingDaysSheet.rows[3].cells[7].value).toBe("ー");
     expect(nonWorkingDaysSheet.rows[3].cells[4].fillColor).toBe(EDITABLE_FILL);
     expect(nonWorkingDaysSheet.rows[3].cells[5].fillColor).toBe(EDITABLE_FILL);
     expect(nonWorkingDaysSheet.rows[3].cells[6].fillColor).toBe(EDITABLE_FILL);
     expect(nonWorkingDaysSheet.rows[3].cells[7].fillColor).toBe(EDITABLE_FILL);
+    expect(nonWorkingDaysSheet.dataValidations).toEqual([
+      { type: "list", sqref: "H4:H4", formula1: "Options!$A$2:$A$3", allowBlank: true }
+    ]);
     expect(nonWorkingDaysSheet.rows).toHaveLength(SAMPLE_HOLIDAY_COUNT + 3);
+
+    expect(optionsSheet.rows[0].cells.map((cell) => cell.value)).toEqual(["BooleanChoice", "Meaning"]);
+    expect(optionsSheet.rows[1].cells.map((cell) => cell.value)).toEqual(["○", "true"]);
+    expect(optionsSheet.rows[2].cells.map((cell) => cell.value)).toEqual(["ー", "false"]);
   });
 
   it("can generate a real xlsx from ProjectModel through the workbook adapter", () => {
@@ -250,6 +286,7 @@ describe("mikuproject project xlsx", () => {
     const bytes = codec.exportWorkbook(workbook);
     const entries = codec.listEntries(bytes);
     const projectSheetXml = new TextDecoder().decode(codec.unpackEntries(bytes)["xl/worksheets/sheet1.xml"]);
+    const optionsSheetXml = new TextDecoder().decode(codec.unpackEntries(bytes)["xl/worksheets/sheet7.xml"]);
 
     expect(entries).toContain("xl/workbook.xml");
     expect(entries).toContain("xl/worksheets/sheet1.xml");
@@ -257,7 +294,11 @@ describe("mikuproject project xlsx", () => {
     expect(projectSheetXml).not.toContain('ref="A1:B1"');
     expect(projectSheetXml).toContain('ref="A11:B11"');
     expect(projectSheetXml).toContain('t="inlineStr"><is><t>1</t></is>');
-    expect(projectSheetXml).toContain('t="inlineStr"><is><t>true</t></is>');
+    expect(projectSheetXml).toContain('<dataValidation type="list" allowBlank="1" showErrorMessage="1" sqref="B17"><formula1>Options!$A$2:$A$3</formula1></dataValidation>');
+    expect(projectSheetXml).toContain('t="inlineStr"><is><t>○</t></is>');
+    expect(optionsSheetXml).toContain('t="inlineStr"><is><t>BooleanChoice</t></is>');
+    expect(optionsSheetXml).toContain('t="inlineStr"><is><t>○</t></is>');
+    expect(optionsSheetXml).toContain('t="inlineStr"><is><t>ー</t></is>');
   });
 
   it("imports limited task fields from workbook rows back into ProjectModel", () => {
@@ -269,8 +310,14 @@ describe("mikuproject project xlsx", () => {
     tasksSheet.rows[5].cells[2].value = "初期実装 Updated";
     tasksSheet.rows[5].cells[6].value = "2026-03-17";
     tasksSheet.rows[5].cells[7].value = "2026-03-18";
+    tasksSheet.rows[5].cells[8].value = "PT24H0M0S";
     tasksSheet.rows[5].cells[9].value = 80;
     tasksSheet.rows[5].cells[10].value = 90;
+    tasksSheet.rows[5].cells[11].value = "○";
+    tasksSheet.rows[5].cells[12].value = "○";
+    tasksSheet.rows[5].cells[13].value = "ー";
+    tasksSheet.rows[5].cells[14].value = "2";
+    tasksSheet.rows[5].cells[15].value = "2";
     tasksSheet.rows[5].cells[16].value = "Updated Notes";
 
     const importedModel = projectXlsx.importProjectWorkbook(workbook, model);
@@ -280,20 +327,34 @@ describe("mikuproject project xlsx", () => {
     expect(designTask.name).toBe("初期実装 Updated");
     expect(designTask.start).toBe("2026-03-17");
     expect(designTask.finish).toBe("2026-03-18");
+    expect(designTask.duration).toBe("PT24H0M0S");
     expect(designTask.percentComplete).toBe(80);
     expect(designTask.percentWorkComplete).toBe(90);
+    expect(designTask.milestone).toBe(true);
+    expect(designTask.summary).toBe(true);
+    expect(designTask.critical).toBe(false);
+    expect(designTask.calendarUID).toBe("2");
+    expect(designTask.predecessors).toEqual([{ predecessorUid: "2" }]);
     expect(designTask.notes).toBe("Updated Notes");
     expect(implementationTask.name).toBe("round-trip拡張（MS Project XML → 内部JSON形式 → MS Project XML の往復対応）");
   });
 
   it("imports limited resource and assignment fields from workbook rows back into ProjectModel", () => {
     const { xml, projectXlsx } = bootModules();
-    const model = xml.importMsProjectXml(xml.SAMPLE_XML);
+    const model = xml.importMsProjectXml(dependencyXml);
     const workbook = projectXlsx.exportProjectWorkbook(model);
+    const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
+    resourcesSheet.rows[3].cells[2].value = "Miku Updated";
+    resourcesSheet.rows[3].cells[5].value = "Dev";
+    resourcesSheet.rows[3].cells[6].value = 1;
+    resourcesSheet.rows[3].cells[7].value = "1";
     const importedModel = projectXlsx.importProjectWorkbook(workbook, model);
 
-    expect(importedModel.resources).toEqual([]);
-    expect(importedModel.assignments).toEqual([]);
+    expect(importedModel.resources[0].name).toBe("Miku Updated");
+    expect(importedModel.resources[0].group).toBe("Dev");
+    expect(importedModel.resources[0].maxUnits).toBe(1);
+    expect(importedModel.resources[0].calendarUID).toBe("1");
+    expect(importedModel.assignments).toHaveLength(1);
   });
 
   it("imports limited project fields from workbook rows back into ProjectModel", () => {
@@ -390,14 +451,26 @@ describe("mikuproject project xlsx", () => {
     const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
 
     tasksSheet.rows[5].cells[2].value = "初期実装 Updated";
+    tasksSheet.rows[5].cells[8].value = "PT24H0M0S";
     tasksSheet.rows[5].cells[9].value = 80;
+    tasksSheet.rows[5].cells[11].value = "○";
+    tasksSheet.rows[5].cells[12].value = "○";
+    tasksSheet.rows[5].cells[13].value = "ー";
+    tasksSheet.rows[5].cells[14].value = "2";
+    tasksSheet.rows[5].cells[15].value = "2";
     tasksSheet.rows[5].cells[16].value = "Updated Notes";
 
     const result = projectXlsx.importProjectWorkbookDetailed(workbook, model);
 
     expect(result.changes).toEqual([
       { scope: "tasks", uid: "3", label: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）", field: "Name", before: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）", after: "初期実装 Updated" },
+      { scope: "tasks", uid: "3", label: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）", field: "Duration", before: "PT0H0M0S", after: "PT24H0M0S" },
       { scope: "tasks", uid: "3", label: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）", field: "PercentComplete", before: 100, after: 80 },
+      { scope: "tasks", uid: "3", label: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）", field: "Milestone", before: false, after: true },
+      { scope: "tasks", uid: "3", label: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）", field: "Summary", before: false, after: true },
+      { scope: "tasks", uid: "3", label: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）", field: "Critical", before: undefined, after: false },
+      { scope: "tasks", uid: "3", label: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）", field: "CalendarUID", before: undefined, after: "2" },
+      { scope: "tasks", uid: "3", label: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）", field: "Predecessors", before: undefined, after: "2" },
       { scope: "tasks", uid: "3", label: "初期実装（MS Project XML 調査・基軸フォーマット選定・内部モデルの概要確定）", field: "Notes", before: undefined, after: "Updated Notes" }
     ]);
   });
@@ -415,7 +488,7 @@ describe("mikuproject project xlsx", () => {
 
     expect(result.changes).toEqual([
       { scope: "project", uid: "project", label: "mikuproject開発", field: "Name", before: "mikuproject開発", after: "Renamed Project" },
-      { scope: "project", uid: "project", label: "mikuproject開発", field: "MinutesPerDay", before: undefined, after: 420 }
+      { scope: "project", uid: "project", label: "mikuproject開発", field: "MinutesPerDay", before: 480, after: 420 }
     ]);
   });
 
@@ -522,7 +595,7 @@ describe("mikuproject project xlsx", () => {
   it("reports assignment percent work complete import changes", () => {
     const { projectXlsx, model, workbook } = buildSampleWorkbook((nextWorkbook) => {
       const assignmentsSheet = nextWorkbook.sheets.find((sheet) => sheet.name === "Assignments");
-      expect(assignmentsSheet.rows).toHaveLength(4);
+      expect(assignmentsSheet.rows).toHaveLength(5);
     });
 
     const result = projectXlsx.importProjectWorkbookDetailed(workbook, model);
@@ -640,7 +713,13 @@ describe("mikuproject project xlsx", () => {
     const nonWorkingDaysSheet = workbook.sheets.find((sheet) => sheet.name === "NonWorkingDays");
 
     tasksSheet.rows[5].cells[2].value = "初期実装 via XLSX";
+    tasksSheet.rows[5].cells[8].value = "PT24H0M0S";
     tasksSheet.rows[5].cells[9].value = 60;
+    tasksSheet.rows[5].cells[11].value = "○";
+    tasksSheet.rows[5].cells[12].value = "○";
+    tasksSheet.rows[5].cells[13].value = "ー";
+    tasksSheet.rows[5].cells[14].value = "2";
+    tasksSheet.rows[5].cells[15].value = "2";
     tasksSheet.rows[5].cells[16].value = "初期実装 notes via XLSX";
     calendarsSheet.rows[3].cells[1].value = "Standard via XLSX";
     calendarsSheet.rows[3].cells[2].value = true;
@@ -653,10 +732,22 @@ describe("mikuproject project xlsx", () => {
     const importedModel = projectXlsx.importProjectWorkbook(importedWorkbook, model);
 
     expect(importedModel.tasks.find((task) => task.uid === "3").name).toBe("初期実装 via XLSX");
+    expect(importedModel.tasks.find((task) => task.uid === "3").duration).toBe("PT24H0M0S");
     expect(importedModel.tasks.find((task) => task.uid === "3").percentComplete).toBe(60);
+    expect(importedModel.tasks.find((task) => task.uid === "3").milestone).toBe(true);
+    expect(importedModel.tasks.find((task) => task.uid === "3").summary).toBe(true);
+    expect(importedModel.tasks.find((task) => task.uid === "3").critical).toBe(false);
+    expect(importedModel.tasks.find((task) => task.uid === "3").calendarUID).toBe("2");
+    expect(importedModel.tasks.find((task) => task.uid === "3").predecessors).toEqual([{ predecessorUid: "2" }]);
     expect(importedModel.tasks.find((task) => task.uid === "3").notes).toBe("初期実装 notes via XLSX");
-    expect(importedModel.resources).toEqual([]);
-    expect(importedModel.assignments).toEqual([]);
+    expect(importedModel.resources).toHaveLength(1);
+    expect(importedModel.resources[0].name).toBe("Mikuku");
+    expect(importedModel.resources[0].initials).toBe("M");
+    expect(importedModel.assignments).toHaveLength(2);
+    expect(importedModel.assignments[0].taskUid).toBe("3");
+    expect(importedModel.assignments[0].resourceUid).toBe("1");
+    expect(importedModel.assignments[1].taskUid).toBe("4");
+    expect(importedModel.assignments[1].resourceUid).toBe("1");
     expect(importedModel.calendars.find((calendar) => calendar.uid === "1").name).toBe("Standard via XLSX");
     expect(importedModel.calendars.find((calendar) => calendar.uid === "1").isBaseCalendar).toBe(true);
     expect(importedModel.calendars.find((calendar) => calendar.uid === "1").baseCalendarUID).toBe("1");

--- a/tests/mikuproject-wbs-xlsx.test.js
+++ b/tests/mikuproject-wbs-xlsx.test.js
@@ -167,9 +167,9 @@ describe("mikuproject wbs xlsx", () => {
     expect(sheet.rows[summaryHeaderIndex + 9].cells[0].value).toBe("タスク");
     expect(sheet.rows[summaryHeaderIndex + 9].cells[1].value).toBe("13");
     expect(sheet.rows[summaryHeaderIndex + 10].cells[0].value).toBe("リソース");
-    expect(sheet.rows[summaryHeaderIndex + 10].cells[1].value).toBe("0");
+    expect(sheet.rows[summaryHeaderIndex + 10].cells[1].value).toBe("1");
     expect(sheet.rows[summaryHeaderIndex + 11].cells[0].value).toBe("割当");
-    expect(sheet.rows[summaryHeaderIndex + 11].cells[1].value).toBe("0");
+    expect(sheet.rows[summaryHeaderIndex + 11].cells[1].value).toBe("2");
     expect(sheet.rows[summaryHeaderIndex + 12].cells[0].value).toBe("カレンダ");
     expect(sheet.rows[summaryHeaderIndex + 12].cells[1].value).toBe("1");
     const headerRowIndex = findRowIndexByCellValue(sheet, "UID");
@@ -740,9 +740,9 @@ describe("mikuproject wbs xlsx", () => {
 
     expect(sheet.rows[projectInfoHeaderIndex + 1].cells[0].value).toBe("プロジェクト名");
     expect(sheet.rows[projectInfoHeaderIndex + 1].cells[2].value).toBe("Sample Project ...");
-    expect(secondTaskRow.cells[15].value).toBe("-");
+    expect(secondTaskRow.cells[15].value).toBe("Mikuku");
     expect(secondTaskRow.cells[16].value).toBe("1 Standa...");
-    expect(secondTaskRow.cells[17].value).toBe("-");
+    expect(secondTaskRow.cells[17].value).toBe("Mikuku");
     expect(thirdTaskRow.cells[18].value).toBe("-");
   });
 


### PR DESCRIPTION
## 概要

この変更では、通常 workbook (`XLSX`) / workbook JSON の import 対象列を拡張し、真偽値列のドロップダウン選択や task / resource の追加項目の round-trip を強化しています。あわせて、`project_draft_view` のサンプルと import 実装、関連ドキュメント、テストを更新しています。

## 変更内容

### workbook / XLSX import の拡張

- `Tasks` の import 対象列を拡張
  - `Duration`
  - `Milestone`
  - `Summary`
  - `Critical`
  - `CalendarUID`
  - `Predecessors`
- `Resources` の import 対象列を拡張
  - `CalendarUID`
- `Predecessors` は、現時点では `predecessorUid` の `,` 区切り一覧を読む最小対応
- workbook JSON 側も同じ import 対象に追従

### Excel 出力の編集 UX 改善

- `dataValidation` を workbook 出力に追加
- `Options` シートを追加し、真偽値列の選択肢を定義
  - `○`
  - `ー`
- `Project.ScheduleFromStart`、`Tasks` の真偽値列、`Calendars.IsBaseCalendar`、`NonWorkingDays.DayWorking` にドロップダウンを追加
- `Tasks` の真偽値列は、空でも罫線と editable の見た目を維持
- `Tasks` の真偽値列の背景色を editable セル系に統一

### `project_draft_view` の拡張とサンプル更新

- `project_draft_view` import で project 設定項目を取り込み
  - `schedule_from_start`
  - `minutes_per_day`
  - `minutes_per_week`
  - `days_per_month`
- `project_draft_view` import で最小の `resources` / `assignments` を受け付けるように拡張
- `SAMPLE_PROJECT_DRAFT_VIEW` を更新
  - project 設定値を追加
  - resource `Mikuku` を追加
  - `initials: "M"` を追加
  - assignment を 2 件追加
- 通常サンプル XML も上記サンプルから生成される内容に追従

### ドキュメント更新

- `docs/spec.md`
  - 現在の `XLSX Import` 対象列に更新
  - `Predecessors` の最小対応を明記
  - `project_draft_view` における `resources` / `assignments` の最小表現を追記
- `docs/architecture.md`
  - 実装 FAQ を追加
  - workbook JSON と `project_draft_view` の違いを明記
  - 画面の `サンプル` と `SAMPLE_PROJECT_DRAFT_VIEW` の関係を明記
- `docs/mikuproject-ai-json-spec.md`
  - `project_draft_view` 例に `resources` / `assignments` を追加
- `docs/msprojectxml-ai-integration.md`
  - `project_draft_view` 例に `resources` / `assignments` を追加
- `docs/TODO.md`
  - task 真偽値列が戻る前提に更新
  - `Tasks.Predecessors` の import 対応メモを追加
  - MVP 候補列の優先順位メモを追加
  - 低優先度のタイムチャート検討メモを追加
  - `Daily` 表示の横幅調整検討メモを追加

## テスト

- 関連テストを更新
  - `mikuproject-main`
  - `mikuproject-project-xlsx`
  - `mikuproject-project-workbook-json`
  - `mikuproject-wbs-xlsx`

## ポイント

- `Predecessors` の workbook import は最小対応であり、`type / linkLag` などの詳細表現は未対応