### PR TITLE
Overview の Daily/Weekly SVG ラベル配置とプレビュー幅を調整

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5,7 +5,6 @@
 ## mikuproject
 
 - 最優先: サンプルデータを更新し、利用者の好みに合う題材・構造・見た目へ見直す
-- `excel-io` の workbook スタイルにフォントサイズ指定を追加し、XLSX 出力で大きい見出し文字を使えるようにする
 - WBS workbook と `mikuproject-sample.xlsx` のタイトル行で、フォントサイズ指定をどこまで使うか整理する
 - `Mermaid` 出力は Markdown / 設計資料向けに残しつつ、見た目を制御しやすい `WBS SVG` 描画を別系統で追加するか検討する
 - `WBS SVG` について、今の既定である `近接ラベル` 表示だけを残し、左側にテキストを描画する `一覧ラベル` モードは将来的に廃止したい
@@ -43,6 +42,7 @@
 - `project_draft_request` を UI から生成しやすくするか整理する
 - UI の微調整として、`Input / Overview / Output` の各カードの余白・見出し・ボタン階層を見直し、`miku` 系テーマの統一感をさらに整える
 - `Overview` タブの summary / validation / preview の情報密度を見直し、どこを見る画面なのかをより直感的に伝わる構成へ調整する
+- `Overview` の label placement 調査で追加したデバッグ関数・判断ログ用コード・不要化した分岐が残っていないか点検し、不要なら整理する
 - `Output` タブの生成AI連携と各種 export ボタンの優先度表現を見直し、主操作と補助操作の区別をより明確にする
 - `build:xlsx-sample` の所要時間を個別計測し、sample workbook 生成処理の支配要因を確認する
 - `main.test.js` の初期化 DOM をケース別に最小化できるか見直す

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -2077,7 +2077,8 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 
 .md-svg-preview-stage svg {
   display: block;
-  max-width: 100%;
+  width: 100%;
+  max-width: none;
   height: auto;
 }
 
@@ -13044,7 +13045,8 @@ if (!customElements.get("lht-page-menu")) {
  * SPDX-License-Identifier: Apache-2.0
  */
 (() => {
-    const DAY_WIDTH = 56;
+    const WEEK_WIDTH = 38;
+    const DAY_WIDTH = WEEK_WIDTH;
     const LIST_LABEL_WIDTH = 360;
     const NEAR_LEFT_LABEL_WIDTH = 0;
     const NEAR_RIGHT_LABEL_WIDTH = 0;
@@ -13068,12 +13070,12 @@ if (!customElements.get("lht-page-menu")) {
     const MONTHLY_MAX_LABEL_CHARS = 15;
     const ZIP_FIXED_MOD_TIME = 0;
     const ZIP_FIXED_MOD_DATE = ((2025 - 1980) << 9) | (1 << 5) | 1;
-    const WEEK_WIDTH = 38;
     const WEEKLY_HEADER_HEIGHT = 96;
     const WEEKLY_TOP_PADDING = 22;
     const WEEKLY_BOTTOM_PADDING = 28;
     const WEEKLY_LEFT_PADDING = 0;
     const WEEKLY_RIGHT_PADDING = 0;
+    const WEEKLY_TRIM_PADDING = 16;
     function exportNativeSvg(model, options = {}) {
         const labelMode = options.labelMode || "near";
         const holidaySet = new Set([
@@ -13115,7 +13117,6 @@ if (!customElements.get("lht-page-menu")) {
             ".axis { font-size: 12px; fill: #5b6370; }",
             ".label { font-size: 13px; }",
             ".phaseLabel { font-size: 13px; font-weight: 700; }",
-            ".onBarLabelBg { fill: rgba(255,255,255,0.9); }",
             ".grid { stroke: #c9d3e1; stroke-width: 1; }",
             ".today { stroke: #ff6b5a; stroke-width: 2; }",
             "</style>",
@@ -13178,12 +13179,7 @@ if (!customElements.get("lht-page-menu")) {
                 }
                 if (useOnBarLabel) {
                     const labelText = escapeXml(formatTaskLabel(row.task, labelMode));
-                    const labelWidth = estimateLabelWidth(row.label, row.kind === "phase");
                     const labelCenterX = barX + (barWidth / 2);
-                    const labelX = labelCenterX - (labelWidth / 2) - 8;
-                    const labelY = row.kind === "phase" ? rowY + 15 : rowY + 10;
-                    const labelHeight = row.kind === "phase" ? 18 : 20;
-                    parts.push(`<rect class="onBarLabelBg" x="${labelX}" y="${labelY}" width="${labelWidth + 16}" height="${labelHeight}" rx="4"/>`);
                     parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelCenterX}" y="${rowY + 24}" text-anchor="middle">${labelText}</text>`);
                     continue;
                 }
@@ -13209,12 +13205,19 @@ if (!customElements.get("lht-page-menu")) {
         const chartWidth = weeklyBand.length * WEEK_WIDTH;
         const chartOriginXBase = WEEKLY_LEFT_PADDING;
         const labelPlacements = rows.map((row) => resolveWeeklyLabelPlacement(row, chartOriginXBase, chartWidth));
+        const labelMinX = labelPlacements.reduce((min, placement) => {
+            const placementMinX = placement.anchor === "start" ? placement.x : placement.x - placement.width;
+            return Math.min(min, placementMinX);
+        }, chartOriginXBase);
         const labelMaxX = labelPlacements.reduce((max, placement) => {
             const placementMaxX = placement.anchor === "start" ? placement.x + placement.width : placement.x;
             return Math.max(max, placementMaxX);
         }, chartOriginXBase + chartWidth);
-        const chartOriginX = chartOriginXBase;
-        const svgWidth = labelMaxX + WEEKLY_RIGHT_PADDING;
+        const contentMinX = Math.min(chartOriginXBase, labelMinX);
+        const contentMaxX = Math.max(chartOriginXBase + chartWidth, labelMaxX);
+        const shiftX = WEEKLY_TRIM_PADDING - contentMinX;
+        const chartOriginX = chartOriginXBase + shiftX;
+        const svgWidth = (contentMaxX - contentMinX) + (WEEKLY_TRIM_PADDING * 2) + WEEKLY_RIGHT_PADDING;
         const svgHeight = WEEKLY_TOP_PADDING + WEEKLY_HEADER_HEIGHT + (rows.length * ROW_HEIGHT) + WEEKLY_BOTTOM_PADDING;
         const todayWeekIndex = indexOfWeekForDate(weeklyBand, model.project.currentDate);
         const parts = [
@@ -13259,7 +13262,7 @@ if (!customElements.get("lht-page-menu")) {
             const rowY = chartOriginY + row.y;
             if (row.startIndex === null || row.endIndex === null) {
                 const fallbackLabelPlacement = labelPlacements[rowIndex];
-                parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${fallbackLabelPlacement.x}" y="${rowY + 24}" text-anchor="${fallbackLabelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
+                parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${fallbackLabelPlacement.x + shiftX}" y="${rowY + 24}" text-anchor="${fallbackLabelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
                 continue;
             }
             const barX = chartOriginX + (row.startIndex * WEEK_WIDTH) + 4;
@@ -13296,7 +13299,7 @@ if (!customElements.get("lht-page-menu")) {
                 }
             }
             const labelPlacement = labelPlacements[rowIndex];
-            parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelPlacement.x}" y="${rowY + 24}" text-anchor="${labelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
+            parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelPlacement.x + shiftX}" y="${rowY + 24}" text-anchor="${labelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
         }
         parts.push("</svg>");
         return parts.join("");
@@ -13500,26 +13503,60 @@ if (!customElements.get("lht-page-menu")) {
         return task.name || "-";
     }
     function resolveLabelPlacement(row, chartOriginX, chartWidth, labelMode) {
+        const decision = resolveLabelPlacementDecision(row, chartOriginX, chartWidth, labelMode);
+        return { x: decision.x, anchor: decision.anchor, width: decision.width };
+    }
+    function resolveLabelPlacementDecision(row, chartOriginX, chartWidth, labelMode) {
         if (labelMode === "list" || row.startIndex === null || row.endIndex === null) {
-            return { x: LEFT_PADDING + 10, anchor: "start", width: estimateLabelWidth(row.label, row.kind === "phase") };
+            return {
+                x: LEFT_PADDING + 10,
+                anchor: "start",
+                width: estimateLabelWidth(row.label, row.kind === "phase"),
+                reason: "list-mode-or-missing-range",
+                metrics: {
+                    labelMode,
+                    startIndex: row.startIndex,
+                    endIndex: row.endIndex
+                }
+            };
         }
-        const textWidth = estimateLabelWidth(row.label, row.kind === "phase");
-        const gap = 12;
-        const shapeStartX = row.kind === "milestone"
-            ? chartOriginX + (row.startIndex * DAY_WIDTH) + (DAY_WIDTH / 2) - 13
-            : chartOriginX + (row.startIndex * DAY_WIDTH) + 6;
-        const shapeEndX = row.kind === "milestone"
-            ? chartOriginX + (row.startIndex * DAY_WIDTH) + (DAY_WIDTH / 2) + 13
-            : chartOriginX + (row.endIndex * DAY_WIDTH) + DAY_WIDTH - 6;
-        const chartMidX = chartOriginX + (chartWidth / 2);
-        if (shapeEndX <= chartMidX) {
-            return { x: shapeEndX + gap, anchor: "start", width: textWidth };
-        }
-        return { x: Math.max(textWidth, shapeStartX - gap), anchor: "end", width: textWidth };
+        return resolveSideLabelPlacementDecision(row, chartOriginX, chartWidth, {
+            cellWidth: DAY_WIDTH,
+            gap: 18,
+            rangeInset: 6,
+            milestoneHalfWidth: 13,
+            preferredColumns: 4,
+            missingRangeX: LEFT_PADDING + 10,
+            missingRangeReason: "list-mode-or-missing-range"
+        });
     }
     function estimateLabelWidth(label, isPhase) {
-        const basePerChar = isPhase ? 14 : 13;
-        return Math.max(48, Math.ceil(String(label || "").length * basePerChar));
+        const text = String(label || "").trim() || "-";
+        let width = 0;
+        for (const char of text) {
+            if (/\s/.test(char)) {
+                width += 4;
+                continue;
+            }
+            if (/[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uff01-\uff60\uffe0-\uffee]/.test(char)) {
+                width += isPhase ? 13 : 12;
+                continue;
+            }
+            if (/[A-Z]/.test(char)) {
+                width += 8;
+                continue;
+            }
+            if (/[a-z0-9]/.test(char)) {
+                width += 7;
+                continue;
+            }
+            if (/[\u0021-\u007e]/.test(char)) {
+                width += 6;
+                continue;
+            }
+            width += isPhase ? 12 : 11;
+        }
+        return Math.max(48, Math.ceil(width));
     }
     function shouldUseDailyOnBarLabel(row, chartOriginX, chartWidth, bandLength, labelMode) {
         if (labelMode !== "near") {
@@ -13532,37 +13569,114 @@ if (!customElements.get("lht-page-menu")) {
             return false;
         }
         if (row.startIndex === 0 && row.endIndex === bandLength - 1) {
-            return true;
+            const fullWidthTextWidth = estimateLabelWidth(row.label, row.kind === "phase");
+            const fullWidthBarWidth = Math.max(12, ((row.endIndex - row.startIndex + 1) * DAY_WIDTH) - 12);
+            return fullWidthBarWidth >= fullWidthTextWidth + 16;
         }
         const textWidth = estimateLabelWidth(row.label, row.kind === "phase");
-        const gap = 12;
+        const gap = 18;
         const shapeStartX = row.kind === "milestone"
             ? chartOriginX + (row.startIndex * DAY_WIDTH) + (DAY_WIDTH / 2) - 13
             : chartOriginX + (row.startIndex * DAY_WIDTH) + 6;
         const shapeEndX = row.kind === "milestone"
             ? chartOriginX + (row.startIndex * DAY_WIDTH) + (DAY_WIDTH / 2) + 13
             : chartOriginX + (row.endIndex * DAY_WIDTH) + DAY_WIDTH - 6;
+        const barWidth = Math.max(12, ((row.endIndex - row.startIndex + 1) * DAY_WIDTH) - 12);
         const leftRoom = Math.max(0, shapeStartX - gap - chartOriginX);
         const rightRoom = Math.max(0, (chartOriginX + chartWidth) - (shapeEndX + gap));
+        if (barWidth < textWidth + 16) {
+            return false;
+        }
         return leftRoom < textWidth && rightRoom < textWidth;
     }
     function resolveWeeklyLabelPlacement(row, chartOriginX, chartWidth) {
-        if (row.startIndex === null || row.endIndex === null) {
-            return { x: chartOriginX + 10, anchor: "start", width: estimateLabelWidth(row.label, row.kind === "phase") };
-        }
+        const decision = resolveWeeklyLabelPlacementDecision(row, chartOriginX, chartWidth);
+        return { x: decision.x, anchor: decision.anchor, width: decision.width };
+    }
+    function resolveWeeklyLabelPlacementDecision(row, chartOriginX, chartWidth) {
+        return resolveSideLabelPlacementDecision(row, chartOriginX, chartWidth, {
+            cellWidth: WEEK_WIDTH,
+            gap: 16,
+            rangeInset: 4,
+            milestoneHalfWidth: 11,
+            preferredColumns: 4,
+            missingRangeX: chartOriginX + 10,
+            missingRangeReason: "missing-range"
+        });
+    }
+    function resolveSideLabelPlacementDecision(row, chartOriginX, chartWidth, config) {
         const textWidth = estimateLabelWidth(row.label, row.kind === "phase");
-        const gap = 10;
-        const shapeStartX = row.kind === "milestone"
-            ? chartOriginX + (row.startIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2) - 11
-            : chartOriginX + (row.startIndex * WEEK_WIDTH) + 4;
-        const shapeEndX = row.kind === "milestone"
-            ? chartOriginX + (row.startIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2) + 11
-            : chartOriginX + (row.endIndex * WEEK_WIDTH) + WEEK_WIDTH - 4;
-        const chartMidX = chartOriginX + (chartWidth / 2);
-        if (shapeEndX <= chartMidX) {
-            return { x: shapeEndX + gap, anchor: "start", width: textWidth };
+        if (row.startIndex === null || row.endIndex === null) {
+            return {
+                x: config.missingRangeX,
+                anchor: "start",
+                width: textWidth,
+                reason: config.missingRangeReason,
+                metrics: {
+                    startIndex: row.startIndex,
+                    endIndex: row.endIndex
+                }
+            };
         }
-        return { x: Math.max(textWidth, shapeStartX - gap), anchor: "end", width: textWidth };
+        const geometry = buildPlacementGeometry(row, chartOriginX, chartWidth, config);
+        const preferredRoom = Math.min(textWidth, config.cellWidth * config.preferredColumns);
+        if (geometry.shapeCenterX >= geometry.chartMidX) {
+            if (geometry.leftRoom < textWidth && geometry.rightRoom >= textWidth) {
+                return buildPlacementDecision("start", geometry.shapeEndX + config.gap, textWidth, "midpoint-right-but-left-overflows-fallback-right", geometry, config, { preferredRoom });
+            }
+            return buildPlacementDecision("end", geometry.shapeStartX - config.gap, textWidth, "midpoint-right-prefer-left", geometry, config, { preferredRoom });
+        }
+        if (geometry.rightRoom >= preferredRoom) {
+            return buildPlacementDecision("start", geometry.shapeEndX + config.gap, textWidth, "enough-right-room", geometry, config, { preferredRoom });
+        }
+        if (geometry.leftRoom >= preferredRoom) {
+            return buildPlacementDecision("end", geometry.shapeStartX - config.gap, textWidth, "enough-left-room", geometry, config, { preferredRoom });
+        }
+        if (geometry.rightRoom > geometry.leftRoom) {
+            return buildPlacementDecision("start", geometry.shapeEndX + config.gap, textWidth, "fallback-wider-right-room", geometry, config, { preferredRoom });
+        }
+        return buildPlacementDecision("end", geometry.shapeStartX - config.gap, textWidth, "fallback-wider-left-room", geometry, config, { preferredRoom });
+    }
+    function buildPlacementGeometry(row, chartOriginX, chartWidth, config) {
+        const shapeStartX = row.kind === "milestone"
+            ? chartOriginX + (row.startIndex * config.cellWidth) + (config.cellWidth / 2) - config.milestoneHalfWidth
+            : chartOriginX + (row.startIndex * config.cellWidth) + config.rangeInset;
+        const shapeEndX = row.kind === "milestone"
+            ? chartOriginX + (row.startIndex * config.cellWidth) + (config.cellWidth / 2) + config.milestoneHalfWidth
+            : chartOriginX + (row.endIndex * config.cellWidth) + config.cellWidth - config.rangeInset;
+        const chartMidX = chartOriginX + (chartWidth / 2);
+        const chartEndX = chartOriginX + chartWidth;
+        return {
+            chartOriginX,
+            shapeStartX,
+            shapeEndX,
+            shapeCenterX: (shapeStartX + shapeEndX) / 2,
+            chartMidX,
+            chartEndX,
+            leftRoom: Math.max(0, (shapeStartX - config.gap) - chartOriginX),
+            rightRoom: Math.max(0, chartEndX - (shapeEndX + config.gap))
+        };
+    }
+    function buildPlacementDecision(anchor, x, textWidth, reason, geometry, config, extras = {}) {
+        return {
+            x,
+            anchor,
+            width: textWidth,
+            reason,
+            metrics: {
+                textWidth,
+                ...extras,
+                gap: config.gap,
+                shapeStartX: geometry.shapeStartX,
+                shapeEndX: geometry.shapeEndX,
+                shapeCenterX: geometry.shapeCenterX,
+                chartMidX: geometry.chartMidX,
+                leftRoom: geometry.leftRoom,
+                rightRoom: geometry.rightRoom,
+                chartOriginX: geometry.chartOriginX,
+                chartEndX: geometry.chartEndX
+            }
+        };
     }
     function formatSvgAxisDate(day) {
         const match = day.match(/^(\d{4})-(\d{2})-(\d{2})$/);

--- a/src/css/app.css
+++ b/src/css/app.css
@@ -1016,7 +1016,8 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 
 .md-svg-preview-stage svg {
   display: block;
-  max-width: 100%;
+  width: 100%;
+  max-width: none;
   height: auto;
 }
 

--- a/src/js/wbs-svg.js
+++ b/src/js/wbs-svg.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 (() => {
-    const DAY_WIDTH = 56;
+    const WEEK_WIDTH = 38;
+    const DAY_WIDTH = WEEK_WIDTH;
     const LIST_LABEL_WIDTH = 360;
     const NEAR_LEFT_LABEL_WIDTH = 0;
     const NEAR_RIGHT_LABEL_WIDTH = 0;
@@ -27,12 +28,12 @@
     const MONTHLY_MAX_LABEL_CHARS = 15;
     const ZIP_FIXED_MOD_TIME = 0;
     const ZIP_FIXED_MOD_DATE = ((2025 - 1980) << 9) | (1 << 5) | 1;
-    const WEEK_WIDTH = 38;
     const WEEKLY_HEADER_HEIGHT = 96;
     const WEEKLY_TOP_PADDING = 22;
     const WEEKLY_BOTTOM_PADDING = 28;
     const WEEKLY_LEFT_PADDING = 0;
     const WEEKLY_RIGHT_PADDING = 0;
+    const WEEKLY_TRIM_PADDING = 16;
     function exportNativeSvg(model, options = {}) {
         const labelMode = options.labelMode || "near";
         const holidaySet = new Set([
@@ -74,7 +75,6 @@
             ".axis { font-size: 12px; fill: #5b6370; }",
             ".label { font-size: 13px; }",
             ".phaseLabel { font-size: 13px; font-weight: 700; }",
-            ".onBarLabelBg { fill: rgba(255,255,255,0.9); }",
             ".grid { stroke: #c9d3e1; stroke-width: 1; }",
             ".today { stroke: #ff6b5a; stroke-width: 2; }",
             "</style>",
@@ -137,12 +137,7 @@
                 }
                 if (useOnBarLabel) {
                     const labelText = escapeXml(formatTaskLabel(row.task, labelMode));
-                    const labelWidth = estimateLabelWidth(row.label, row.kind === "phase");
                     const labelCenterX = barX + (barWidth / 2);
-                    const labelX = labelCenterX - (labelWidth / 2) - 8;
-                    const labelY = row.kind === "phase" ? rowY + 15 : rowY + 10;
-                    const labelHeight = row.kind === "phase" ? 18 : 20;
-                    parts.push(`<rect class="onBarLabelBg" x="${labelX}" y="${labelY}" width="${labelWidth + 16}" height="${labelHeight}" rx="4"/>`);
                     parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelCenterX}" y="${rowY + 24}" text-anchor="middle">${labelText}</text>`);
                     continue;
                 }
@@ -168,12 +163,19 @@
         const chartWidth = weeklyBand.length * WEEK_WIDTH;
         const chartOriginXBase = WEEKLY_LEFT_PADDING;
         const labelPlacements = rows.map((row) => resolveWeeklyLabelPlacement(row, chartOriginXBase, chartWidth));
+        const labelMinX = labelPlacements.reduce((min, placement) => {
+            const placementMinX = placement.anchor === "start" ? placement.x : placement.x - placement.width;
+            return Math.min(min, placementMinX);
+        }, chartOriginXBase);
         const labelMaxX = labelPlacements.reduce((max, placement) => {
             const placementMaxX = placement.anchor === "start" ? placement.x + placement.width : placement.x;
             return Math.max(max, placementMaxX);
         }, chartOriginXBase + chartWidth);
-        const chartOriginX = chartOriginXBase;
-        const svgWidth = labelMaxX + WEEKLY_RIGHT_PADDING;
+        const contentMinX = Math.min(chartOriginXBase, labelMinX);
+        const contentMaxX = Math.max(chartOriginXBase + chartWidth, labelMaxX);
+        const shiftX = WEEKLY_TRIM_PADDING - contentMinX;
+        const chartOriginX = chartOriginXBase + shiftX;
+        const svgWidth = (contentMaxX - contentMinX) + (WEEKLY_TRIM_PADDING * 2) + WEEKLY_RIGHT_PADDING;
         const svgHeight = WEEKLY_TOP_PADDING + WEEKLY_HEADER_HEIGHT + (rows.length * ROW_HEIGHT) + WEEKLY_BOTTOM_PADDING;
         const todayWeekIndex = indexOfWeekForDate(weeklyBand, model.project.currentDate);
         const parts = [
@@ -218,7 +220,7 @@
             const rowY = chartOriginY + row.y;
             if (row.startIndex === null || row.endIndex === null) {
                 const fallbackLabelPlacement = labelPlacements[rowIndex];
-                parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${fallbackLabelPlacement.x}" y="${rowY + 24}" text-anchor="${fallbackLabelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
+                parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${fallbackLabelPlacement.x + shiftX}" y="${rowY + 24}" text-anchor="${fallbackLabelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
                 continue;
             }
             const barX = chartOriginX + (row.startIndex * WEEK_WIDTH) + 4;
@@ -255,7 +257,7 @@
                 }
             }
             const labelPlacement = labelPlacements[rowIndex];
-            parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelPlacement.x}" y="${rowY + 24}" text-anchor="${labelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
+            parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelPlacement.x + shiftX}" y="${rowY + 24}" text-anchor="${labelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
         }
         parts.push("</svg>");
         return parts.join("");
@@ -459,26 +461,60 @@
         return task.name || "-";
     }
     function resolveLabelPlacement(row, chartOriginX, chartWidth, labelMode) {
+        const decision = resolveLabelPlacementDecision(row, chartOriginX, chartWidth, labelMode);
+        return { x: decision.x, anchor: decision.anchor, width: decision.width };
+    }
+    function resolveLabelPlacementDecision(row, chartOriginX, chartWidth, labelMode) {
         if (labelMode === "list" || row.startIndex === null || row.endIndex === null) {
-            return { x: LEFT_PADDING + 10, anchor: "start", width: estimateLabelWidth(row.label, row.kind === "phase") };
+            return {
+                x: LEFT_PADDING + 10,
+                anchor: "start",
+                width: estimateLabelWidth(row.label, row.kind === "phase"),
+                reason: "list-mode-or-missing-range",
+                metrics: {
+                    labelMode,
+                    startIndex: row.startIndex,
+                    endIndex: row.endIndex
+                }
+            };
         }
-        const textWidth = estimateLabelWidth(row.label, row.kind === "phase");
-        const gap = 12;
-        const shapeStartX = row.kind === "milestone"
-            ? chartOriginX + (row.startIndex * DAY_WIDTH) + (DAY_WIDTH / 2) - 13
-            : chartOriginX + (row.startIndex * DAY_WIDTH) + 6;
-        const shapeEndX = row.kind === "milestone"
-            ? chartOriginX + (row.startIndex * DAY_WIDTH) + (DAY_WIDTH / 2) + 13
-            : chartOriginX + (row.endIndex * DAY_WIDTH) + DAY_WIDTH - 6;
-        const chartMidX = chartOriginX + (chartWidth / 2);
-        if (shapeEndX <= chartMidX) {
-            return { x: shapeEndX + gap, anchor: "start", width: textWidth };
-        }
-        return { x: Math.max(textWidth, shapeStartX - gap), anchor: "end", width: textWidth };
+        return resolveSideLabelPlacementDecision(row, chartOriginX, chartWidth, {
+            cellWidth: DAY_WIDTH,
+            gap: 18,
+            rangeInset: 6,
+            milestoneHalfWidth: 13,
+            preferredColumns: 4,
+            missingRangeX: LEFT_PADDING + 10,
+            missingRangeReason: "list-mode-or-missing-range"
+        });
     }
     function estimateLabelWidth(label, isPhase) {
-        const basePerChar = isPhase ? 14 : 13;
-        return Math.max(48, Math.ceil(String(label || "").length * basePerChar));
+        const text = String(label || "").trim() || "-";
+        let width = 0;
+        for (const char of text) {
+            if (/\s/.test(char)) {
+                width += 4;
+                continue;
+            }
+            if (/[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uff01-\uff60\uffe0-\uffee]/.test(char)) {
+                width += isPhase ? 13 : 12;
+                continue;
+            }
+            if (/[A-Z]/.test(char)) {
+                width += 8;
+                continue;
+            }
+            if (/[a-z0-9]/.test(char)) {
+                width += 7;
+                continue;
+            }
+            if (/[\u0021-\u007e]/.test(char)) {
+                width += 6;
+                continue;
+            }
+            width += isPhase ? 12 : 11;
+        }
+        return Math.max(48, Math.ceil(width));
     }
     function shouldUseDailyOnBarLabel(row, chartOriginX, chartWidth, bandLength, labelMode) {
         if (labelMode !== "near") {
@@ -491,37 +527,114 @@
             return false;
         }
         if (row.startIndex === 0 && row.endIndex === bandLength - 1) {
-            return true;
+            const fullWidthTextWidth = estimateLabelWidth(row.label, row.kind === "phase");
+            const fullWidthBarWidth = Math.max(12, ((row.endIndex - row.startIndex + 1) * DAY_WIDTH) - 12);
+            return fullWidthBarWidth >= fullWidthTextWidth + 16;
         }
         const textWidth = estimateLabelWidth(row.label, row.kind === "phase");
-        const gap = 12;
+        const gap = 18;
         const shapeStartX = row.kind === "milestone"
             ? chartOriginX + (row.startIndex * DAY_WIDTH) + (DAY_WIDTH / 2) - 13
             : chartOriginX + (row.startIndex * DAY_WIDTH) + 6;
         const shapeEndX = row.kind === "milestone"
             ? chartOriginX + (row.startIndex * DAY_WIDTH) + (DAY_WIDTH / 2) + 13
             : chartOriginX + (row.endIndex * DAY_WIDTH) + DAY_WIDTH - 6;
+        const barWidth = Math.max(12, ((row.endIndex - row.startIndex + 1) * DAY_WIDTH) - 12);
         const leftRoom = Math.max(0, shapeStartX - gap - chartOriginX);
         const rightRoom = Math.max(0, (chartOriginX + chartWidth) - (shapeEndX + gap));
+        if (barWidth < textWidth + 16) {
+            return false;
+        }
         return leftRoom < textWidth && rightRoom < textWidth;
     }
     function resolveWeeklyLabelPlacement(row, chartOriginX, chartWidth) {
-        if (row.startIndex === null || row.endIndex === null) {
-            return { x: chartOriginX + 10, anchor: "start", width: estimateLabelWidth(row.label, row.kind === "phase") };
-        }
+        const decision = resolveWeeklyLabelPlacementDecision(row, chartOriginX, chartWidth);
+        return { x: decision.x, anchor: decision.anchor, width: decision.width };
+    }
+    function resolveWeeklyLabelPlacementDecision(row, chartOriginX, chartWidth) {
+        return resolveSideLabelPlacementDecision(row, chartOriginX, chartWidth, {
+            cellWidth: WEEK_WIDTH,
+            gap: 16,
+            rangeInset: 4,
+            milestoneHalfWidth: 11,
+            preferredColumns: 4,
+            missingRangeX: chartOriginX + 10,
+            missingRangeReason: "missing-range"
+        });
+    }
+    function resolveSideLabelPlacementDecision(row, chartOriginX, chartWidth, config) {
         const textWidth = estimateLabelWidth(row.label, row.kind === "phase");
-        const gap = 10;
-        const shapeStartX = row.kind === "milestone"
-            ? chartOriginX + (row.startIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2) - 11
-            : chartOriginX + (row.startIndex * WEEK_WIDTH) + 4;
-        const shapeEndX = row.kind === "milestone"
-            ? chartOriginX + (row.startIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2) + 11
-            : chartOriginX + (row.endIndex * WEEK_WIDTH) + WEEK_WIDTH - 4;
-        const chartMidX = chartOriginX + (chartWidth / 2);
-        if (shapeEndX <= chartMidX) {
-            return { x: shapeEndX + gap, anchor: "start", width: textWidth };
+        if (row.startIndex === null || row.endIndex === null) {
+            return {
+                x: config.missingRangeX,
+                anchor: "start",
+                width: textWidth,
+                reason: config.missingRangeReason,
+                metrics: {
+                    startIndex: row.startIndex,
+                    endIndex: row.endIndex
+                }
+            };
         }
-        return { x: Math.max(textWidth, shapeStartX - gap), anchor: "end", width: textWidth };
+        const geometry = buildPlacementGeometry(row, chartOriginX, chartWidth, config);
+        const preferredRoom = Math.min(textWidth, config.cellWidth * config.preferredColumns);
+        if (geometry.shapeCenterX >= geometry.chartMidX) {
+            if (geometry.leftRoom < textWidth && geometry.rightRoom >= textWidth) {
+                return buildPlacementDecision("start", geometry.shapeEndX + config.gap, textWidth, "midpoint-right-but-left-overflows-fallback-right", geometry, config, { preferredRoom });
+            }
+            return buildPlacementDecision("end", geometry.shapeStartX - config.gap, textWidth, "midpoint-right-prefer-left", geometry, config, { preferredRoom });
+        }
+        if (geometry.rightRoom >= preferredRoom) {
+            return buildPlacementDecision("start", geometry.shapeEndX + config.gap, textWidth, "enough-right-room", geometry, config, { preferredRoom });
+        }
+        if (geometry.leftRoom >= preferredRoom) {
+            return buildPlacementDecision("end", geometry.shapeStartX - config.gap, textWidth, "enough-left-room", geometry, config, { preferredRoom });
+        }
+        if (geometry.rightRoom > geometry.leftRoom) {
+            return buildPlacementDecision("start", geometry.shapeEndX + config.gap, textWidth, "fallback-wider-right-room", geometry, config, { preferredRoom });
+        }
+        return buildPlacementDecision("end", geometry.shapeStartX - config.gap, textWidth, "fallback-wider-left-room", geometry, config, { preferredRoom });
+    }
+    function buildPlacementGeometry(row, chartOriginX, chartWidth, config) {
+        const shapeStartX = row.kind === "milestone"
+            ? chartOriginX + (row.startIndex * config.cellWidth) + (config.cellWidth / 2) - config.milestoneHalfWidth
+            : chartOriginX + (row.startIndex * config.cellWidth) + config.rangeInset;
+        const shapeEndX = row.kind === "milestone"
+            ? chartOriginX + (row.startIndex * config.cellWidth) + (config.cellWidth / 2) + config.milestoneHalfWidth
+            : chartOriginX + (row.endIndex * config.cellWidth) + config.cellWidth - config.rangeInset;
+        const chartMidX = chartOriginX + (chartWidth / 2);
+        const chartEndX = chartOriginX + chartWidth;
+        return {
+            chartOriginX,
+            shapeStartX,
+            shapeEndX,
+            shapeCenterX: (shapeStartX + shapeEndX) / 2,
+            chartMidX,
+            chartEndX,
+            leftRoom: Math.max(0, (shapeStartX - config.gap) - chartOriginX),
+            rightRoom: Math.max(0, chartEndX - (shapeEndX + config.gap))
+        };
+    }
+    function buildPlacementDecision(anchor, x, textWidth, reason, geometry, config, extras = {}) {
+        return {
+            x,
+            anchor,
+            width: textWidth,
+            reason,
+            metrics: {
+                textWidth,
+                ...extras,
+                gap: config.gap,
+                shapeStartX: geometry.shapeStartX,
+                shapeEndX: geometry.shapeEndX,
+                shapeCenterX: geometry.shapeCenterX,
+                chartMidX: geometry.chartMidX,
+                leftRoom: geometry.leftRoom,
+                rightRoom: geometry.rightRoom,
+                chartOriginX: geometry.chartOriginX,
+                chartEndX: geometry.chartEndX
+            }
+        };
     }
     function formatSvgAxisDate(day) {
         const match = day.match(/^(\d{4})-(\d{2})-(\d{2})$/);

--- a/src/ts/wbs-svg.ts
+++ b/src/ts/wbs-svg.ts
@@ -27,6 +27,32 @@
     width: number;
   };
 
+  type NativeSvgLabelPlacementDecision = NativeSvgLabelPlacement & {
+    reason: string;
+    metrics: Record<string, number | string | boolean | null>;
+  };
+
+  type NativeSvgPlacementGeometry = {
+    chartOriginX: number;
+    shapeStartX: number;
+    shapeEndX: number;
+    shapeCenterX: number;
+    chartMidX: number;
+    chartEndX: number;
+    leftRoom: number;
+    rightRoom: number;
+  };
+
+  type NativeSvgPlacementConfig = {
+    cellWidth: number;
+    gap: number;
+    rangeInset: number;
+    milestoneHalfWidth: number;
+    preferredColumns: number;
+    missingRangeX: number;
+    missingRangeReason: string;
+  };
+
   type ZipEntry = {
     name: string;
     data: Uint8Array;
@@ -46,7 +72,8 @@
     monthKey: string;
   };
 
-  const DAY_WIDTH = 56;
+  const WEEK_WIDTH = 38;
+  const DAY_WIDTH = WEEK_WIDTH;
   const LIST_LABEL_WIDTH = 360;
   const NEAR_LEFT_LABEL_WIDTH = 0;
   const NEAR_RIGHT_LABEL_WIDTH = 0;
@@ -70,12 +97,12 @@
   const MONTHLY_MAX_LABEL_CHARS = 15;
   const ZIP_FIXED_MOD_TIME = 0;
   const ZIP_FIXED_MOD_DATE = ((2025 - 1980) << 9) | (1 << 5) | 1;
-  const WEEK_WIDTH = 38;
   const WEEKLY_HEADER_HEIGHT = 96;
   const WEEKLY_TOP_PADDING = 22;
   const WEEKLY_BOTTOM_PADDING = 28;
   const WEEKLY_LEFT_PADDING = 0;
   const WEEKLY_RIGHT_PADDING = 0;
+  const WEEKLY_TRIM_PADDING = 16;
 
   function exportNativeSvg(model: ProjectModel, options: NativeSvgExportOptions = {}): string {
     const labelMode = options.labelMode || "near";
@@ -128,7 +155,6 @@
       ".axis { font-size: 12px; fill: #5b6370; }",
       ".label { font-size: 13px; }",
       ".phaseLabel { font-size: 13px; font-weight: 700; }",
-      ".onBarLabelBg { fill: rgba(255,255,255,0.9); }",
       ".grid { stroke: #c9d3e1; stroke-width: 1; }",
       ".today { stroke: #ff6b5a; stroke-width: 2; }",
       "</style>",
@@ -193,12 +219,7 @@
         }
         if (useOnBarLabel) {
           const labelText = escapeXml(formatTaskLabel(row.task, labelMode));
-          const labelWidth = estimateLabelWidth(row.label, row.kind === "phase");
           const labelCenterX = barX + (barWidth / 2);
-          const labelX = labelCenterX - (labelWidth / 2) - 8;
-          const labelY = row.kind === "phase" ? rowY + 15 : rowY + 10;
-          const labelHeight = row.kind === "phase" ? 18 : 20;
-          parts.push(`<rect class="onBarLabelBg" x="${labelX}" y="${labelY}" width="${labelWidth + 16}" height="${labelHeight}" rx="4"/>`);
           parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelCenterX}" y="${rowY + 24}" text-anchor="middle">${labelText}</text>`);
           continue;
         }
@@ -236,12 +257,19 @@
     const chartWidth = weeklyBand.length * WEEK_WIDTH;
     const chartOriginXBase = WEEKLY_LEFT_PADDING;
     const labelPlacements = rows.map((row) => resolveWeeklyLabelPlacement(row, chartOriginXBase, chartWidth));
+    const labelMinX = labelPlacements.reduce((min, placement) => {
+      const placementMinX = placement.anchor === "start" ? placement.x : placement.x - placement.width;
+      return Math.min(min, placementMinX);
+    }, chartOriginXBase);
     const labelMaxX = labelPlacements.reduce((max, placement) => {
       const placementMaxX = placement.anchor === "start" ? placement.x + placement.width : placement.x;
       return Math.max(max, placementMaxX);
     }, chartOriginXBase + chartWidth);
-    const chartOriginX = chartOriginXBase;
-    const svgWidth = labelMaxX + WEEKLY_RIGHT_PADDING;
+    const contentMinX = Math.min(chartOriginXBase, labelMinX);
+    const contentMaxX = Math.max(chartOriginXBase + chartWidth, labelMaxX);
+    const shiftX = WEEKLY_TRIM_PADDING - contentMinX;
+    const chartOriginX = chartOriginXBase + shiftX;
+    const svgWidth = (contentMaxX - contentMinX) + (WEEKLY_TRIM_PADDING * 2) + WEEKLY_RIGHT_PADDING;
     const svgHeight = WEEKLY_TOP_PADDING + WEEKLY_HEADER_HEIGHT + (rows.length * ROW_HEIGHT) + WEEKLY_BOTTOM_PADDING;
     const todayWeekIndex = indexOfWeekForDate(weeklyBand, model.project.currentDate);
 
@@ -292,7 +320,7 @@
       const rowY = chartOriginY + row.y;
       if (row.startIndex === null || row.endIndex === null) {
         const fallbackLabelPlacement = labelPlacements[rowIndex];
-        parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${fallbackLabelPlacement.x}" y="${rowY + 24}" text-anchor="${fallbackLabelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
+        parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${fallbackLabelPlacement.x + shiftX}" y="${rowY + 24}" text-anchor="${fallbackLabelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
         continue;
       }
       const barX = chartOriginX + (row.startIndex * WEEK_WIDTH) + 4;
@@ -327,7 +355,7 @@
         }
       }
       const labelPlacement = labelPlacements[rowIndex];
-      parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelPlacement.x}" y="${rowY + 24}" text-anchor="${labelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
+      parts.push(`<text class="${row.kind === "phase" ? "phaseLabel" : "label"}" x="${labelPlacement.x + shiftX}" y="${rowY + 24}" text-anchor="${labelPlacement.anchor}">${escapeXml(formatTaskLabel(row.task, "near"))}</text>`);
     }
 
     parts.push("</svg>");
@@ -564,28 +592,67 @@
     chartWidth: number,
     labelMode: "near" | "list"
   ): NativeSvgLabelPlacement {
-    if (labelMode === "list" || row.startIndex === null || row.endIndex === null) {
-      return { x: LEFT_PADDING + 10, anchor: "start", width: estimateLabelWidth(row.label, row.kind === "phase") };
-    }
+    const decision = resolveLabelPlacementDecision(row, chartOriginX, chartWidth, labelMode);
+    return { x: decision.x, anchor: decision.anchor, width: decision.width };
+  }
 
-    const textWidth = estimateLabelWidth(row.label, row.kind === "phase");
-    const gap = 12;
-    const shapeStartX = row.kind === "milestone"
-      ? chartOriginX + (row.startIndex * DAY_WIDTH) + (DAY_WIDTH / 2) - 13
-      : chartOriginX + (row.startIndex * DAY_WIDTH) + 6;
-    const shapeEndX = row.kind === "milestone"
-      ? chartOriginX + (row.startIndex * DAY_WIDTH) + (DAY_WIDTH / 2) + 13
-      : chartOriginX + (row.endIndex * DAY_WIDTH) + DAY_WIDTH - 6;
-    const chartMidX = chartOriginX + (chartWidth / 2);
-    if (shapeEndX <= chartMidX) {
-      return { x: shapeEndX + gap, anchor: "start", width: textWidth };
+  function resolveLabelPlacementDecision(
+    row: NativeSvgTaskRow,
+    chartOriginX: number,
+    chartWidth: number,
+    labelMode: "near" | "list"
+  ): NativeSvgLabelPlacementDecision {
+    if (labelMode === "list" || row.startIndex === null || row.endIndex === null) {
+      return {
+        x: LEFT_PADDING + 10,
+        anchor: "start",
+        width: estimateLabelWidth(row.label, row.kind === "phase"),
+        reason: "list-mode-or-missing-range",
+        metrics: {
+          labelMode,
+          startIndex: row.startIndex,
+          endIndex: row.endIndex
+        }
+      };
     }
-    return { x: Math.max(textWidth, shapeStartX - gap), anchor: "end", width: textWidth };
+    return resolveSideLabelPlacementDecision(row, chartOriginX, chartWidth, {
+      cellWidth: DAY_WIDTH,
+      gap: 18,
+      rangeInset: 6,
+      milestoneHalfWidth: 13,
+      preferredColumns: 4,
+      missingRangeX: LEFT_PADDING + 10,
+      missingRangeReason: "list-mode-or-missing-range"
+    });
   }
 
   function estimateLabelWidth(label: string, isPhase: boolean): number {
-    const basePerChar = isPhase ? 14 : 13;
-    return Math.max(48, Math.ceil(String(label || "").length * basePerChar));
+    const text = String(label || "").trim() || "-";
+    let width = 0;
+    for (const char of text) {
+      if (/\s/.test(char)) {
+        width += 4;
+        continue;
+      }
+      if (/[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff\uff01-\uff60\uffe0-\uffee]/.test(char)) {
+        width += isPhase ? 13 : 12;
+        continue;
+      }
+      if (/[A-Z]/.test(char)) {
+        width += 8;
+        continue;
+      }
+      if (/[a-z0-9]/.test(char)) {
+        width += 7;
+        continue;
+      }
+      if (/[\u0021-\u007e]/.test(char)) {
+        width += 6;
+        continue;
+      }
+      width += isPhase ? 12 : 11;
+    }
+    return Math.max(48, Math.ceil(width));
   }
 
   function shouldUseDailyOnBarLabel(
@@ -605,18 +672,24 @@
       return false;
     }
     if (row.startIndex === 0 && row.endIndex === bandLength - 1) {
-      return true;
+      const fullWidthTextWidth = estimateLabelWidth(row.label, row.kind === "phase");
+      const fullWidthBarWidth = Math.max(12, ((row.endIndex - row.startIndex + 1) * DAY_WIDTH) - 12);
+      return fullWidthBarWidth >= fullWidthTextWidth + 16;
     }
     const textWidth = estimateLabelWidth(row.label, row.kind === "phase");
-    const gap = 12;
+    const gap = 18;
     const shapeStartX = row.kind === "milestone"
       ? chartOriginX + (row.startIndex * DAY_WIDTH) + (DAY_WIDTH / 2) - 13
       : chartOriginX + (row.startIndex * DAY_WIDTH) + 6;
     const shapeEndX = row.kind === "milestone"
       ? chartOriginX + (row.startIndex * DAY_WIDTH) + (DAY_WIDTH / 2) + 13
       : chartOriginX + (row.endIndex * DAY_WIDTH) + DAY_WIDTH - 6;
+    const barWidth = Math.max(12, ((row.endIndex - row.startIndex + 1) * DAY_WIDTH) - 12);
     const leftRoom = Math.max(0, shapeStartX - gap - chartOriginX);
     const rightRoom = Math.max(0, (chartOriginX + chartWidth) - (shapeEndX + gap));
+    if (barWidth < textWidth + 16) {
+      return false;
+    }
     return leftRoom < textWidth && rightRoom < textWidth;
   }
 
@@ -625,23 +698,120 @@
     chartOriginX: number,
     chartWidth: number
   ): NativeSvgLabelPlacement {
+    const decision = resolveWeeklyLabelPlacementDecision(row, chartOriginX, chartWidth);
+    return { x: decision.x, anchor: decision.anchor, width: decision.width };
+  }
+
+  function resolveWeeklyLabelPlacementDecision(
+    row: NativeSvgTaskRow,
+    chartOriginX: number,
+    chartWidth: number
+  ): NativeSvgLabelPlacementDecision {
+    return resolveSideLabelPlacementDecision(row, chartOriginX, chartWidth, {
+      cellWidth: WEEK_WIDTH,
+      gap: 16,
+      rangeInset: 4,
+      milestoneHalfWidth: 11,
+      preferredColumns: 4,
+      missingRangeX: chartOriginX + 10,
+      missingRangeReason: "missing-range"
+    });
+  }
+
+  function resolveSideLabelPlacementDecision(
+    row: NativeSvgTaskRow,
+    chartOriginX: number,
+    chartWidth: number,
+    config: NativeSvgPlacementConfig
+  ): NativeSvgLabelPlacementDecision {
+    const textWidth = estimateLabelWidth(row.label, row.kind === "phase");
     if (row.startIndex === null || row.endIndex === null) {
-      return { x: chartOriginX + 10, anchor: "start", width: estimateLabelWidth(row.label, row.kind === "phase") };
+      return {
+        x: config.missingRangeX,
+        anchor: "start",
+        width: textWidth,
+        reason: config.missingRangeReason,
+        metrics: {
+          startIndex: row.startIndex,
+          endIndex: row.endIndex
+        }
+      };
     }
 
-    const textWidth = estimateLabelWidth(row.label, row.kind === "phase");
-    const gap = 10;
-    const shapeStartX = row.kind === "milestone"
-      ? chartOriginX + (row.startIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2) - 11
-      : chartOriginX + (row.startIndex * WEEK_WIDTH) + 4;
-    const shapeEndX = row.kind === "milestone"
-      ? chartOriginX + (row.startIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2) + 11
-      : chartOriginX + (row.endIndex * WEEK_WIDTH) + WEEK_WIDTH - 4;
-    const chartMidX = chartOriginX + (chartWidth / 2);
-    if (shapeEndX <= chartMidX) {
-      return { x: shapeEndX + gap, anchor: "start", width: textWidth };
+    const geometry = buildPlacementGeometry(row, chartOriginX, chartWidth, config);
+    const preferredRoom = Math.min(textWidth, config.cellWidth * config.preferredColumns);
+    if (geometry.shapeCenterX >= geometry.chartMidX) {
+      if (geometry.leftRoom < textWidth && geometry.rightRoom >= textWidth) {
+        return buildPlacementDecision("start", geometry.shapeEndX + config.gap, textWidth, "midpoint-right-but-left-overflows-fallback-right", geometry, config, { preferredRoom });
+      }
+      return buildPlacementDecision("end", geometry.shapeStartX - config.gap, textWidth, "midpoint-right-prefer-left", geometry, config, { preferredRoom });
     }
-    return { x: Math.max(textWidth, shapeStartX - gap), anchor: "end", width: textWidth };
+    if (geometry.rightRoom >= preferredRoom) {
+      return buildPlacementDecision("start", geometry.shapeEndX + config.gap, textWidth, "enough-right-room", geometry, config, { preferredRoom });
+    }
+    if (geometry.leftRoom >= preferredRoom) {
+      return buildPlacementDecision("end", geometry.shapeStartX - config.gap, textWidth, "enough-left-room", geometry, config, { preferredRoom });
+    }
+    if (geometry.rightRoom > geometry.leftRoom) {
+      return buildPlacementDecision("start", geometry.shapeEndX + config.gap, textWidth, "fallback-wider-right-room", geometry, config, { preferredRoom });
+    }
+    return buildPlacementDecision("end", geometry.shapeStartX - config.gap, textWidth, "fallback-wider-left-room", geometry, config, { preferredRoom });
+  }
+
+  function buildPlacementGeometry(
+    row: NativeSvgTaskRow,
+    chartOriginX: number,
+    chartWidth: number,
+    config: NativeSvgPlacementConfig
+  ): NativeSvgPlacementGeometry {
+    const shapeStartX = row.kind === "milestone"
+      ? chartOriginX + (row.startIndex! * config.cellWidth) + (config.cellWidth / 2) - config.milestoneHalfWidth
+      : chartOriginX + (row.startIndex! * config.cellWidth) + config.rangeInset;
+    const shapeEndX = row.kind === "milestone"
+      ? chartOriginX + (row.startIndex! * config.cellWidth) + (config.cellWidth / 2) + config.milestoneHalfWidth
+      : chartOriginX + (row.endIndex! * config.cellWidth) + config.cellWidth - config.rangeInset;
+    const chartMidX = chartOriginX + (chartWidth / 2);
+    const chartEndX = chartOriginX + chartWidth;
+    return {
+      chartOriginX,
+      shapeStartX,
+      shapeEndX,
+      shapeCenterX: (shapeStartX + shapeEndX) / 2,
+      chartMidX,
+      chartEndX,
+      leftRoom: Math.max(0, (shapeStartX - config.gap) - chartOriginX),
+      rightRoom: Math.max(0, chartEndX - (shapeEndX + config.gap))
+    };
+  }
+
+  function buildPlacementDecision(
+    anchor: "start" | "end",
+    x: number,
+    textWidth: number,
+    reason: string,
+    geometry: NativeSvgPlacementGeometry,
+    config: NativeSvgPlacementConfig,
+    extras: Record<string, number | string | boolean | null> = {}
+  ): NativeSvgLabelPlacementDecision {
+    return {
+      x,
+      anchor,
+      width: textWidth,
+      reason,
+      metrics: {
+        textWidth,
+        ...extras,
+        gap: config.gap,
+        shapeStartX: geometry.shapeStartX,
+        shapeEndX: geometry.shapeEndX,
+        shapeCenterX: geometry.shapeCenterX,
+        chartMidX: geometry.chartMidX,
+        leftRoom: geometry.leftRoom,
+        rightRoom: geometry.rightRoom,
+        chartOriginX: geometry.chartOriginX,
+        chartEndX: geometry.chartEndX
+      }
+    };
   }
 
   function formatSvgAxisDate(day: string): string {

--- a/tests/mikuproject-main.test.js
+++ b/tests/mikuproject-main.test.js
@@ -686,6 +686,30 @@ describe("mikuproject main", () => {
     expect(document.getElementById("nativeSvgPreview").innerHTML).not.toContain("project range 2026-03-16 - 2026-04-01");
   });
 
+  it("keeps long daily task labels outside narrow on-bar labels", async () => {
+    bootPage();
+
+    parseXmlViaHook();
+    await exportMermaidViaHook();
+
+    const dailySvg = document.getElementById("nativeSvgPreview").innerHTML;
+
+    expect(dailySvg).not.toContain('text-anchor="middle">round-trip拡張（MS Project XML → 内部JSON形式 → MS Project XML の往復対応）</text>');
+    expect(dailySvg).not.toContain('text-anchor="middle">MS Project XML と XLSX の相互変換・round-trip実装</text>');
+  });
+
+  it("places daily labels on the left after they pass the chart midpoint", async () => {
+    bootPage();
+
+    parseXmlViaHook();
+    await exportMermaidViaHook();
+
+    const dailySvg = document.getElementById("nativeSvgPreview").innerHTML;
+
+    expect(dailySvg).toContain('text-anchor="start">架空検討フェーズ【架空】</text>');
+    expect(dailySvg).toContain('text-anchor="end">MS Project XML と XLSX の相互変換・round-trip実装</text>');
+  });
+
   it("keeps complex mermaid dependencies as comments", () => {
     const xmlTools = bootXmlModule();
     const model = {


### PR DESCRIPTION
## 概要

`Overview` タブの `Daily` / `Weekly` SVG プレビューについて、ラベル配置と表示幅を見直しました。長い task label が図形と重なりにくいようにしつつ、`Weekly` 側の左右余白も詰めています。

## 変更内容

### SVG ラベル配置の調整

- `Daily` の日幅を `Weekly` と同じ幅に揃えました
- `Daily` / `Weekly` の左右ラベル配置ロジックを見直しました
- ラベル配置判定を共通化し、`Daily` と `Weekly` の差分は設定値で扱う形に整理しました
- ラベル幅の見積りを単純な固定幅計算から、文字種に応じた見積りへ変更しました
- `Daily` の on-bar label で使っていた白背景を除去しました
- 長い label が narrow な on-bar label にならないように調整しました
- `Weekly` では左にはみ出す label を考慮して全体をシフトし、不要な左右余白を減らしました
- `Weekly` の SVG 幅を、描画実体に近い範囲でトリムするようにしました

### プレビュー表示の調整

- SVG プレビュー領域で、`svg` が表示領域の幅を使うように CSS を更新しました

### TODO 更新

- 実装済みだった `excel-io` のフォントサイズ対応に関する古い TODO を削除しました
- `Overview` の label placement 調査で追加したデバッグ関数や判断ログ用コードの整理を検討する TODO を追加しました

## テスト

- `tests/mikuproject-main.test.js` に、少なくとも次の観点を追加しました
  - 長い `Daily` task label が on-bar label にならないこと
  - `Daily` で中央以降の label が左側配置になること

## 更新ファイル

- `src/ts/wbs-svg.ts`
- `src/js/wbs-svg.js`
- `src/css/app.css`
- `mikuproject.html`
- `tests/mikuproject-main.test.js`
- `docs/TODO.md`