### PR TITLE
Patch JSON の `update_task` first cut 取込を実装し、AI JSON 連携仕様を更新

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -35,7 +35,12 @@
 - `task_edit_view` の projection を実装する
 - `.editjson` の import で現状 `project_draft_view` だけを受けている制約を見直し、将来の `task_edit_view` / Patch JSON など他の `view_type` も扱えるようにする
 - 既存 project 向け Patch JSON の schema を具体化する
+- 既存 project 向け Patch JSON について、少なくとも `update_task` を含む最小 operation set の設計メモを `md` で固める
+- 既存 project 向け Patch JSON を生成AIへ返させるための prompt / rules / 出力例を `md` で整備する
+- 既存 project 向け Patch JSON で、`predecessors` を `update_task.fields` に含めるか、`link_tasks / unlink_tasks` に分離するかを明確化する
 - Patch JSON を内部モデルへ適用する処理を実装する
+- Patch JSON の読込導線と、`project_draft_view` との判別 UI / status message / 差分要約表示を整備する
+- Patch JSON の正常系・異常系・validation・round-trip 観点のテストを追加する
 - Patch JSON import 後の validation と差分要約 UI を実装する
 - import 前後で、どの `task / calendar / assignment` がどう変わったかを見やすく確認できる差分可視化を追加する
 - 差分適用を前提として、生成AI や外部編集結果を全件置換ではなく部分適用できる運用を強化する

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,9 +93,10 @@
 - 既存 project 向けには `project_overview_view` と `phase_detail_view` を出力する
 - 既存 project 向けには `full bundle` も出力できる
 - 新規生成向けには、生成AIが返した `project_draft_view` を取り込める
+- 既存 project 向けには、Patch JSON の `update_task` first cut を取り込める
 - `mikuproject_workbook_json` は `.json`、生成AI 向け編集用 JSON は `.editjson` を推奨拡張子とする
-- 現時点で UI から実装済みなのは `project_overview_view` / `phase_detail_view` / `full bundle` の出力と `project_draft_view` の取込である
-- `task_edit_view` と Patch JSON 適用は設計メモ段階で、まだ実装していない
+- 現時点で UI から実装済みなのは `project_overview_view` / `phase_detail_view` / `full bundle` の出力、`project_draft_view` の取込、Patch JSON の `update_task` first cut の取込である
+- `task_edit_view` と、Patch JSON の `move_task` / `link_tasks` / `unlink_tasks` / `add_task` / `delete_task` は設計メモ段階で、まだ実装していない
 
 詳細な考え方は `docs/mikuproject-ai-json-spec.md` と `docs/msprojectxml-ai-integration.md` に置く。
 

--- a/docs/mikuproject-ai-json-spec.md
+++ b/docs/mikuproject-ai-json-spec.md
@@ -1,5 +1,9 @@
 # mikuproject AI JSON Prompt / Spec
 
+この文書は、`mikuproject AI JSON Prompt / Spec` の定義である。
+
+- Version: `v20260402`
+
 私たちは、これから取り組むプロジェクトの内容を理解し、WBS の観点から必要なマイルストーン / フェーズ / タスクを整理し、`mikuproject` に設定するための入力へ落とし込んでいきます。
 
 `mikuproject` は、`MS Project XML` を基軸に、変換・可視化・限定編集を行う single-file web app です。
@@ -19,15 +23,16 @@
 - 実装済み: `project_overview_view` の export
 - 実装済み: `phase_detail_view` の export
 - 実装済み: `project_draft_view` の import
+- 実装済み: Patch JSON の `update_task` first cut import / 適用
 - 未実装: `task_edit_view`
-- 未実装: Patch JSON の import / 適用
 - `project_draft_request` は補助的な構想・helper であり、現行 UI の主機能ではありません
 
 ## 前提
 
 - AI へ渡される入力は用途別 projection JSON です
 - AI は説明文を返してよいです
-- 既存編集向けの Patch JSON は将来案として設計中です
+- 既存編集向けの Patch JSON は `update_task` の first cut を実装済みです
+- ただし `move_task` / `link_tasks` / `unlink_tasks` / `add_task` / `delete_task` は未実装です
 - `MS Project XML` は保存と互換のための外部形式ですが、AI は直接扱いません
 - workbook JSON と AI 向け編集用 JSON を混同しないため、当面 `project_draft_view` などの編集用 JSON には `.editjson` 拡張子を推奨します
 
@@ -39,6 +44,9 @@
 - 与えられた projection と rules の範囲を超えて変更してはいけません
 - 業務意味が不明な場合、断定的な再設計は避けてください
 - 業務意味が不明な変更は候補案として扱ってください
+- 非稼働日ルールは原則として尊重します
+- ただし、人間が明示的に「この日は稼働日無視でよい」と指示した場合は、その指示を優先してよいです
+- 稼働日無視の例外を適用した場合は、その旨を説明文に明記してください
 
 ## Projection JSON の代表例
 
@@ -234,7 +242,9 @@
       "name": "要件定義",
       "parent_uid": null,
       "position": 0,
-      "is_summary": true
+      "is_summary": true,
+      "planned_start": "2026-04-01",
+      "planned_finish": "2026-04-10"
     }
   ],
   "assignments": [
@@ -260,6 +270,13 @@
 
 - `uid` は常に string です
 - `parent_uid`, `from_uid`, `to_uid`, `task_uid` も常に string です
+
+### calendar の前提
+
+- `calendar_uid = "1"` は、既定の `Standard` calendar を指します
+- 既定の `Standard` calendar では、土曜日と日曜日を非稼働日として扱います
+- task や resource に個別 `calendar_uid` がない場合は、project 既定 calendar を継承する前提で扱います
+- したがって、通常 task の日付を考えるときは、まず `calendar_uid = "1"` の土日非稼働を前提にしてよいです
 
 ### 日付・期間
 
@@ -328,12 +345,61 @@
 - 親子や順序の変更は `move_task` を使います
 - 依存関係の追加や解除は `link_tasks` / `unlink_tasks` を使います
 
+### Patch JSON の MVP 方針
+
+- 最初の import 実装では、既存 project 向け Patch JSON の最小対応として `update_task` から着手します
+- MVP では `operations` 配列を順に適用します
+- MVP では、少なくとも `uid` で対象 task を特定できることを前提にします
+- MVP で受ける `fields` は、まず次のような task の基本計画項目に絞る方針です
+  - `name`
+  - `planned_start`
+  - `planned_finish`
+  - `planned_duration`
+  - `planned_duration_hours`
+- MVP では、`move_task` / `link_tasks` / `unlink_tasks` は schema 上の設計候補として残してよいですが、import 実装の first cut では未対応でもよいです
+- MVP では、`add_task` / `delete_task` も first cut の import 実装対象には含めません
+- MVP では、既存 task の安全な部分更新を優先し、`update_task` のみに絞る方針を推奨します
+- `add_task` は早い段階で欲しくなる可能性がありますが、`uid` 採番、親子位置、summary 構造、依存関係などの整合を要するため、MVP からは外します
+- `delete_task` は子 task、assignment、dependency などを壊しやすいため、MVP では扱わない方針を推奨します
+- MVP では、未対応 `op` は静かに無視せず、少なくとも warning または error として扱う方針です
+- MVP では、存在しない `uid`、不正日付、不正 field 名は validation 対象とします
+- MVP では、未指定 field は変更なしとして扱います
+- MVP では、Patch JSON は既存 project への部分適用であり、新規 project 草案の全量置換には使いません
+- MVP では、Patch JSON による `planned_start` / `planned_finish` の更新は、原則として非稼働日を避ける前提です
+- ただし、人間が明示的に非稼働日での作業を指示した場合は、その指示を優先してよいです
+- 例外適用時は、説明文で「非稼働日ルールより人間指示を優先した」ことを明示してください
+
+### Patch JSON の MVP 例
+
+```json
+{
+  "operations": [
+    {
+      "op": "update_task",
+      "uid": "101",
+      "fields": {
+        "planned_start": "2026-04-03",
+        "planned_finish": "2026-04-06"
+      }
+    }
+  ]
+}
+```
+
 ### 新規生成モードの原則
 
 - `project_draft_request` に対する返答は `project_draft_view` です
 - このとき `Patch JSON` は返しません
 - draft は正本ではなく草案です
 - draft 内の `uid` は `"draft-1"` のような仮 UID でよいです
+- 新規生成モードでは、非稼働日を厳密に考慮しなくてもかまいません
+- 新規生成モードでは、まず phase / milestone / task の構造と大まかな順序を優先します
+- 新規生成モードでも、可能なら仮の `planned_start` / `planned_finish` を task に入れてください
+- この仮日付は通常 task だけでなく、summary task と milestone にも入れてよいです
+- summary task には、その配下 task を大まかに包む期間を仮で入れてください
+- milestone には、その節目の日付を仮で入れてください
+- 人間が「とりあえずえいやで日付を入れてよい」と指示している場合は、細かい整合よりもまず日付を埋めることを優先してよいです
+- 新規生成後の稼働日・祝日を考慮した再計画は、後続の Patch JSON で行う想定です
 - `percent_complete` を含めてよいです
 - task が通常 task で、`planned_start` / `planned_finish` が日付だけの場合、`mikuproject` 側では勤務時間帯を補完して扱うことがあります
 - 同日 task の date-only 指定は、通常 task なら `09:00:00` 開始 / `18:00:00` 終了へ補完されることがあります

--- a/docs/msprojectxml-ai-integration.md
+++ b/docs/msprojectxml-ai-integration.md
@@ -9,8 +9,9 @@
 - 実装済み: `project_overview_view` export
 - 実装済み: `phase_detail_view` export
 - 実装済み: `project_draft_view` import
+- 実装済み: Patch JSON の `update_task` first cut import
 - 未実装: `task_edit_view`
-- 未実装: Patch JSON の受信・適用
+- 未実装: Patch JSON の `move_task` / `link_tasks` / `unlink_tasks` / `add_task` / `delete_task`
 
 この設計では、生成AIとの会話は `JSON` ベースで行う方針とする。
 
@@ -30,7 +31,7 @@
 - AIの編集結果を、安全かつ検証可能な形で受け取る
 - `MS Project XML` との互換性を維持する
 
-なお、現時点の UI で扱える生成AI連携は、既存 project に対する `project_overview_view` / `phase_detail_view` の保存と、新規草案として返ってきた `project_draft_view` の取込までである。
+なお、現時点の UI で扱える生成AI連携は、既存 project に対する `project_overview_view` / `phase_detail_view` の保存、Patch JSON の `update_task` first cut 取込、新規草案として返ってきた `project_draft_view` の取込までである。
 
 ## 最重要方針
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -457,7 +457,39 @@ preview / validation の現状メモ:
 
 - 既存 project 向けには `project_overview_view` / `phase_detail_view` / `full bundle` の export を持つ
 - 新規生成向けには `project_draft_view` の import を持つ
-- `task_edit_view` の export と Patch JSON の import / 適用は、現時点では未実装とする
+- 既存 project 向けには Patch JSON の `update_task` first cut import / 適用を持つ
+- `task_edit_view` の export は、現時点では未実装とする
+- Patch JSON のうち `move_task` / `link_tasks` / `unlink_tasks` / `add_task` / `delete_task` は、現時点では未実装とする
+
+Patch JSON の次段 MVP 方針:
+
+- 既存 project 向けの AI 返却形式として `Patch JSON` を将来追加する
+- first cut は `operations` 配列を持つ部分適用 JSON とする
+- first cut では、少なくとも `update_task` の import / 適用から着手する
+- first cut では、対象 task は `uid` で特定する
+- first cut では、task の基本計画項目
+  - `name`
+  - `planned_start`
+  - `planned_finish`
+  - `planned_duration`
+  - `planned_duration_hours`
+  を優先して扱う
+- first cut では、`update_task` に絞る方針を推奨する
+- `add_task` は将来候補として残すが、`uid` 採番、親子位置、summary 構造、依存関係の整合が必要なため、first cut からは外す
+- `delete_task` は破壊範囲が大きいため、first cut からは外す
+- `move_task` / `link_tasks` / `unlink_tasks` は設計上の候補として残すが、first cut の実装対象とは限らない
+- 未知 `op`、存在しない `uid`、不正 field、不正日付は validation または import warning/error の対象とする
+- `project_draft_view` は新規草案作成を優先するため、非稼働日を厳密に考慮しなくてもよい
+- `project_draft_view` では、粗い草案でもよいので task に仮の `planned_start` / `planned_finish` を入れてよい
+- この仮日付は通常 task だけでなく、summary task と milestone にも入れてよい
+- summary task には配下 task を大まかに包む期間、milestone には節目の日付を仮で入れる方針を許容する
+- 人間が「とりあえずえいやで日付を入れてよい」と指示している場合は、細かい整合よりも日付充足を優先してよい
+- `calendar_uid = "1"` は既定の `Standard` calendar を指し、土曜日と日曜日を非稼働日として扱う前提とする
+- task / resource に個別 `CalendarUID` がない場合は、project 既定 calendar を継承する前提で扱う
+- 稼働日・祝日を考慮した日付補正は、後続の Patch JSON による再計画で扱う
+- Patch JSON の `planned_start` / `planned_finish` 更新は、原則として非稼働日を避ける前提とする
+- ただし、人間が明示的に非稼働日での実施を指示した場合は、その指示を優先できる
+- 非稼働日ルールより人間指示を優先した場合は、AI 側の説明文でもその例外適用を明示する
 
 ここでいう `Overview` は、内部実装上の `transform` 相当タブを、ユーザー向けに読み替えた呼称である。
 

--- a/mikuproject-src.html
+++ b/mikuproject-src.html
@@ -96,7 +96,7 @@
                   `.xlsx` と `mikuproject_workbook_json (.json)` は `MS Project XML` の代替正本ではなく、確認と限定編集のための周辺表現として扱います。
                 </p>
                 <p class="md-note-card__text">
-                  `project_draft_view (.editjson)` は生成AI 向けの編集用 JSON として扱います。反映結果は、`Project / Tasks / Resources / Assignments / Calendars` ごとの件数と、`UID` 単位の差分要約として画面上に表示します。
+                  `project_draft_view (.editjson)` と Patch JSON は生成AI 向けの編集用 JSON として扱います。反映結果は、`Project / Tasks / Resources / Assignments / Calendars` ごとの件数と、`UID` 単位の差分要約として画面上に表示します。
                 </p>
                 <p class="md-note-card__text"><strong>反映対象</strong></p>
                 <ul class="md-note-list">
@@ -138,7 +138,7 @@
               </div>
               <template id="aiPromptTemplate">{{AI_PROMPT_TEXT}}</template>
               <div class="md-form-grid">
-                <lht-text-field-help field-id="projectDraftImportInput" label="生成AIが返した JSON" rows="14" help-text="生成AIが返した `project_draft_view` の JSON テキストを貼り付けます。最後に json フェンスを持つ応答全体でもかまいません。"></lht-text-field-help>
+                <lht-text-field-help field-id="projectDraftImportInput" label="生成AIが返した JSON" rows="14" help-text="生成AIが返した `project_draft_view` または Patch JSON のテキストを貼り付けます。最後に json フェンスを持つ応答全体でもかまいません。"></lht-text-field-help>
               </div>
             </section>
           </div>
@@ -439,6 +439,7 @@
   <script src="src/js/project-workbook-schema.js"></script>
   <script src="src/js/project-xlsx.js"></script>
   <script src="src/js/project-workbook-json.js"></script>
+  <script src="src/js/project-patch-json.js"></script>
   <script src="src/js/wbs-xlsx.js"></script>
   <script src="src/js/wbs-markdown.js"></script>
   <script src="src/js/wbs-svg.js"></script>

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -2223,7 +2223,7 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
                   `.xlsx` と `mikuproject_workbook_json (.json)` は `MS Project XML` の代替正本ではなく、確認と限定編集のための周辺表現として扱います。
                 </p>
                 <p class="md-note-card__text">
-                  `project_draft_view (.editjson)` は生成AI 向けの編集用 JSON として扱います。反映結果は、`Project / Tasks / Resources / Assignments / Calendars` ごとの件数と、`UID` 単位の差分要約として画面上に表示します。
+                  `project_draft_view (.editjson)` と Patch JSON は生成AI 向けの編集用 JSON として扱います。反映結果は、`Project / Tasks / Resources / Assignments / Calendars` ごとの件数と、`UID` 単位の差分要約として画面上に表示します。
                 </p>
                 <p class="md-note-card__text"><strong>反映対象</strong></p>
                 <ul class="md-note-list">
@@ -2265,6 +2265,10 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
               </div>
               <template id="aiPromptTemplate"># mikuproject AI JSON Prompt / Spec
 
+この文書は、`mikuproject AI JSON Prompt / Spec` の定義である。
+
+- Version: `v20260402`
+
 私たちは、これから取り組むプロジェクトの内容を理解し、WBS の観点から必要なマイルストーン / フェーズ / タスクを整理し、`mikuproject` に設定するための入力へ落とし込んでいきます。
 
 `mikuproject` は、`MS Project XML` を基軸に、変換・可視化・限定編集を行う single-file web app です。
@@ -2284,15 +2288,16 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 - 実装済み: `project_overview_view` の export
 - 実装済み: `phase_detail_view` の export
 - 実装済み: `project_draft_view` の import
+- 実装済み: Patch JSON の `update_task` first cut import / 適用
 - 未実装: `task_edit_view`
-- 未実装: Patch JSON の import / 適用
 - `project_draft_request` は補助的な構想・helper であり、現行 UI の主機能ではありません
 
 ## 前提
 
 - AI へ渡される入力は用途別 projection JSON です
 - AI は説明文を返してよいです
-- 既存編集向けの Patch JSON は将来案として設計中です
+- 既存編集向けの Patch JSON は `update_task` の first cut を実装済みです
+- ただし `move_task` / `link_tasks` / `unlink_tasks` / `add_task` / `delete_task` は未実装です
 - `MS Project XML` は保存と互換のための外部形式ですが、AI は直接扱いません
 - workbook JSON と AI 向け編集用 JSON を混同しないため、当面 `project_draft_view` などの編集用 JSON には `.editjson` 拡張子を推奨します
 
@@ -2304,6 +2309,9 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 - 与えられた projection と rules の範囲を超えて変更してはいけません
 - 業務意味が不明な場合、断定的な再設計は避けてください
 - 業務意味が不明な変更は候補案として扱ってください
+- 非稼働日ルールは原則として尊重します
+- ただし、人間が明示的に「この日は稼働日無視でよい」と指示した場合は、その指示を優先してよいです
+- 稼働日無視の例外を適用した場合は、その旨を説明文に明記してください
 
 ## Projection JSON の代表例
 
@@ -2499,7 +2507,9 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
       "name": "要件定義",
       "parent_uid": null,
       "position": 0,
-      "is_summary": true
+      "is_summary": true,
+      "planned_start": "2026-04-01",
+      "planned_finish": "2026-04-10"
     }
   ],
   "assignments": [
@@ -2525,6 +2535,13 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 
 - `uid` は常に string です
 - `parent_uid`, `from_uid`, `to_uid`, `task_uid` も常に string です
+
+### calendar の前提
+
+- `calendar_uid = "1"` は、既定の `Standard` calendar を指します
+- 既定の `Standard` calendar では、土曜日と日曜日を非稼働日として扱います
+- task や resource に個別 `calendar_uid` がない場合は、project 既定 calendar を継承する前提で扱います
+- したがって、通常 task の日付を考えるときは、まず `calendar_uid = "1"` の土日非稼働を前提にしてよいです
 
 ### 日付・期間
 
@@ -2593,12 +2610,61 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 - 親子や順序の変更は `move_task` を使います
 - 依存関係の追加や解除は `link_tasks` / `unlink_tasks` を使います
 
+### Patch JSON の MVP 方針
+
+- 最初の import 実装では、既存 project 向け Patch JSON の最小対応として `update_task` から着手します
+- MVP では `operations` 配列を順に適用します
+- MVP では、少なくとも `uid` で対象 task を特定できることを前提にします
+- MVP で受ける `fields` は、まず次のような task の基本計画項目に絞る方針です
+  - `name`
+  - `planned_start`
+  - `planned_finish`
+  - `planned_duration`
+  - `planned_duration_hours`
+- MVP では、`move_task` / `link_tasks` / `unlink_tasks` は schema 上の設計候補として残してよいですが、import 実装の first cut では未対応でもよいです
+- MVP では、`add_task` / `delete_task` も first cut の import 実装対象には含めません
+- MVP では、既存 task の安全な部分更新を優先し、`update_task` のみに絞る方針を推奨します
+- `add_task` は早い段階で欲しくなる可能性がありますが、`uid` 採番、親子位置、summary 構造、依存関係などの整合を要するため、MVP からは外します
+- `delete_task` は子 task、assignment、dependency などを壊しやすいため、MVP では扱わない方針を推奨します
+- MVP では、未対応 `op` は静かに無視せず、少なくとも warning または error として扱う方針です
+- MVP では、存在しない `uid`、不正日付、不正 field 名は validation 対象とします
+- MVP では、未指定 field は変更なしとして扱います
+- MVP では、Patch JSON は既存 project への部分適用であり、新規 project 草案の全量置換には使いません
+- MVP では、Patch JSON による `planned_start` / `planned_finish` の更新は、原則として非稼働日を避ける前提です
+- ただし、人間が明示的に非稼働日での作業を指示した場合は、その指示を優先してよいです
+- 例外適用時は、説明文で「非稼働日ルールより人間指示を優先した」ことを明示してください
+
+### Patch JSON の MVP 例
+
+```json
+{
+  "operations": [
+    {
+      "op": "update_task",
+      "uid": "101",
+      "fields": {
+        "planned_start": "2026-04-03",
+        "planned_finish": "2026-04-06"
+      }
+    }
+  ]
+}
+```
+
 ### 新規生成モードの原則
 
 - `project_draft_request` に対する返答は `project_draft_view` です
 - このとき `Patch JSON` は返しません
 - draft は正本ではなく草案です
 - draft 内の `uid` は `"draft-1"` のような仮 UID でよいです
+- 新規生成モードでは、非稼働日を厳密に考慮しなくてもかまいません
+- 新規生成モードでは、まず phase / milestone / task の構造と大まかな順序を優先します
+- 新規生成モードでも、可能なら仮の `planned_start` / `planned_finish` を task に入れてください
+- この仮日付は通常 task だけでなく、summary task と milestone にも入れてよいです
+- summary task には、その配下 task を大まかに包む期間を仮で入れてください
+- milestone には、その節目の日付を仮で入れてください
+- 人間が「とりあえずえいやで日付を入れてよい」と指示している場合は、細かい整合よりもまず日付を埋めることを優先してよいです
+- 新規生成後の稼働日・祝日を考慮した再計画は、後続の Patch JSON で行う想定です
 - `percent_complete` を含めてよいです
 - task が通常 task で、`planned_start` / `planned_finish` が日付だけの場合、`mikuproject` 側では勤務時間帯を補完して扱うことがあります
 - 同日 task の date-only 指定は、通常 task なら `09:00:00` 開始 / `18:00:00` 終了へ補完されることがあります
@@ -2681,7 +2747,7 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
 - phase 定義は当面 `top-level summary task` 固定ですが、将来的にはより柔軟な定義へ拡張する余地があります
 </template>
               <div class="md-form-grid">
-                <lht-text-field-help field-id="projectDraftImportInput" label="生成AIが返した JSON" rows="14" help-text="生成AIが返した `project_draft_view` の JSON テキストを貼り付けます。最後に json フェンスを持つ応答全体でもかまいません。"></lht-text-field-help>
+                <lht-text-field-help field-id="projectDraftImportInput" label="生成AIが返した JSON" rows="14" help-text="生成AIが返した `project_draft_view` または Patch JSON のテキストを貼り付けます。最後に json フェンスを持つ応答全体でもかまいません。"></lht-text-field-help>
               </div>
             </section>
           </div>
@@ -2975,6 +3041,7 @@ md-outlined-select.md-outlined-field:focus-within::part(container) {
     <lht-toast id="toast"></lht-toast>
   </div>
   </main>
+  
   
   
   
@@ -11428,6 +11495,235 @@ if (!customElements.get("lht-page-menu")) {
  * SPDX-License-Identifier: Apache-2.0
  */
 (() => {
+    const mikuprojectXml = globalThis.__mikuprojectXml;
+    if (!mikuprojectXml) {
+        throw new Error("mikuproject XML module is not loaded");
+    }
+    function importProjectPatchJson(documentLike, baseModel) {
+        const validation = validatePatchDocument(documentLike);
+        const nextModel = cloneProjectModel(baseModel);
+        const changes = [];
+        const warnings = [...validation.warnings];
+        const taskByUid = new Map(nextModel.tasks.map((task) => [task.uid, task]));
+        validation.document.operations.forEach((operation, index) => {
+            const op = String(operation.op || "").trim();
+            if (op !== "update_task") {
+                warnings.push({ message: `未対応の op は無視します: operations[${index}].op = ${op || "(empty)"}` });
+                return;
+            }
+            const uid = String(operation.uid || "").trim();
+            if (!uid) {
+                warnings.push({ message: `update_task の uid がありません: operations[${index}]` });
+                return;
+            }
+            const task = taskByUid.get(uid);
+            if (!task) {
+                warnings.push({ message: `update_task の uid が既存 task を指していません: ${uid}` });
+                return;
+            }
+            if (!operation.fields || typeof operation.fields !== "object" || Array.isArray(operation.fields)) {
+                warnings.push({ message: `update_task.fields がオブジェクトではありません: ${uid}` });
+                return;
+            }
+            applyUpdateTaskOperation(task, operation.fields, nextModel.project, changes, warnings, index);
+        });
+        return {
+            model: mikuprojectXml.normalizeProjectModel(nextModel),
+            changes,
+            warnings
+        };
+    }
+    function validatePatchDocument(documentLike) {
+        if (!documentLike || typeof documentLike !== "object" || Array.isArray(documentLike)) {
+            throw new Error("Patch JSON がオブジェクトではありません");
+        }
+        const document = documentLike;
+        if (!Array.isArray(document.operations)) {
+            throw new Error("Patch JSON には operations 配列が必要です");
+        }
+        const warnings = [];
+        document.operations.forEach((operation, index) => {
+            if (!operation || typeof operation !== "object" || Array.isArray(operation)) {
+                throw new Error(`operations[${index}] がオブジェクトではありません`);
+            }
+        });
+        return {
+            document: document,
+            warnings
+        };
+    }
+    function applyUpdateTaskOperation(task, rawFields, project, changes, warnings, operationIndex) {
+        const fields = { ...rawFields };
+        if (Object.keys(fields).length === 0) {
+            warnings.push({ message: `update_task に fields がありません: ${task.uid}` });
+            return;
+        }
+        if (fields.planned_duration !== undefined && fields.planned_duration_hours !== undefined) {
+            warnings.push({ message: `planned_duration と planned_duration_hours が同時指定されたため、planned_duration_hours は無視します: ${task.uid}` });
+            delete fields.planned_duration_hours;
+        }
+        const handledFields = new Set();
+        if (fields.name !== undefined) {
+            handledFields.add("name");
+            if (typeof fields.name !== "string" || fields.name.trim() === "") {
+                warnings.push({ message: `update_task.name は空でない文字列が必要です: ${task.uid}` });
+            }
+            else if (task.name !== fields.name.trim()) {
+                changes.push({
+                    scope: "tasks",
+                    uid: task.uid,
+                    label: task.name || task.uid,
+                    field: "name",
+                    before: task.name,
+                    after: fields.name.trim()
+                });
+                task.name = fields.name.trim();
+            }
+        }
+        if (fields.planned_start !== undefined) {
+            handledFields.add("planned_start");
+            const normalizedStart = normalizePatchedTaskDate(fields.planned_start, "start", task, project);
+            if (normalizedStart === undefined) {
+                warnings.push({ message: `update_task.planned_start の日付形式が解釈できません: ${task.uid}` });
+            }
+            else if (task.start !== normalizedStart) {
+                changes.push({
+                    scope: "tasks",
+                    uid: task.uid,
+                    label: task.name || task.uid,
+                    field: "planned_start",
+                    before: task.start,
+                    after: normalizedStart
+                });
+                task.start = normalizedStart;
+            }
+        }
+        if (fields.planned_finish !== undefined) {
+            handledFields.add("planned_finish");
+            const normalizedFinish = normalizePatchedTaskDate(fields.planned_finish, "finish", task, project);
+            if (normalizedFinish === undefined) {
+                warnings.push({ message: `update_task.planned_finish の日付形式が解釈できません: ${task.uid}` });
+            }
+            else if (task.finish !== normalizedFinish) {
+                changes.push({
+                    scope: "tasks",
+                    uid: task.uid,
+                    label: task.name || task.uid,
+                    field: "planned_finish",
+                    before: task.finish,
+                    after: normalizedFinish
+                });
+                task.finish = normalizedFinish;
+            }
+        }
+        if (fields.planned_duration !== undefined) {
+            handledFields.add("planned_duration");
+            if (typeof fields.planned_duration !== "string" || fields.planned_duration.trim() === "") {
+                warnings.push({ message: `update_task.planned_duration は空でない文字列が必要です: ${task.uid}` });
+            }
+            else if (task.duration !== fields.planned_duration.trim()) {
+                changes.push({
+                    scope: "tasks",
+                    uid: task.uid,
+                    label: task.name || task.uid,
+                    field: "planned_duration",
+                    before: task.duration,
+                    after: fields.planned_duration.trim()
+                });
+                task.duration = fields.planned_duration.trim();
+            }
+        }
+        if (fields.planned_duration_hours !== undefined) {
+            handledFields.add("planned_duration_hours");
+            if (typeof fields.planned_duration_hours !== "number" || !Number.isFinite(fields.planned_duration_hours) || fields.planned_duration_hours < 0) {
+                warnings.push({ message: `update_task.planned_duration_hours は 0 以上の数値が必要です: ${task.uid}` });
+            }
+            else {
+                const beforeHours = parseDurationHours(task.duration);
+                const nextDuration = formatDurationHours(fields.planned_duration_hours);
+                if (task.duration !== nextDuration) {
+                    changes.push({
+                        scope: "tasks",
+                        uid: task.uid,
+                        label: task.name || task.uid,
+                        field: "planned_duration_hours",
+                        before: beforeHours,
+                        after: fields.planned_duration_hours
+                    });
+                    task.duration = nextDuration;
+                }
+            }
+        }
+        Object.keys(fields).forEach((fieldName) => {
+            if (handledFields.has(fieldName)) {
+                return;
+            }
+            warnings.push({ message: `未対応の field は無視します: operations[${operationIndex}].fields.${fieldName}` });
+        });
+    }
+    function normalizePatchedTaskDate(value, kind, task, project) {
+        if (typeof value !== "string") {
+            return undefined;
+        }
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return undefined;
+        }
+        if (!isDateText(trimmed)) {
+            return undefined;
+        }
+        if (isDateOnlyText(trimmed) && !task.milestone) {
+            const timeText = kind === "start"
+                ? (project.defaultStartTime || "09:00:00")
+                : (project.defaultFinishTime || "18:00:00");
+            return `${trimmed}T${timeText}`;
+        }
+        return trimmed;
+    }
+    function isDateOnlyText(value) {
+        return /^\d{4}-\d{2}-\d{2}$/.test(value);
+    }
+    function isDateText(value) {
+        if (isDateOnlyText(value)) {
+            return true;
+        }
+        return !Number.isNaN(new Date(value).getTime());
+    }
+    function formatDurationHours(hours) {
+        const totalSeconds = Math.round(hours * 60 * 60);
+        const normalizedSeconds = Math.max(0, totalSeconds);
+        const durationHours = Math.floor(normalizedSeconds / 3600);
+        const durationMinutes = Math.floor((normalizedSeconds % 3600) / 60);
+        const durationSeconds = normalizedSeconds % 60;
+        return `PT${durationHours}H${durationMinutes}M${durationSeconds}S`;
+    }
+    function parseDurationHours(duration) {
+        const text = String(duration || "").trim();
+        const match = text.match(/^PT(?:(\d+(?:\.\d+)?)H)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)S)?$/);
+        if (!match) {
+            return undefined;
+        }
+        const hours = Number(match[1] || 0);
+        const minutes = Number(match[2] || 0);
+        const seconds = Number(match[3] || 0);
+        return hours + (minutes / 60) + (seconds / 3600);
+    }
+    function cloneProjectModel(model) {
+        return JSON.parse(JSON.stringify(model));
+    }
+    globalThis.__mikuprojectProjectPatchJson = {
+        importProjectPatchJson,
+        validatePatchDocument
+    };
+})();
+  </script>
+
+  <script>
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+(() => {
     const HEADER_FILL = "#D9EAF7";
     const HEADER_ID_FILL = "#E1EDF8";
     const HEADER_STRUCTURE_FILL = "#E6F0DF";
@@ -14036,6 +14332,10 @@ if (!customElements.get("lht-page-menu")) {
     if (!mikuprojectProjectWorkbookJson) {
         throw new Error("mikuproject Project Workbook JSON module is not loaded");
     }
+    const mikuprojectProjectPatchJson = globalThis.__mikuprojectProjectPatchJson;
+    if (!mikuprojectProjectPatchJson) {
+        throw new Error("mikuproject Project Patch JSON module is not loaded");
+    }
     const mikuprojectWbsXlsx = globalThis.__mikuprojectWbsXlsx;
     if (!mikuprojectWbsXlsx) {
         throw new Error("mikuproject WBS XLSX module is not loaded");
@@ -15040,6 +15340,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         if (candidate.view_type === "project_draft_view") {
             return "project_draft_view";
         }
+        if (Array.isArray(candidate.operations)) {
+            return "patch_json";
+        }
         return undefined;
     }
     async function importProjectDraftFromText() {
@@ -15060,6 +15363,52 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         setStatus(issues.length > 0 ? `project_draft_view を取り込みました。検証で ${issues.length} 件の問題があります` : "project_draft_view を取り込みました");
         showToast("project_draft_view を取り込みました");
         setActiveTab("transform", { skipTransformRefresh: true });
+    }
+    async function importPatchJsonFromSourceText(sourceText) {
+        const trimmedSourceText = sourceText.trim();
+        if (!trimmedSourceText) {
+            throw new Error("Patch JSON を入力してください");
+        }
+        const documentLike = JSON.parse(extractLastJsonBlock(trimmedSourceText));
+        const baseModel = ensureCurrentModel();
+        const result = mikuprojectProjectPatchJson.importProjectPatchJson(documentLike, baseModel);
+        currentModel = result.model;
+        const issues = mikuprojectXml.validateProjectModel(currentModel);
+        updateSummary(currentModel);
+        renderValidationIssues(issues);
+        renderImportWarnings(result.warnings);
+        renderXlsxImportSummary(result.changes);
+        if (result.changes.length > 0) {
+            getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
+            markXmlDirty();
+        }
+        isXmlSourceDirty = false;
+        const summaryText = result.changes.length > 0
+            ? `Patch JSON を読み込んで ${result.changes.length} 件の変更を反映しました。XML は再生成済みで、必要なら XML Export で保存できます`
+            : "Patch JSON に反映対象の変更はありませんでした。XML は未変更です";
+        const warningText = result.warnings.length > 0 ? `。Patch JSON 取込で ${result.warnings.length} 件の warning を無視しました` : "";
+        setStatus(issues.length > 0 ? `${summaryText}${warningText}。検証で ${issues.length} 件の問題があります` : `${summaryText}${warningText}`);
+        showToast("Patch JSON を反映しました");
+        setActiveTab("transform", { skipTransformRefresh: true });
+        await exportCurrentMermaid({ silent: true });
+    }
+    async function importAiEditJsonFromText() {
+        const sourceText = getTextArea("projectDraftImportInput").value.trim();
+        if (!sourceText) {
+            throw new Error("project_draft_view または Patch JSON を入力してください");
+        }
+        const jsonText = extractLastJsonBlock(sourceText);
+        const documentLike = JSON.parse(jsonText);
+        const kind = detectJsonDocumentKind(documentLike);
+        if (kind === "project_draft_view") {
+            await importProjectDraftFromText();
+            return;
+        }
+        if (kind === "patch_json") {
+            await importPatchJsonFromSourceText(sourceText);
+            return;
+        }
+        throw new Error("project_draft_view または Patch JSON を入力してください");
     }
     function loadProjectDraftSample() {
         const sampleDraftText = JSON.stringify(mikuprojectXml.SAMPLE_PROJECT_DRAFT_VIEW, null, 2);
@@ -15128,7 +15477,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             return;
         }
         if (normalizedName.endsWith(".editjson")) {
-            await importProjectDraftFromFile(file);
+            const sourceText = await file.text();
+            getTextArea("projectDraftImportInput").value = sourceText;
+            await importAiEditJsonFromText();
             return;
         }
         if (normalizedName.endsWith(".json")) {
@@ -15144,7 +15495,12 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
                 await importProjectDraftFromText();
                 return;
             }
-            throw new Error("JSON の format / view_type を判別できません。workbook JSON か project_draft_view を指定してください");
+            if (kind === "patch_json") {
+                getTextArea("projectDraftImportInput").value = sourceText;
+                await importPatchJsonFromSourceText(sourceText);
+                return;
+            }
+            throw new Error("JSON の format / view_type を判別できません。workbook JSON、project_draft_view、または Patch JSON を指定してください");
         }
         throw new Error("対応していないファイル形式です。.xml / .xlsx / .json / .editjson / .csv を指定してください");
     }
@@ -15537,10 +15893,10 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         });
         getElement("importProjectDraftBtn").addEventListener("click", async () => {
             try {
-                await importProjectDraftFromText();
+                await importAiEditJsonFromText();
             }
             catch (error) {
-                setStatus(error instanceof Error ? error.message : "project_draft_view 取り込みに失敗しました");
+                setStatus(error instanceof Error ? error.message : "編集用 JSON 取り込みに失敗しました");
             }
         });
         getElement("exportPhaseDetailBtn").addEventListener("click", () => {

--- a/scripts/build-project.mjs
+++ b/scripts/build-project.mjs
@@ -25,6 +25,7 @@ const TARGETS = [
       "src/ts/project-workbook-schema.ts",
       "src/ts/project-xlsx.ts",
       "src/ts/project-workbook-json.ts",
+      "src/ts/project-patch-json.ts",
       "src/ts/wbs-xlsx.ts",
       "src/ts/wbs-markdown.ts",
       "src/ts/wbs-svg.ts",

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -19,6 +19,10 @@
     if (!mikuprojectProjectWorkbookJson) {
         throw new Error("mikuproject Project Workbook JSON module is not loaded");
     }
+    const mikuprojectProjectPatchJson = globalThis.__mikuprojectProjectPatchJson;
+    if (!mikuprojectProjectPatchJson) {
+        throw new Error("mikuproject Project Patch JSON module is not loaded");
+    }
     const mikuprojectWbsXlsx = globalThis.__mikuprojectWbsXlsx;
     if (!mikuprojectWbsXlsx) {
         throw new Error("mikuproject WBS XLSX module is not loaded");
@@ -1023,6 +1027,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         if (candidate.view_type === "project_draft_view") {
             return "project_draft_view";
         }
+        if (Array.isArray(candidate.operations)) {
+            return "patch_json";
+        }
         return undefined;
     }
     async function importProjectDraftFromText() {
@@ -1043,6 +1050,52 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         setStatus(issues.length > 0 ? `project_draft_view を取り込みました。検証で ${issues.length} 件の問題があります` : "project_draft_view を取り込みました");
         showToast("project_draft_view を取り込みました");
         setActiveTab("transform", { skipTransformRefresh: true });
+    }
+    async function importPatchJsonFromSourceText(sourceText) {
+        const trimmedSourceText = sourceText.trim();
+        if (!trimmedSourceText) {
+            throw new Error("Patch JSON を入力してください");
+        }
+        const documentLike = JSON.parse(extractLastJsonBlock(trimmedSourceText));
+        const baseModel = ensureCurrentModel();
+        const result = mikuprojectProjectPatchJson.importProjectPatchJson(documentLike, baseModel);
+        currentModel = result.model;
+        const issues = mikuprojectXml.validateProjectModel(currentModel);
+        updateSummary(currentModel);
+        renderValidationIssues(issues);
+        renderImportWarnings(result.warnings);
+        renderXlsxImportSummary(result.changes);
+        if (result.changes.length > 0) {
+            getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
+            markXmlDirty();
+        }
+        isXmlSourceDirty = false;
+        const summaryText = result.changes.length > 0
+            ? `Patch JSON を読み込んで ${result.changes.length} 件の変更を反映しました。XML は再生成済みで、必要なら XML Export で保存できます`
+            : "Patch JSON に反映対象の変更はありませんでした。XML は未変更です";
+        const warningText = result.warnings.length > 0 ? `。Patch JSON 取込で ${result.warnings.length} 件の warning を無視しました` : "";
+        setStatus(issues.length > 0 ? `${summaryText}${warningText}。検証で ${issues.length} 件の問題があります` : `${summaryText}${warningText}`);
+        showToast("Patch JSON を反映しました");
+        setActiveTab("transform", { skipTransformRefresh: true });
+        await exportCurrentMermaid({ silent: true });
+    }
+    async function importAiEditJsonFromText() {
+        const sourceText = getTextArea("projectDraftImportInput").value.trim();
+        if (!sourceText) {
+            throw new Error("project_draft_view または Patch JSON を入力してください");
+        }
+        const jsonText = extractLastJsonBlock(sourceText);
+        const documentLike = JSON.parse(jsonText);
+        const kind = detectJsonDocumentKind(documentLike);
+        if (kind === "project_draft_view") {
+            await importProjectDraftFromText();
+            return;
+        }
+        if (kind === "patch_json") {
+            await importPatchJsonFromSourceText(sourceText);
+            return;
+        }
+        throw new Error("project_draft_view または Patch JSON を入力してください");
     }
     function loadProjectDraftSample() {
         const sampleDraftText = JSON.stringify(mikuprojectXml.SAMPLE_PROJECT_DRAFT_VIEW, null, 2);
@@ -1111,7 +1164,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             return;
         }
         if (normalizedName.endsWith(".editjson")) {
-            await importProjectDraftFromFile(file);
+            const sourceText = await file.text();
+            getTextArea("projectDraftImportInput").value = sourceText;
+            await importAiEditJsonFromText();
             return;
         }
         if (normalizedName.endsWith(".json")) {
@@ -1127,7 +1182,12 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
                 await importProjectDraftFromText();
                 return;
             }
-            throw new Error("JSON の format / view_type を判別できません。workbook JSON か project_draft_view を指定してください");
+            if (kind === "patch_json") {
+                getTextArea("projectDraftImportInput").value = sourceText;
+                await importPatchJsonFromSourceText(sourceText);
+                return;
+            }
+            throw new Error("JSON の format / view_type を判別できません。workbook JSON、project_draft_view、または Patch JSON を指定してください");
         }
         throw new Error("対応していないファイル形式です。.xml / .xlsx / .json / .editjson / .csv を指定してください");
     }
@@ -1520,10 +1580,10 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         });
         getElement("importProjectDraftBtn").addEventListener("click", async () => {
             try {
-                await importProjectDraftFromText();
+                await importAiEditJsonFromText();
             }
             catch (error) {
-                setStatus(error instanceof Error ? error.message : "project_draft_view 取り込みに失敗しました");
+                setStatus(error instanceof Error ? error.message : "編集用 JSON 取り込みに失敗しました");
             }
         });
         getElement("exportPhaseDetailBtn").addEventListener("click", () => {

--- a/src/js/project-patch-json.js
+++ b/src/js/project-patch-json.js
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+(() => {
+    const mikuprojectXml = globalThis.__mikuprojectXml;
+    if (!mikuprojectXml) {
+        throw new Error("mikuproject XML module is not loaded");
+    }
+    function importProjectPatchJson(documentLike, baseModel) {
+        const validation = validatePatchDocument(documentLike);
+        const nextModel = cloneProjectModel(baseModel);
+        const changes = [];
+        const warnings = [...validation.warnings];
+        const taskByUid = new Map(nextModel.tasks.map((task) => [task.uid, task]));
+        validation.document.operations.forEach((operation, index) => {
+            const op = String(operation.op || "").trim();
+            if (op !== "update_task") {
+                warnings.push({ message: `未対応の op は無視します: operations[${index}].op = ${op || "(empty)"}` });
+                return;
+            }
+            const uid = String(operation.uid || "").trim();
+            if (!uid) {
+                warnings.push({ message: `update_task の uid がありません: operations[${index}]` });
+                return;
+            }
+            const task = taskByUid.get(uid);
+            if (!task) {
+                warnings.push({ message: `update_task の uid が既存 task を指していません: ${uid}` });
+                return;
+            }
+            if (!operation.fields || typeof operation.fields !== "object" || Array.isArray(operation.fields)) {
+                warnings.push({ message: `update_task.fields がオブジェクトではありません: ${uid}` });
+                return;
+            }
+            applyUpdateTaskOperation(task, operation.fields, nextModel.project, changes, warnings, index);
+        });
+        return {
+            model: mikuprojectXml.normalizeProjectModel(nextModel),
+            changes,
+            warnings
+        };
+    }
+    function validatePatchDocument(documentLike) {
+        if (!documentLike || typeof documentLike !== "object" || Array.isArray(documentLike)) {
+            throw new Error("Patch JSON がオブジェクトではありません");
+        }
+        const document = documentLike;
+        if (!Array.isArray(document.operations)) {
+            throw new Error("Patch JSON には operations 配列が必要です");
+        }
+        const warnings = [];
+        document.operations.forEach((operation, index) => {
+            if (!operation || typeof operation !== "object" || Array.isArray(operation)) {
+                throw new Error(`operations[${index}] がオブジェクトではありません`);
+            }
+        });
+        return {
+            document: document,
+            warnings
+        };
+    }
+    function applyUpdateTaskOperation(task, rawFields, project, changes, warnings, operationIndex) {
+        const fields = { ...rawFields };
+        if (Object.keys(fields).length === 0) {
+            warnings.push({ message: `update_task に fields がありません: ${task.uid}` });
+            return;
+        }
+        if (fields.planned_duration !== undefined && fields.planned_duration_hours !== undefined) {
+            warnings.push({ message: `planned_duration と planned_duration_hours が同時指定されたため、planned_duration_hours は無視します: ${task.uid}` });
+            delete fields.planned_duration_hours;
+        }
+        const handledFields = new Set();
+        if (fields.name !== undefined) {
+            handledFields.add("name");
+            if (typeof fields.name !== "string" || fields.name.trim() === "") {
+                warnings.push({ message: `update_task.name は空でない文字列が必要です: ${task.uid}` });
+            }
+            else if (task.name !== fields.name.trim()) {
+                changes.push({
+                    scope: "tasks",
+                    uid: task.uid,
+                    label: task.name || task.uid,
+                    field: "name",
+                    before: task.name,
+                    after: fields.name.trim()
+                });
+                task.name = fields.name.trim();
+            }
+        }
+        if (fields.planned_start !== undefined) {
+            handledFields.add("planned_start");
+            const normalizedStart = normalizePatchedTaskDate(fields.planned_start, "start", task, project);
+            if (normalizedStart === undefined) {
+                warnings.push({ message: `update_task.planned_start の日付形式が解釈できません: ${task.uid}` });
+            }
+            else if (task.start !== normalizedStart) {
+                changes.push({
+                    scope: "tasks",
+                    uid: task.uid,
+                    label: task.name || task.uid,
+                    field: "planned_start",
+                    before: task.start,
+                    after: normalizedStart
+                });
+                task.start = normalizedStart;
+            }
+        }
+        if (fields.planned_finish !== undefined) {
+            handledFields.add("planned_finish");
+            const normalizedFinish = normalizePatchedTaskDate(fields.planned_finish, "finish", task, project);
+            if (normalizedFinish === undefined) {
+                warnings.push({ message: `update_task.planned_finish の日付形式が解釈できません: ${task.uid}` });
+            }
+            else if (task.finish !== normalizedFinish) {
+                changes.push({
+                    scope: "tasks",
+                    uid: task.uid,
+                    label: task.name || task.uid,
+                    field: "planned_finish",
+                    before: task.finish,
+                    after: normalizedFinish
+                });
+                task.finish = normalizedFinish;
+            }
+        }
+        if (fields.planned_duration !== undefined) {
+            handledFields.add("planned_duration");
+            if (typeof fields.planned_duration !== "string" || fields.planned_duration.trim() === "") {
+                warnings.push({ message: `update_task.planned_duration は空でない文字列が必要です: ${task.uid}` });
+            }
+            else if (task.duration !== fields.planned_duration.trim()) {
+                changes.push({
+                    scope: "tasks",
+                    uid: task.uid,
+                    label: task.name || task.uid,
+                    field: "planned_duration",
+                    before: task.duration,
+                    after: fields.planned_duration.trim()
+                });
+                task.duration = fields.planned_duration.trim();
+            }
+        }
+        if (fields.planned_duration_hours !== undefined) {
+            handledFields.add("planned_duration_hours");
+            if (typeof fields.planned_duration_hours !== "number" || !Number.isFinite(fields.planned_duration_hours) || fields.planned_duration_hours < 0) {
+                warnings.push({ message: `update_task.planned_duration_hours は 0 以上の数値が必要です: ${task.uid}` });
+            }
+            else {
+                const beforeHours = parseDurationHours(task.duration);
+                const nextDuration = formatDurationHours(fields.planned_duration_hours);
+                if (task.duration !== nextDuration) {
+                    changes.push({
+                        scope: "tasks",
+                        uid: task.uid,
+                        label: task.name || task.uid,
+                        field: "planned_duration_hours",
+                        before: beforeHours,
+                        after: fields.planned_duration_hours
+                    });
+                    task.duration = nextDuration;
+                }
+            }
+        }
+        Object.keys(fields).forEach((fieldName) => {
+            if (handledFields.has(fieldName)) {
+                return;
+            }
+            warnings.push({ message: `未対応の field は無視します: operations[${operationIndex}].fields.${fieldName}` });
+        });
+    }
+    function normalizePatchedTaskDate(value, kind, task, project) {
+        if (typeof value !== "string") {
+            return undefined;
+        }
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return undefined;
+        }
+        if (!isDateText(trimmed)) {
+            return undefined;
+        }
+        if (isDateOnlyText(trimmed) && !task.milestone) {
+            const timeText = kind === "start"
+                ? (project.defaultStartTime || "09:00:00")
+                : (project.defaultFinishTime || "18:00:00");
+            return `${trimmed}T${timeText}`;
+        }
+        return trimmed;
+    }
+    function isDateOnlyText(value) {
+        return /^\d{4}-\d{2}-\d{2}$/.test(value);
+    }
+    function isDateText(value) {
+        if (isDateOnlyText(value)) {
+            return true;
+        }
+        return !Number.isNaN(new Date(value).getTime());
+    }
+    function formatDurationHours(hours) {
+        const totalSeconds = Math.round(hours * 60 * 60);
+        const normalizedSeconds = Math.max(0, totalSeconds);
+        const durationHours = Math.floor(normalizedSeconds / 3600);
+        const durationMinutes = Math.floor((normalizedSeconds % 3600) / 60);
+        const durationSeconds = normalizedSeconds % 60;
+        return `PT${durationHours}H${durationMinutes}M${durationSeconds}S`;
+    }
+    function parseDurationHours(duration) {
+        const text = String(duration || "").trim();
+        const match = text.match(/^PT(?:(\d+(?:\.\d+)?)H)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)S)?$/);
+        if (!match) {
+            return undefined;
+        }
+        const hours = Number(match[1] || 0);
+        const minutes = Number(match[2] || 0);
+        const seconds = Number(match[3] || 0);
+        return hours + (minutes / 60) + (seconds / 3600);
+    }
+    function cloneProjectModel(model) {
+        return JSON.parse(JSON.stringify(model));
+    }
+    globalThis.__mikuprojectProjectPatchJson = {
+        importProjectPatchJson,
+        validatePatchDocument
+    };
+})();

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -106,6 +106,35 @@
     throw new Error("mikuproject Project Workbook JSON module is not loaded");
   }
 
+  const mikuprojectProjectPatchJson = (globalThis as typeof globalThis & {
+    __mikuprojectProjectPatchJson?: {
+      importProjectPatchJson: (documentLike: unknown, baseModel: ProjectModel) => {
+        model: ProjectModel;
+        changes: Array<{
+          scope: "project" | "tasks" | "resources" | "assignments" | "calendars";
+          uid: string;
+          label: string;
+          field: string;
+          before: string | number | boolean | undefined;
+          after: string | number | boolean;
+        }>;
+        warnings: Array<{
+          message: string;
+        }>;
+      };
+      validatePatchDocument: (documentLike: unknown) => {
+        document: unknown;
+        warnings: Array<{
+          message: string;
+        }>;
+      };
+    };
+  }).__mikuprojectProjectPatchJson;
+
+  if (!mikuprojectProjectPatchJson) {
+    throw new Error("mikuproject Project Patch JSON module is not loaded");
+  }
+
   const mikuprojectWbsXlsx = (globalThis as typeof globalThis & {
     __mikuprojectWbsXlsx?: {
       collectWbsHolidayDates: (model: ProjectModel) => string[];
@@ -1291,19 +1320,23 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     return value.trim();
   }
 
-  function detectJsonDocumentKind(documentLike: unknown): "workbook_json" | "project_draft_view" | undefined {
+  function detectJsonDocumentKind(documentLike: unknown): "workbook_json" | "project_draft_view" | "patch_json" | undefined {
     if (!documentLike || typeof documentLike !== "object") {
       return undefined;
     }
     const candidate = documentLike as {
       format?: string;
       view_type?: string;
+      operations?: unknown;
     };
     if (candidate.format === "mikuproject_workbook_json") {
       return "workbook_json";
     }
     if (candidate.view_type === "project_draft_view") {
       return "project_draft_view";
+    }
+    if (Array.isArray(candidate.operations)) {
+      return "patch_json";
     }
     return undefined;
   }
@@ -1326,6 +1359,54 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     setStatus(issues.length > 0 ? `project_draft_view を取り込みました。検証で ${issues.length} 件の問題があります` : "project_draft_view を取り込みました");
     showToast("project_draft_view を取り込みました");
     setActiveTab("transform", { skipTransformRefresh: true });
+  }
+
+  async function importPatchJsonFromSourceText(sourceText: string): Promise<void> {
+    const trimmedSourceText = sourceText.trim();
+    if (!trimmedSourceText) {
+      throw new Error("Patch JSON を入力してください");
+    }
+    const documentLike = JSON.parse(extractLastJsonBlock(trimmedSourceText));
+    const baseModel = ensureCurrentModel();
+    const result = mikuprojectProjectPatchJson.importProjectPatchJson(documentLike, baseModel);
+    currentModel = result.model;
+    const issues = mikuprojectXml.validateProjectModel(currentModel);
+    updateSummary(currentModel);
+    renderValidationIssues(issues);
+    renderImportWarnings(result.warnings);
+    renderXlsxImportSummary(result.changes);
+    if (result.changes.length > 0) {
+      getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
+      markXmlDirty();
+    }
+    isXmlSourceDirty = false;
+    const summaryText = result.changes.length > 0
+      ? `Patch JSON を読み込んで ${result.changes.length} 件の変更を反映しました。XML は再生成済みで、必要なら XML Export で保存できます`
+      : "Patch JSON に反映対象の変更はありませんでした。XML は未変更です";
+    const warningText = result.warnings.length > 0 ? `。Patch JSON 取込で ${result.warnings.length} 件の warning を無視しました` : "";
+    setStatus(issues.length > 0 ? `${summaryText}${warningText}。検証で ${issues.length} 件の問題があります` : `${summaryText}${warningText}`);
+    showToast("Patch JSON を反映しました");
+    setActiveTab("transform", { skipTransformRefresh: true });
+    await exportCurrentMermaid({ silent: true });
+  }
+
+  async function importAiEditJsonFromText(): Promise<void> {
+    const sourceText = getTextArea("projectDraftImportInput").value.trim();
+    if (!sourceText) {
+      throw new Error("project_draft_view または Patch JSON を入力してください");
+    }
+    const jsonText = extractLastJsonBlock(sourceText);
+    const documentLike = JSON.parse(jsonText);
+    const kind = detectJsonDocumentKind(documentLike);
+    if (kind === "project_draft_view") {
+      await importProjectDraftFromText();
+      return;
+    }
+    if (kind === "patch_json") {
+      await importPatchJsonFromSourceText(sourceText);
+      return;
+    }
+    throw new Error("project_draft_view または Patch JSON を入力してください");
   }
 
   function loadProjectDraftSample(): void {
@@ -1399,7 +1480,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
       return;
     }
     if (normalizedName.endsWith(".editjson")) {
-      await importProjectDraftFromFile(file);
+      const sourceText = await file.text();
+      getTextArea("projectDraftImportInput").value = sourceText;
+      await importAiEditJsonFromText();
       return;
     }
     if (normalizedName.endsWith(".json")) {
@@ -1415,7 +1498,12 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         await importProjectDraftFromText();
         return;
       }
-      throw new Error("JSON の format / view_type を判別できません。workbook JSON か project_draft_view を指定してください");
+      if (kind === "patch_json") {
+        getTextArea("projectDraftImportInput").value = sourceText;
+        await importPatchJsonFromSourceText(sourceText);
+        return;
+      }
+      throw new Error("JSON の format / view_type を判別できません。workbook JSON、project_draft_view、または Patch JSON を指定してください");
     }
     throw new Error("対応していないファイル形式です。.xml / .xlsx / .json / .editjson / .csv を指定してください");
   }
@@ -1843,9 +1931,9 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
     });
     getElement<HTMLButtonElement>("importProjectDraftBtn").addEventListener("click", async () => {
       try {
-        await importProjectDraftFromText();
+        await importAiEditJsonFromText();
       } catch (error) {
-        setStatus(error instanceof Error ? error.message : "project_draft_view 取り込みに失敗しました");
+        setStatus(error instanceof Error ? error.message : "編集用 JSON 取り込みに失敗しました");
       }
     });
     getElement<HTMLButtonElement>("exportPhaseDetailBtn").addEventListener("click", () => {

--- a/src/ts/project-patch-json.ts
+++ b/src/ts/project-patch-json.ts
@@ -1,0 +1,301 @@
+/*
+ * Copyright 2026 Toshiki Iga
+ * SPDX-License-Identifier: Apache-2.0
+ */
+(() => {
+  type ImportChange = {
+    scope: "project" | "tasks" | "resources" | "assignments" | "calendars";
+    uid: string;
+    label: string;
+    field: string;
+    before: string | number | boolean | undefined;
+    after: string | number | boolean;
+  };
+
+  type PatchWarning = {
+    message: string;
+  };
+
+  type PatchOperation = {
+    op?: string;
+    uid?: string;
+    fields?: Record<string, unknown>;
+  };
+
+  type PatchDocument = {
+    operations: PatchOperation[];
+  };
+
+  const mikuprojectXml = (globalThis as typeof globalThis & {
+    __mikuprojectXml?: {
+      normalizeProjectModel: (model: ProjectModel) => ProjectModel;
+    };
+  }).__mikuprojectXml;
+
+  if (!mikuprojectXml) {
+    throw new Error("mikuproject XML module is not loaded");
+  }
+
+  function importProjectPatchJson(documentLike: unknown, baseModel: ProjectModel): {
+    model: ProjectModel;
+    changes: ImportChange[];
+    warnings: PatchWarning[];
+  } {
+    const validation = validatePatchDocument(documentLike);
+    const nextModel = cloneProjectModel(baseModel);
+    const changes: ImportChange[] = [];
+    const warnings = [...validation.warnings];
+    const taskByUid = new Map(nextModel.tasks.map((task) => [task.uid, task]));
+
+    validation.document.operations.forEach((operation, index) => {
+      const op = String(operation.op || "").trim();
+      if (op !== "update_task") {
+        warnings.push({ message: `未対応の op は無視します: operations[${index}].op = ${op || "(empty)"}` });
+        return;
+      }
+
+      const uid = String(operation.uid || "").trim();
+      if (!uid) {
+        warnings.push({ message: `update_task の uid がありません: operations[${index}]` });
+        return;
+      }
+      const task = taskByUid.get(uid);
+      if (!task) {
+        warnings.push({ message: `update_task の uid が既存 task を指していません: ${uid}` });
+        return;
+      }
+      if (!operation.fields || typeof operation.fields !== "object" || Array.isArray(operation.fields)) {
+        warnings.push({ message: `update_task.fields がオブジェクトではありません: ${uid}` });
+        return;
+      }
+
+      applyUpdateTaskOperation(task, operation.fields, nextModel.project, changes, warnings, index);
+    });
+
+    return {
+      model: mikuprojectXml.normalizeProjectModel(nextModel),
+      changes,
+      warnings
+    };
+  }
+
+  function validatePatchDocument(documentLike: unknown): {
+    document: PatchDocument;
+    warnings: PatchWarning[];
+  } {
+    if (!documentLike || typeof documentLike !== "object" || Array.isArray(documentLike)) {
+      throw new Error("Patch JSON がオブジェクトではありません");
+    }
+    const document = documentLike as Partial<PatchDocument>;
+    if (!Array.isArray(document.operations)) {
+      throw new Error("Patch JSON には operations 配列が必要です");
+    }
+    const warnings: PatchWarning[] = [];
+    document.operations.forEach((operation, index) => {
+      if (!operation || typeof operation !== "object" || Array.isArray(operation)) {
+        throw new Error(`operations[${index}] がオブジェクトではありません`);
+      }
+    });
+    return {
+      document: document as PatchDocument,
+      warnings
+    };
+  }
+
+  function applyUpdateTaskOperation(
+    task: TaskModel,
+    rawFields: Record<string, unknown>,
+    project: ProjectInfo,
+    changes: ImportChange[],
+    warnings: PatchWarning[],
+    operationIndex: number
+  ): void {
+    const fields = { ...rawFields };
+    if (Object.keys(fields).length === 0) {
+      warnings.push({ message: `update_task に fields がありません: ${task.uid}` });
+      return;
+    }
+    if (fields.planned_duration !== undefined && fields.planned_duration_hours !== undefined) {
+      warnings.push({ message: `planned_duration と planned_duration_hours が同時指定されたため、planned_duration_hours は無視します: ${task.uid}` });
+      delete fields.planned_duration_hours;
+    }
+
+    const handledFields = new Set<string>();
+
+    if (fields.name !== undefined) {
+      handledFields.add("name");
+      if (typeof fields.name !== "string" || fields.name.trim() === "") {
+        warnings.push({ message: `update_task.name は空でない文字列が必要です: ${task.uid}` });
+      } else if (task.name !== fields.name.trim()) {
+        changes.push({
+          scope: "tasks",
+          uid: task.uid,
+          label: task.name || task.uid,
+          field: "name",
+          before: task.name,
+          after: fields.name.trim()
+        });
+        task.name = fields.name.trim();
+      }
+    }
+
+    if (fields.planned_start !== undefined) {
+      handledFields.add("planned_start");
+      const normalizedStart = normalizePatchedTaskDate(fields.planned_start, "start", task, project);
+      if (normalizedStart === undefined) {
+        warnings.push({ message: `update_task.planned_start の日付形式が解釈できません: ${task.uid}` });
+      } else if (task.start !== normalizedStart) {
+        changes.push({
+          scope: "tasks",
+          uid: task.uid,
+          label: task.name || task.uid,
+          field: "planned_start",
+          before: task.start,
+          after: normalizedStart
+        });
+        task.start = normalizedStart;
+      }
+    }
+
+    if (fields.planned_finish !== undefined) {
+      handledFields.add("planned_finish");
+      const normalizedFinish = normalizePatchedTaskDate(fields.planned_finish, "finish", task, project);
+      if (normalizedFinish === undefined) {
+        warnings.push({ message: `update_task.planned_finish の日付形式が解釈できません: ${task.uid}` });
+      } else if (task.finish !== normalizedFinish) {
+        changes.push({
+          scope: "tasks",
+          uid: task.uid,
+          label: task.name || task.uid,
+          field: "planned_finish",
+          before: task.finish,
+          after: normalizedFinish
+        });
+        task.finish = normalizedFinish;
+      }
+    }
+
+    if (fields.planned_duration !== undefined) {
+      handledFields.add("planned_duration");
+      if (typeof fields.planned_duration !== "string" || fields.planned_duration.trim() === "") {
+        warnings.push({ message: `update_task.planned_duration は空でない文字列が必要です: ${task.uid}` });
+      } else if (task.duration !== fields.planned_duration.trim()) {
+        changes.push({
+          scope: "tasks",
+          uid: task.uid,
+          label: task.name || task.uid,
+          field: "planned_duration",
+          before: task.duration,
+          after: fields.planned_duration.trim()
+        });
+        task.duration = fields.planned_duration.trim();
+      }
+    }
+
+    if (fields.planned_duration_hours !== undefined) {
+      handledFields.add("planned_duration_hours");
+      if (typeof fields.planned_duration_hours !== "number" || !Number.isFinite(fields.planned_duration_hours) || fields.planned_duration_hours < 0) {
+        warnings.push({ message: `update_task.planned_duration_hours は 0 以上の数値が必要です: ${task.uid}` });
+      } else {
+        const beforeHours = parseDurationHours(task.duration);
+        const nextDuration = formatDurationHours(fields.planned_duration_hours);
+        if (task.duration !== nextDuration) {
+          changes.push({
+            scope: "tasks",
+            uid: task.uid,
+            label: task.name || task.uid,
+            field: "planned_duration_hours",
+            before: beforeHours,
+            after: fields.planned_duration_hours
+          });
+          task.duration = nextDuration;
+        }
+      }
+    }
+
+    Object.keys(fields).forEach((fieldName) => {
+      if (handledFields.has(fieldName)) {
+        return;
+      }
+      warnings.push({ message: `未対応の field は無視します: operations[${operationIndex}].fields.${fieldName}` });
+    });
+  }
+
+  function normalizePatchedTaskDate(
+    value: unknown,
+    kind: "start" | "finish",
+    task: TaskModel,
+    project: ProjectInfo
+  ): string | undefined {
+    if (typeof value !== "string") {
+      return undefined;
+    }
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    if (!isDateText(trimmed)) {
+      return undefined;
+    }
+    if (isDateOnlyText(trimmed) && !task.milestone) {
+      const timeText = kind === "start"
+        ? (project.defaultStartTime || "09:00:00")
+        : (project.defaultFinishTime || "18:00:00");
+      return `${trimmed}T${timeText}`;
+    }
+    return trimmed;
+  }
+
+  function isDateOnlyText(value: string): boolean {
+    return /^\d{4}-\d{2}-\d{2}$/.test(value);
+  }
+
+  function isDateText(value: string): boolean {
+    if (isDateOnlyText(value)) {
+      return true;
+    }
+    return !Number.isNaN(new Date(value).getTime());
+  }
+
+  function formatDurationHours(hours: number): string {
+    const totalSeconds = Math.round(hours * 60 * 60);
+    const normalizedSeconds = Math.max(0, totalSeconds);
+    const durationHours = Math.floor(normalizedSeconds / 3600);
+    const durationMinutes = Math.floor((normalizedSeconds % 3600) / 60);
+    const durationSeconds = normalizedSeconds % 60;
+    return `PT${durationHours}H${durationMinutes}M${durationSeconds}S`;
+  }
+
+  function parseDurationHours(duration: string | undefined): number | undefined {
+    const text = String(duration || "").trim();
+    const match = text.match(/^PT(?:(\d+(?:\.\d+)?)H)?(?:(\d+(?:\.\d+)?)M)?(?:(\d+(?:\.\d+)?)S)?$/);
+    if (!match) {
+      return undefined;
+    }
+    const hours = Number(match[1] || 0);
+    const minutes = Number(match[2] || 0);
+    const seconds = Number(match[3] || 0);
+    return hours + (minutes / 60) + (seconds / 3600);
+  }
+
+  function cloneProjectModel(model: ProjectModel): ProjectModel {
+    return JSON.parse(JSON.stringify(model)) as ProjectModel;
+  }
+
+  (globalThis as typeof globalThis & {
+    __mikuprojectProjectPatchJson?: {
+      importProjectPatchJson: (documentLike: unknown, baseModel: ProjectModel) => {
+        model: ProjectModel;
+        changes: ImportChange[];
+        warnings: PatchWarning[];
+      };
+      validatePatchDocument: (documentLike: unknown) => {
+        document: PatchDocument;
+        warnings: PatchWarning[];
+      };
+    };
+  }).__mikuprojectProjectPatchJson = {
+    importProjectPatchJson,
+    validatePatchDocument
+  };
+})();

--- a/tests/mikuproject-main.test.js
+++ b/tests/mikuproject-main.test.js
@@ -37,6 +37,10 @@ const projectWorkbookJsonCode = readFileSync(
   path.resolve(__dirname, "../src/js/project-workbook-json.js"),
   "utf8"
 );
+const projectPatchJsonCode = readFileSync(
+  path.resolve(__dirname, "../src/js/project-patch-json.js"),
+  "utf8"
+);
 const wbsXlsxCode = readFileSync(
   path.resolve(__dirname, "../src/js/wbs-xlsx.js"),
   "utf8"
@@ -249,7 +253,7 @@ function mountDom() {
 
 function bootPage() {
   mountDom();
-  new Function(`${typesCode}\n${markdownEscapeCode}\n${excelIoCode}\n${msProjectXmlCode}\n${projectWorkbookSchemaCode}\n${projectXlsxCode}\n${projectWorkbookJsonCode}\n${wbsXlsxCode}\n${wbsMarkdownCode}\n${nativeSvgCode}\n${mainCode}`)();
+  new Function(`${typesCode}\n${markdownEscapeCode}\n${excelIoCode}\n${msProjectXmlCode}\n${projectWorkbookSchemaCode}\n${projectXlsxCode}\n${projectWorkbookJsonCode}\n${projectPatchJsonCode}\n${wbsXlsxCode}\n${wbsMarkdownCode}\n${nativeSvgCode}\n${mainCode}`)();
   document.dispatchEvent(new Event("DOMContentLoaded"));
 }
 
@@ -523,6 +527,73 @@ describe("mikuproject main", () => {
     expect(document.getElementById("modelOutput").value).toContain("\"initials\": \"M\"");
     expect(document.getElementById("modelOutput").value).toContain("\"taskUid\": \"2\"");
     expect(document.getElementById("modelOutput").value).toContain("\"resourceUid\": \"1\"");
+  });
+
+  it("imports patch json edits into the current model and xml", async () => {
+    bootPage();
+
+    document.getElementById("projectDraftImportInput").value = [
+      "説明文",
+      "```json",
+      JSON.stringify({
+        operations: [
+          {
+            op: "update_task",
+            uid: "10",
+            fields: {
+              planned_start: "2026-03-24",
+              planned_finish: "2026-03-26"
+            }
+          },
+          {
+            op: "update_task",
+            uid: "11",
+            fields: {
+              name: "XLSXレイアウト最終調整"
+            }
+          }
+        ]
+      }, null, 2),
+      "```"
+    ].join("\n");
+
+    document.getElementById("importProjectDraftBtn").click();
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("xmlInput").value).toContain("<Name>XLSXレイアウト最終調整</Name>");
+    expect(document.getElementById("xmlInput").value).toContain("<Start>2026-03-24T09:00:00</Start>");
+    expect(document.getElementById("xmlInput").value).toContain("<Finish>2026-03-26T18:00:00</Finish>");
+    expect(document.getElementById("modelOutput").value).toContain("\"name\": \"XLSXレイアウト最終調整\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"start\": \"2026-03-24T09:00:00\"");
+    expect(document.getElementById("modelOutput").value).toContain("\"finish\": \"2026-03-26T18:00:00\"");
+    expect(document.getElementById("statusMessage").textContent).toContain("Patch JSON を読み込んで 3 件の変更を反映しました");
+    expect(document.getElementById("xlsxImportSummary").innerHTML).toContain("planned_start");
+    expect(document.getElementById("xlsxImportSummary").innerHTML).toContain("planned_finish");
+    expect(document.getElementById("xlsxImportSummary").innerHTML).toContain("name");
+  });
+
+  it("reports patch json warnings for unsupported operations", async () => {
+    bootPage();
+
+    document.getElementById("projectDraftImportInput").value = JSON.stringify({
+      operations: [
+        {
+          op: "link_tasks",
+          from_uid: "1",
+          to_uid: "3",
+          type: "FS"
+        }
+      ]
+    }, null, 2);
+
+    document.getElementById("importProjectDraftBtn").click();
+    await flushAsyncWork();
+    await flushAsyncWork();
+
+    expect(document.getElementById("statusMessage").textContent).toContain("Patch JSON に反映対象の変更はありませんでした");
+    expect(document.getElementById("statusMessage").textContent).toContain("warning を無視しました");
+    expect(document.getElementById("importWarnings").textContent).toContain("未対応の op は無視します");
   });
 
   it("limits default calendar holiday exceptions to the project date range", () => {


### PR DESCRIPTION
## 概要

既存 project 向けの Patch JSON について、`update_task` の first cut 取込を追加しました。あわせて、`project_draft_view` と Patch JSON を生成AI向け編集用 JSON として扱う前提に合わせて、UI、仕様書、テストを更新しています。

## 変更内容

### Patch JSON の first cut 実装

- `src/ts/project-patch-json.ts` を追加
- `operations` 配列を持つ Patch JSON を検証し、`update_task` を既存 `ProjectModel` に部分適用する処理を追加
- first cut の更新対象 field
  - `name`
  - `planned_start`
  - `planned_finish`
  - `planned_duration`
  - `planned_duration_hours`
- `uid` による task 特定を前提とし、未対応 `op`、存在しない `uid`、不正 field、不正日付は warning として扱う
- 取込結果として、変更一覧と warning 一覧を返す

### UI と import 導線の更新

- `main.ts` で JSON 判別を拡張し、`project_draft_view` に加えて Patch JSON を受け付けるように変更
- `.editjson` と `.json` の取込時に、内容から `project_draft_view` / workbook JSON / Patch JSON を振り分けるように変更
- 「生成AIが返した JSON」入力欄で、`project_draft_view` または Patch JSON を貼り付けて取込できるように変更
- Patch JSON 取込後に、warning と差分要約を表示し、変更があれば XML を再生成するように変更
- `mikuproject-src.html` に `project-patch-json.js` の読み込みを追加
- `scripts/build-project.mjs` に `src/ts/project-patch-json.ts` を追加

### ドキュメント更新

- `docs/mikuproject-ai-json-spec.md`
  - 文書宣言と版情報を追加
  - Patch JSON の `update_task` first cut 実装済み状態に更新
  - MVP 方針、例、`.editjson` の扱い、非稼働日と人間指示の扱い、`calendar_uid = "1"` の土日非稼働前提を追記
  - `project_draft_view` では粗い仮日付を入れてよいことを追記
- `docs/spec.md`
  - 現状実装範囲を Patch JSON `update_task` first cut 対応に更新
  - `project_draft_view` と Patch JSON の役割分担、非稼働日方針、`calendar_uid = "1"` の前提を追記
- `docs/architecture.md`
  - 生成AI連携の実装状況を更新し、Patch JSON `update_task` first cut 取込を明記
- `docs/msprojectxml-ai-integration.md`
  - Patch JSON `update_task` first cut import 実装済みの整理に更新
- `docs/TODO.md`
  - Patch JSON の設計、prompt、UI、テストに関する TODO を追加

## テスト

- `tests/mikuproject-main.test.js` を更新
- Patch JSON の正常系
  - 現在の model / XML に `update_task` が反映されること
- Patch JSON の warning 系
  - 未対応 `op` が warning として表示されること

## ポイント確認

- このコミットで対応している Patch JSON は `update_task` の first cut のみです
- `move_task` / `link_tasks` / `unlink_tasks` / `add_task` / `delete_task` は未実装です