### PR TITLE
Overview の SVG 出力に前後関係コネクタを追加

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -20,6 +20,8 @@
   - `Name / Start / Finish / PercentComplete / PercentWorkComplete / Notes` など主要 editable 列が戻る
   - `Milestone / Summary / Critical` など現在の task 真偽値列が戻る
 - `Tasks.Predecessors` について、現状の `predecessorUid` `,` 区切り MVP から、`type / linkLag` など複雑な依存表現をどこまで戻すか整理する
+- `.xlsm` について、`xlsx` 相当の workbook として import だけ受ける first cut を追加する
+  - macro / VBA project の保持は行わず、今回の利用範囲では落ちてよい前提とする
 - workbook import の次段候補として、少なくとも次の列を優先順位つきで整理する
   - 優先候補: `Resources.StandardRate / OvertimeRate / CostPerUse`
   - 優先候補: `Assignments.Start / Finish`
@@ -29,6 +31,9 @@
 - `project_draft_request` を UI から生成しやすくするか整理する
 - UI の微調整として、`Input / Overview / Output` の各カードの余白・見出し・ボタン階層を見直し、`miku` 系テーマの統一感をさらに整える
 - `Overview` タブの summary / validation / preview の情報密度を見直し、どこを見る画面なのかをより直感的に伝わる構成へ調整する
+- `Overview` 画面について、簡易な task 操作機能を追加するか検討する
+  - 今は表示専用だが、軽い編集や操作だけはできると便利な可能性がある
+  - 一方で責務過多や誤操作の不幸もありうるため、まずは仕様整理から始める
 - `Output` タブの生成AI連携と各種 export ボタンの優先度表現を見直し、主操作と補助操作の区別をより明確にする
 - `build:xlsx-sample` の所要時間を個別計測し、sample workbook 生成処理の支配要因を確認する
 - `docs/spec.md` に残っている実装済み前提との差分を定期的に解消する
@@ -49,6 +54,18 @@
 - `mikuproject-sample.xlsx` の `Resources / Assignments / NonWorkingDays` で、強調色が過剰にならない最終バランスを調整する
 - `WBS` の `プロジェクト情報` / `凡例` などと、`Project` シートの `Basic Info` に入っているドット編みかけ表現を除去する
 - WBS workbook の表示改善を継続する
+- SVG 出力について、プロジェクト名の位置を少し上にできるか調整する
+- SVG 出力の phase の線を、今より少し太くするか検討する
+  - 現状は細く感じるため、可読性と全体バランスを見ながら調整可否を確認する
+- SVG のガントチャートについて、前後関係を dependency connector として表示するか検討する
+  - 参考イメージは、task bar の背面に置く細い connector line とする
+  - 完全な自由曲線ではなく、横→縦→横の直交配線を角丸でつなぐ表現を first candidate とする
+  - 始点と終点では、bar 端から少し離した短い水平セグメントを持たせる
+  - 長い区間は水平・垂直を基本にし、角だけを小さめの半径で丸める
+  - bar / milestone / label より背面に描き、dependency は補助情報として主張しすぎないようにする
+  - 線幅は task bar より細く、色は薄めにして、最後だけ小さい矢印で向きを示す
+  - first cut では `FS` だけ表示するか、`SS / FF / SF` まで含めるかを整理する
+  - connector の交差、密集時の可読性、`Daily / Weekly` の両方で成立するかを確認する
 - `Daily` 表示の日ごとの横幅を、もう少し狭くできるか検討する
   - まずは変更仕様の整理から始め、可読性、文字詰まり、祝日/週境界の見え方、`Weekly / Monthly` とのバランスを確認する
 - WBS workbook の見た目改善と、構造忠実 workbook との責務分離を保つ

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -16011,7 +16011,13 @@ if (!customElements.get("lht-page-menu")) {
             ".phaseLabel { font-size: 13px; font-weight: 700; }",
             ".grid { stroke: #c9d3e1; stroke-width: 1; }",
             ".today { stroke: #ff6b5a; stroke-width: 2; }",
+            ".dependencyPath { fill: none; stroke: #9eb6c8; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; opacity: 0.95; }",
             "</style>",
+            "<defs>",
+            '<marker id="dependencyArrow" markerWidth="7" markerHeight="7" refX="5.5" refY="3.5" orient="auto" markerUnits="strokeWidth">',
+            '<path d="M0,0 L7,3.5 L0,7 Z" fill="#9eb6c8" />',
+            "</marker>",
+            "</defs>",
             `<rect x="0" y="0" width="${svgWidth}" height="${svgHeight}" fill="#ffffff"/>`,
             `<text class="title" x="${chartOriginX + (chartWidth / 2)}" y="${TOP_PADDING + 18}" text-anchor="middle">${escapeXml(model.project.name || "-")}</text>`
         ];
@@ -16031,6 +16037,15 @@ if (!customElements.get("lht-page-menu")) {
             const todayX = chartOriginX + (todayIndex * DAY_WIDTH) + (DAY_WIDTH / 2);
             parts.push(`<line class="today" x1="${todayX}" y1="${TOP_PADDING + 26}" x2="${todayX}" y2="${svgHeight - BOTTOM_PADDING}" />`);
         }
+        parts.push(...buildDependencyConnectorElements(model.tasks, rows, chartOriginX, chartOriginY, {
+            cellWidth: DAY_WIDTH,
+            rangeInset: 6,
+            milestoneHalfWidth: 13,
+            routeOffset: 14,
+            routeSpacing: 6,
+            targetInset: 4,
+            cornerRadius: 8
+        }));
         for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
             const row = rows[rowIndex];
             const rowY = chartOriginY + row.y;
@@ -16125,7 +16140,13 @@ if (!customElements.get("lht-page-menu")) {
             ".grid { stroke: #c9d3e1; stroke-width: 1; }",
             ".today { stroke: #ff6b5a; stroke-width: 2; }",
             ".monthBoundary { stroke: #98a2b3; stroke-width: 1.5; }",
+            ".dependencyPath { fill: none; stroke: #9eb6c8; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; opacity: 0.95; }",
             "</style>",
+            "<defs>",
+            '<marker id="dependencyArrow" markerWidth="7" markerHeight="7" refX="5.5" refY="3.5" orient="auto" markerUnits="strokeWidth">',
+            '<path d="M0,0 L7,3.5 L0,7 Z" fill="#9eb6c8" />',
+            "</marker>",
+            "</defs>",
             `<rect x="0" y="0" width="${svgWidth}" height="${svgHeight}" fill="#ffffff"/>`,
             `<text class="title" x="${chartOriginX + (chartWidth / 2)}" y="${WEEKLY_TOP_PADDING + 18}" text-anchor="middle">${escapeXml(model.project.name || "-")} weekly overview</text>`,
             `<text class="meta" x="${chartOriginX + (chartWidth / 2)}" y="${WEEKLY_TOP_PADDING + 40}" text-anchor="middle">${escapeXml(`project range ${String(model.project.startDate || "").slice(0, 10)} - ${String(model.project.finishDate || "").slice(0, 10)}`)}</text>`
@@ -16149,6 +16170,15 @@ if (!customElements.get("lht-page-menu")) {
             const todayX = chartOriginX + (todayWeekIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2);
             parts.push(`<line class="today" x1="${todayX}" y1="${WEEKLY_TOP_PADDING + 72}" x2="${todayX}" y2="${svgHeight - WEEKLY_BOTTOM_PADDING}" />`);
         }
+        parts.push(...buildDependencyConnectorElements(model.tasks, rows, chartOriginX, chartOriginY, {
+            cellWidth: WEEK_WIDTH,
+            rangeInset: 4,
+            milestoneHalfWidth: 11,
+            routeOffset: 12,
+            routeSpacing: 5,
+            targetInset: 4,
+            cornerRadius: 7
+        }));
         for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
             const row = rows[rowIndex];
             const rowY = chartOriginY + row.y;
@@ -16548,6 +16578,102 @@ if (!customElements.get("lht-page-menu")) {
             leftRoom: Math.max(0, (shapeStartX - config.gap) - chartOriginX),
             rightRoom: Math.max(0, chartEndX - (shapeEndX + config.gap))
         };
+    }
+    function buildDependencyConnectorElements(tasks, rows, chartOriginX, chartOriginY, config) {
+        const geometryByUid = new Map();
+        for (const row of rows) {
+            const geometry = buildShapeGeometry(row, chartOriginX, chartOriginY, config.cellWidth, config.rangeInset, config.milestoneHalfWidth);
+            if (geometry) {
+                geometryByUid.set(row.task.uid, geometry);
+            }
+        }
+        const parts = [];
+        let connectorIndex = 0;
+        for (const task of tasks) {
+            const toGeometry = geometryByUid.get(task.uid);
+            if (!toGeometry) {
+                continue;
+            }
+            for (const predecessor of task.predecessors || []) {
+                if (predecessor.type !== undefined && predecessor.type !== 1) {
+                    continue;
+                }
+                const fromGeometry = geometryByUid.get(predecessor.predecessorUid);
+                if (!fromGeometry) {
+                    continue;
+                }
+                if (fromGeometry.uid === toGeometry.uid) {
+                    continue;
+                }
+                const endX = toGeometry.startX - config.targetInset;
+                const candidateLaneX = fromGeometry.endX + config.routeOffset + ((connectorIndex % 4) * config.routeSpacing);
+                const minLaneX = fromGeometry.endX + 4;
+                const maxLaneX = endX - 4;
+                const laneBaseX = maxLaneX <= minLaneX
+                    ? (fromGeometry.endX + endX) / 2
+                    : Math.max(minLaneX, Math.min(maxLaneX, candidateLaneX));
+                const path = buildDependencyConnectorPath(fromGeometry.endX, fromGeometry.midY, laneBaseX, endX, toGeometry.midY, config.cornerRadius);
+                parts.push(`<path class="dependencyPath" d="${path}" marker-end="url(#dependencyArrow)" data-from-uid="${escapeXml(fromGeometry.uid)}" data-to-uid="${escapeXml(toGeometry.uid)}" data-link-type="FS"/>`);
+                connectorIndex += 1;
+            }
+        }
+        return parts;
+    }
+    function buildShapeGeometry(row, chartOriginX, chartOriginY, cellWidth, rangeInset, milestoneHalfWidth) {
+        if (row.startIndex === null || row.endIndex === null) {
+            return null;
+        }
+        const startX = row.kind === "milestone"
+            ? chartOriginX + (row.startIndex * cellWidth) + (cellWidth / 2) - milestoneHalfWidth
+            : chartOriginX + (row.startIndex * cellWidth) + rangeInset;
+        const endX = row.kind === "milestone"
+            ? chartOriginX + (row.startIndex * cellWidth) + (cellWidth / 2) + milestoneHalfWidth
+            : chartOriginX + (row.endIndex * cellWidth) + cellWidth - rangeInset;
+        return {
+            uid: row.task.uid,
+            kind: row.kind,
+            startX,
+            endX,
+            midY: chartOriginY + row.y + (ROW_HEIGHT / 2)
+        };
+    }
+    function buildDependencyConnectorPath(startX, startY, laneX, endX, endY, radius) {
+        if (endX <= startX) {
+            return `M ${startX} ${startY} L ${startX} ${startY}`;
+        }
+        if (startY === endY) {
+            return `M ${startX} ${startY} L ${endX} ${endY}`;
+        }
+        const directionY = endY > startY ? 1 : -1;
+        const horizontalRoom = Math.max(2, laneX - startX);
+        const targetRoom = Math.max(2, endX - laneX);
+        const verticalRoom = Math.max(2, Math.abs(endY - startY));
+        const usableRadius = Math.min(radius, horizontalRoom * 0.8, targetRoom * 0.8, verticalRoom / 3);
+        const startCurveX = startX + usableRadius;
+        const startCurveY = startY + (directionY * usableRadius);
+        const simpleEndCurveX = endX - usableRadius;
+        if (targetRoom >= Math.max(18, usableRadius * 3)) {
+            const horizontalStartX = laneX + usableRadius;
+            return [
+                `M ${startX} ${startY}`,
+                `C ${startCurveX} ${startY} ${laneX} ${startY} ${laneX} ${startCurveY}`,
+                `L ${laneX} ${endY - (directionY * usableRadius)}`,
+                `C ${laneX} ${endY - (directionY * Math.max(3, usableRadius * 0.45))} ${laneX} ${endY} ${horizontalStartX} ${endY}`,
+                `L ${simpleEndCurveX} ${endY}`,
+                `L ${endX} ${endY}`
+            ].join(" ");
+        }
+        const endCurveEntryX = endX - Math.max(usableRadius, 8);
+        const midY = startY + ((endY - startY) / 2);
+        const axisX = (startX + endCurveEntryX) / 2;
+        const symmetricBulge = Math.min(Math.max(18, usableRadius * 2.4), Math.max(18, (endCurveEntryX - startX) * 0.95));
+        const midRise = Math.min(Math.max(10, usableRadius * 1.3), Math.max(10, verticalRoom * 0.32));
+        return [
+            `M ${startX} ${startY}`,
+            `C ${axisX + symmetricBulge} ${startY} ${axisX + symmetricBulge} ${midY - (directionY * midRise)} ${axisX} ${midY}`,
+            `C ${axisX - symmetricBulge} ${midY + (directionY * midRise)} ${axisX - symmetricBulge} ${endY} ${endCurveEntryX} ${endY}`,
+            `L ${endX} ${endY}`
+        ].join(" ");
     }
     function buildPlacementDecision(anchor, x, textWidth, reason, geometry, config, extras = {}) {
         return {

--- a/src/js/wbs-svg.js
+++ b/src/js/wbs-svg.js
@@ -77,7 +77,13 @@
             ".phaseLabel { font-size: 13px; font-weight: 700; }",
             ".grid { stroke: #c9d3e1; stroke-width: 1; }",
             ".today { stroke: #ff6b5a; stroke-width: 2; }",
+            ".dependencyPath { fill: none; stroke: #9eb6c8; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; opacity: 0.95; }",
             "</style>",
+            "<defs>",
+            '<marker id="dependencyArrow" markerWidth="7" markerHeight="7" refX="5.5" refY="3.5" orient="auto" markerUnits="strokeWidth">',
+            '<path d="M0,0 L7,3.5 L0,7 Z" fill="#9eb6c8" />',
+            "</marker>",
+            "</defs>",
             `<rect x="0" y="0" width="${svgWidth}" height="${svgHeight}" fill="#ffffff"/>`,
             `<text class="title" x="${chartOriginX + (chartWidth / 2)}" y="${TOP_PADDING + 18}" text-anchor="middle">${escapeXml(model.project.name || "-")}</text>`
         ];
@@ -97,6 +103,15 @@
             const todayX = chartOriginX + (todayIndex * DAY_WIDTH) + (DAY_WIDTH / 2);
             parts.push(`<line class="today" x1="${todayX}" y1="${TOP_PADDING + 26}" x2="${todayX}" y2="${svgHeight - BOTTOM_PADDING}" />`);
         }
+        parts.push(...buildDependencyConnectorElements(model.tasks, rows, chartOriginX, chartOriginY, {
+            cellWidth: DAY_WIDTH,
+            rangeInset: 6,
+            milestoneHalfWidth: 13,
+            routeOffset: 14,
+            routeSpacing: 6,
+            targetInset: 4,
+            cornerRadius: 8
+        }));
         for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
             const row = rows[rowIndex];
             const rowY = chartOriginY + row.y;
@@ -191,7 +206,13 @@
             ".grid { stroke: #c9d3e1; stroke-width: 1; }",
             ".today { stroke: #ff6b5a; stroke-width: 2; }",
             ".monthBoundary { stroke: #98a2b3; stroke-width: 1.5; }",
+            ".dependencyPath { fill: none; stroke: #9eb6c8; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; opacity: 0.95; }",
             "</style>",
+            "<defs>",
+            '<marker id="dependencyArrow" markerWidth="7" markerHeight="7" refX="5.5" refY="3.5" orient="auto" markerUnits="strokeWidth">',
+            '<path d="M0,0 L7,3.5 L0,7 Z" fill="#9eb6c8" />',
+            "</marker>",
+            "</defs>",
             `<rect x="0" y="0" width="${svgWidth}" height="${svgHeight}" fill="#ffffff"/>`,
             `<text class="title" x="${chartOriginX + (chartWidth / 2)}" y="${WEEKLY_TOP_PADDING + 18}" text-anchor="middle">${escapeXml(model.project.name || "-")} weekly overview</text>`,
             `<text class="meta" x="${chartOriginX + (chartWidth / 2)}" y="${WEEKLY_TOP_PADDING + 40}" text-anchor="middle">${escapeXml(`project range ${String(model.project.startDate || "").slice(0, 10)} - ${String(model.project.finishDate || "").slice(0, 10)}`)}</text>`
@@ -215,6 +236,15 @@
             const todayX = chartOriginX + (todayWeekIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2);
             parts.push(`<line class="today" x1="${todayX}" y1="${WEEKLY_TOP_PADDING + 72}" x2="${todayX}" y2="${svgHeight - WEEKLY_BOTTOM_PADDING}" />`);
         }
+        parts.push(...buildDependencyConnectorElements(model.tasks, rows, chartOriginX, chartOriginY, {
+            cellWidth: WEEK_WIDTH,
+            rangeInset: 4,
+            milestoneHalfWidth: 11,
+            routeOffset: 12,
+            routeSpacing: 5,
+            targetInset: 4,
+            cornerRadius: 7
+        }));
         for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
             const row = rows[rowIndex];
             const rowY = chartOriginY + row.y;
@@ -614,6 +644,102 @@
             leftRoom: Math.max(0, (shapeStartX - config.gap) - chartOriginX),
             rightRoom: Math.max(0, chartEndX - (shapeEndX + config.gap))
         };
+    }
+    function buildDependencyConnectorElements(tasks, rows, chartOriginX, chartOriginY, config) {
+        const geometryByUid = new Map();
+        for (const row of rows) {
+            const geometry = buildShapeGeometry(row, chartOriginX, chartOriginY, config.cellWidth, config.rangeInset, config.milestoneHalfWidth);
+            if (geometry) {
+                geometryByUid.set(row.task.uid, geometry);
+            }
+        }
+        const parts = [];
+        let connectorIndex = 0;
+        for (const task of tasks) {
+            const toGeometry = geometryByUid.get(task.uid);
+            if (!toGeometry) {
+                continue;
+            }
+            for (const predecessor of task.predecessors || []) {
+                if (predecessor.type !== undefined && predecessor.type !== 1) {
+                    continue;
+                }
+                const fromGeometry = geometryByUid.get(predecessor.predecessorUid);
+                if (!fromGeometry) {
+                    continue;
+                }
+                if (fromGeometry.uid === toGeometry.uid) {
+                    continue;
+                }
+                const endX = toGeometry.startX - config.targetInset;
+                const candidateLaneX = fromGeometry.endX + config.routeOffset + ((connectorIndex % 4) * config.routeSpacing);
+                const minLaneX = fromGeometry.endX + 4;
+                const maxLaneX = endX - 4;
+                const laneBaseX = maxLaneX <= minLaneX
+                    ? (fromGeometry.endX + endX) / 2
+                    : Math.max(minLaneX, Math.min(maxLaneX, candidateLaneX));
+                const path = buildDependencyConnectorPath(fromGeometry.endX, fromGeometry.midY, laneBaseX, endX, toGeometry.midY, config.cornerRadius);
+                parts.push(`<path class="dependencyPath" d="${path}" marker-end="url(#dependencyArrow)" data-from-uid="${escapeXml(fromGeometry.uid)}" data-to-uid="${escapeXml(toGeometry.uid)}" data-link-type="FS"/>`);
+                connectorIndex += 1;
+            }
+        }
+        return parts;
+    }
+    function buildShapeGeometry(row, chartOriginX, chartOriginY, cellWidth, rangeInset, milestoneHalfWidth) {
+        if (row.startIndex === null || row.endIndex === null) {
+            return null;
+        }
+        const startX = row.kind === "milestone"
+            ? chartOriginX + (row.startIndex * cellWidth) + (cellWidth / 2) - milestoneHalfWidth
+            : chartOriginX + (row.startIndex * cellWidth) + rangeInset;
+        const endX = row.kind === "milestone"
+            ? chartOriginX + (row.startIndex * cellWidth) + (cellWidth / 2) + milestoneHalfWidth
+            : chartOriginX + (row.endIndex * cellWidth) + cellWidth - rangeInset;
+        return {
+            uid: row.task.uid,
+            kind: row.kind,
+            startX,
+            endX,
+            midY: chartOriginY + row.y + (ROW_HEIGHT / 2)
+        };
+    }
+    function buildDependencyConnectorPath(startX, startY, laneX, endX, endY, radius) {
+        if (endX <= startX) {
+            return `M ${startX} ${startY} L ${startX} ${startY}`;
+        }
+        if (startY === endY) {
+            return `M ${startX} ${startY} L ${endX} ${endY}`;
+        }
+        const directionY = endY > startY ? 1 : -1;
+        const horizontalRoom = Math.max(2, laneX - startX);
+        const targetRoom = Math.max(2, endX - laneX);
+        const verticalRoom = Math.max(2, Math.abs(endY - startY));
+        const usableRadius = Math.min(radius, horizontalRoom * 0.8, targetRoom * 0.8, verticalRoom / 3);
+        const startCurveX = startX + usableRadius;
+        const startCurveY = startY + (directionY * usableRadius);
+        const simpleEndCurveX = endX - usableRadius;
+        if (targetRoom >= Math.max(18, usableRadius * 3)) {
+            const horizontalStartX = laneX + usableRadius;
+            return [
+                `M ${startX} ${startY}`,
+                `C ${startCurveX} ${startY} ${laneX} ${startY} ${laneX} ${startCurveY}`,
+                `L ${laneX} ${endY - (directionY * usableRadius)}`,
+                `C ${laneX} ${endY - (directionY * Math.max(3, usableRadius * 0.45))} ${laneX} ${endY} ${horizontalStartX} ${endY}`,
+                `L ${simpleEndCurveX} ${endY}`,
+                `L ${endX} ${endY}`
+            ].join(" ");
+        }
+        const endCurveEntryX = endX - Math.max(usableRadius, 8);
+        const midY = startY + ((endY - startY) / 2);
+        const axisX = (startX + endCurveEntryX) / 2;
+        const symmetricBulge = Math.min(Math.max(18, usableRadius * 2.4), Math.max(18, (endCurveEntryX - startX) * 0.95));
+        const midRise = Math.min(Math.max(10, usableRadius * 1.3), Math.max(10, verticalRoom * 0.32));
+        return [
+            `M ${startX} ${startY}`,
+            `C ${axisX + symmetricBulge} ${startY} ${axisX + symmetricBulge} ${midY - (directionY * midRise)} ${axisX} ${midY}`,
+            `C ${axisX - symmetricBulge} ${midY + (directionY * midRise)} ${axisX - symmetricBulge} ${endY} ${endCurveEntryX} ${endY}`,
+            `L ${endX} ${endY}`
+        ].join(" ");
     }
     function buildPlacementDecision(anchor, x, textWidth, reason, geometry, config, extras = {}) {
         return {

--- a/src/ts/wbs-svg.ts
+++ b/src/ts/wbs-svg.ts
@@ -43,6 +43,14 @@
     rightRoom: number;
   };
 
+  type NativeSvgShapeGeometry = {
+    uid: string;
+    kind: "phase" | "task" | "milestone";
+    startX: number;
+    endX: number;
+    midY: number;
+  };
+
   type NativeSvgPlacementConfig = {
     cellWidth: number;
     gap: number;
@@ -157,7 +165,13 @@
       ".phaseLabel { font-size: 13px; font-weight: 700; }",
       ".grid { stroke: #c9d3e1; stroke-width: 1; }",
       ".today { stroke: #ff6b5a; stroke-width: 2; }",
+      ".dependencyPath { fill: none; stroke: #9eb6c8; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; opacity: 0.95; }",
       "</style>",
+      "<defs>",
+      '<marker id="dependencyArrow" markerWidth="7" markerHeight="7" refX="5.5" refY="3.5" orient="auto" markerUnits="strokeWidth">',
+      '<path d="M0,0 L7,3.5 L0,7 Z" fill="#9eb6c8" />',
+      "</marker>",
+      "</defs>",
       `<rect x="0" y="0" width="${svgWidth}" height="${svgHeight}" fill="#ffffff"/>`,
       `<text class="title" x="${chartOriginX + (chartWidth / 2)}" y="${TOP_PADDING + 18}" text-anchor="middle">${escapeXml(model.project.name || "-")}</text>`
     ];
@@ -180,6 +194,16 @@
       const todayX = chartOriginX + (todayIndex * DAY_WIDTH) + (DAY_WIDTH / 2);
       parts.push(`<line class="today" x1="${todayX}" y1="${TOP_PADDING + 26}" x2="${todayX}" y2="${svgHeight - BOTTOM_PADDING}" />`);
     }
+
+    parts.push(...buildDependencyConnectorElements(model.tasks, rows, chartOriginX, chartOriginY, {
+      cellWidth: DAY_WIDTH,
+      rangeInset: 6,
+      milestoneHalfWidth: 13,
+      routeOffset: 14,
+      routeSpacing: 6,
+      targetInset: 4,
+      cornerRadius: 8
+    }));
 
     for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
       const row = rows[rowIndex];
@@ -286,7 +310,13 @@
       ".grid { stroke: #c9d3e1; stroke-width: 1; }",
       ".today { stroke: #ff6b5a; stroke-width: 2; }",
       ".monthBoundary { stroke: #98a2b3; stroke-width: 1.5; }",
+      ".dependencyPath { fill: none; stroke: #9eb6c8; stroke-width: 1.5; stroke-linecap: round; stroke-linejoin: round; opacity: 0.95; }",
       "</style>",
+      "<defs>",
+      '<marker id="dependencyArrow" markerWidth="7" markerHeight="7" refX="5.5" refY="3.5" orient="auto" markerUnits="strokeWidth">',
+      '<path d="M0,0 L7,3.5 L0,7 Z" fill="#9eb6c8" />',
+      "</marker>",
+      "</defs>",
       `<rect x="0" y="0" width="${svgWidth}" height="${svgHeight}" fill="#ffffff"/>`,
       `<text class="title" x="${chartOriginX + (chartWidth / 2)}" y="${WEEKLY_TOP_PADDING + 18}" text-anchor="middle">${escapeXml(model.project.name || "-")} weekly overview</text>`,
       `<text class="meta" x="${chartOriginX + (chartWidth / 2)}" y="${WEEKLY_TOP_PADDING + 40}" text-anchor="middle">${escapeXml(`project range ${String(model.project.startDate || "").slice(0, 10)} - ${String(model.project.finishDate || "").slice(0, 10)}`)}</text>`
@@ -314,6 +344,16 @@
       const todayX = chartOriginX + (todayWeekIndex * WEEK_WIDTH) + (WEEK_WIDTH / 2);
       parts.push(`<line class="today" x1="${todayX}" y1="${WEEKLY_TOP_PADDING + 72}" x2="${todayX}" y2="${svgHeight - WEEKLY_BOTTOM_PADDING}" />`);
     }
+
+    parts.push(...buildDependencyConnectorElements(model.tasks, rows, chartOriginX, chartOriginY, {
+      cellWidth: WEEK_WIDTH,
+      rangeInset: 4,
+      milestoneHalfWidth: 11,
+      routeOffset: 12,
+      routeSpacing: 5,
+      targetInset: 4,
+      cornerRadius: 7
+    }));
 
     for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
       const row = rows[rowIndex];
@@ -782,6 +822,149 @@
       leftRoom: Math.max(0, (shapeStartX - config.gap) - chartOriginX),
       rightRoom: Math.max(0, chartEndX - (shapeEndX + config.gap))
     };
+  }
+
+  function buildDependencyConnectorElements(
+    tasks: TaskModel[],
+    rows: NativeSvgTaskRow[],
+    chartOriginX: number,
+    chartOriginY: number,
+    config: {
+      cellWidth: number;
+      rangeInset: number;
+      milestoneHalfWidth: number;
+      routeOffset: number;
+      routeSpacing: number;
+      targetInset: number;
+      cornerRadius: number;
+    }
+  ): string[] {
+    const geometryByUid = new Map<string, NativeSvgShapeGeometry>();
+    for (const row of rows) {
+      const geometry = buildShapeGeometry(row, chartOriginX, chartOriginY, config.cellWidth, config.rangeInset, config.milestoneHalfWidth);
+      if (geometry) {
+        geometryByUid.set(row.task.uid, geometry);
+      }
+    }
+
+    const parts: string[] = [];
+    let connectorIndex = 0;
+    for (const task of tasks) {
+      const toGeometry = geometryByUid.get(task.uid);
+      if (!toGeometry) {
+        continue;
+      }
+      for (const predecessor of task.predecessors || []) {
+        if (predecessor.type !== undefined && predecessor.type !== 1) {
+          continue;
+        }
+        const fromGeometry = geometryByUid.get(predecessor.predecessorUid);
+        if (!fromGeometry) {
+          continue;
+        }
+        if (fromGeometry.uid === toGeometry.uid) {
+          continue;
+        }
+        const endX = toGeometry.startX - config.targetInset;
+        const candidateLaneX = fromGeometry.endX + config.routeOffset + ((connectorIndex % 4) * config.routeSpacing);
+        const minLaneX = fromGeometry.endX + 4;
+        const maxLaneX = endX - 4;
+        const laneBaseX = maxLaneX <= minLaneX
+          ? (fromGeometry.endX + endX) / 2
+          : Math.max(minLaneX, Math.min(maxLaneX, candidateLaneX));
+        const path = buildDependencyConnectorPath(
+          fromGeometry.endX,
+          fromGeometry.midY,
+          laneBaseX,
+          endX,
+          toGeometry.midY,
+          config.cornerRadius
+        );
+        parts.push(`<path class="dependencyPath" d="${path}" marker-end="url(#dependencyArrow)" data-from-uid="${escapeXml(fromGeometry.uid)}" data-to-uid="${escapeXml(toGeometry.uid)}" data-link-type="FS"/>`);
+        connectorIndex += 1;
+      }
+    }
+    return parts;
+  }
+
+  function buildShapeGeometry(
+    row: NativeSvgTaskRow,
+    chartOriginX: number,
+    chartOriginY: number,
+    cellWidth: number,
+    rangeInset: number,
+    milestoneHalfWidth: number
+  ): NativeSvgShapeGeometry | null {
+    if (row.startIndex === null || row.endIndex === null) {
+      return null;
+    }
+    const startX = row.kind === "milestone"
+      ? chartOriginX + (row.startIndex * cellWidth) + (cellWidth / 2) - milestoneHalfWidth
+      : chartOriginX + (row.startIndex * cellWidth) + rangeInset;
+    const endX = row.kind === "milestone"
+      ? chartOriginX + (row.startIndex * cellWidth) + (cellWidth / 2) + milestoneHalfWidth
+      : chartOriginX + (row.endIndex * cellWidth) + cellWidth - rangeInset;
+    return {
+      uid: row.task.uid,
+      kind: row.kind,
+      startX,
+      endX,
+      midY: chartOriginY + row.y + (ROW_HEIGHT / 2)
+    };
+  }
+
+  function buildDependencyConnectorPath(
+    startX: number,
+    startY: number,
+    laneX: number,
+    endX: number,
+    endY: number,
+    radius: number
+  ): string {
+    if (endX <= startX) {
+      return `M ${startX} ${startY} L ${startX} ${startY}`;
+    }
+    if (startY === endY) {
+      return `M ${startX} ${startY} L ${endX} ${endY}`;
+    }
+    const directionY = endY > startY ? 1 : -1;
+    const horizontalRoom = Math.max(2, laneX - startX);
+    const targetRoom = Math.max(2, endX - laneX);
+    const verticalRoom = Math.max(2, Math.abs(endY - startY));
+    const usableRadius = Math.min(radius, horizontalRoom * 0.8, targetRoom * 0.8, verticalRoom / 3);
+    const startCurveX = startX + usableRadius;
+    const startCurveY = startY + (directionY * usableRadius);
+    const simpleEndCurveX = endX - usableRadius;
+
+    if (targetRoom >= Math.max(18, usableRadius * 3)) {
+      const horizontalStartX = laneX + usableRadius;
+      return [
+        `M ${startX} ${startY}`,
+        `C ${startCurveX} ${startY} ${laneX} ${startY} ${laneX} ${startCurveY}`,
+        `L ${laneX} ${endY - (directionY * usableRadius)}`,
+        `C ${laneX} ${endY - (directionY * Math.max(3, usableRadius * 0.45))} ${laneX} ${endY} ${horizontalStartX} ${endY}`,
+        `L ${simpleEndCurveX} ${endY}`,
+        `L ${endX} ${endY}`
+      ].join(" ");
+    }
+
+    const endCurveEntryX = endX - Math.max(usableRadius, 8);
+    const midY = startY + ((endY - startY) / 2);
+    const axisX = (startX + endCurveEntryX) / 2;
+    const symmetricBulge = Math.min(
+      Math.max(18, usableRadius * 2.4),
+      Math.max(18, (endCurveEntryX - startX) * 0.95)
+    );
+    const midRise = Math.min(
+      Math.max(10, usableRadius * 1.3),
+      Math.max(10, verticalRoom * 0.32)
+    );
+    return [
+      `M ${startX} ${startY}`,
+      `C ${axisX + symmetricBulge} ${startY} ${axisX + symmetricBulge} ${midY - (directionY * midRise)} ${axisX} ${midY}`,
+      `C ${axisX - symmetricBulge} ${midY + (directionY * midRise)} ${axisX - symmetricBulge} ${endY} ${endCurveEntryX} ${endY}`,
+      `L ${endX} ${endY}`
+    ].join(" ");
   }
 
   function buildPlacementDecision(

--- a/tests/mikuproject-main-preview-export.test.js
+++ b/tests/mikuproject-main-preview-export.test.js
@@ -302,6 +302,72 @@ describe("mikuproject main preview export", () => {
     expect(dailySvg).toContain('text-anchor="end">MS Project XML と XLSX の相互変換・round-trip実装</text>');
   });
 
+  it("renders dependency connectors in daily and weekly native svg", () => {
+    bootPage();
+
+    const model = {
+      project: {
+        name: "Dependency Demo",
+        startDate: "2026-03-16T09:00:00",
+        finishDate: "2026-03-20T18:00:00",
+        currentDate: "2026-03-18T12:00:00",
+        scheduleFromStart: true,
+        outlineCodes: [],
+        wbsMasks: [],
+        extendedAttributes: []
+      },
+      tasks: [
+        {
+          uid: "1",
+          id: "1",
+          name: "Prep",
+          outlineLevel: 1,
+          outlineNumber: "1",
+          start: "2026-03-16T09:00:00",
+          finish: "2026-03-17T18:00:00",
+          duration: "PT16H0M0S",
+          milestone: false,
+          summary: false,
+          percentComplete: 100,
+          predecessors: [],
+          extendedAttributes: [],
+          baselines: [],
+          timephasedData: []
+        },
+        {
+          uid: "2",
+          id: "2",
+          name: "Ship",
+          outlineLevel: 1,
+          outlineNumber: "2",
+          start: "2026-03-18T09:00:00",
+          finish: "2026-03-19T18:00:00",
+          duration: "PT16H0M0S",
+          milestone: false,
+          summary: false,
+          percentComplete: 0,
+          predecessors: [{ predecessorUid: "1", type: 1 }],
+          extendedAttributes: [],
+          baselines: [],
+          timephasedData: []
+        }
+      ],
+      resources: [],
+      assignments: [],
+      calendars: []
+    };
+
+    const dailySvg = globalThis.__mikuprojectNativeSvg.exportNativeSvg(model);
+    const weeklySvg = globalThis.__mikuprojectNativeSvg.exportWeeklyNativeSvg(model);
+
+    expect(dailySvg).toContain('class="dependencyPath"');
+    expect(dailySvg).toContain('marker-end="url(#dependencyArrow)"');
+    expect(dailySvg).toContain('data-from-uid="1"');
+    expect(dailySvg).toContain('data-to-uid="2"');
+    expect(weeklySvg).toContain('class="dependencyPath"');
+    expect(weeklySvg).toContain('marker-end="url(#dependencyArrow)"');
+  });
+
   it("exports csv with parent id from the current model", async () => {
     bootPage();
 


### PR DESCRIPTION
## 概要

`Daily / Weekly` の native SVG 出力に、task の前後関係を表すコネクタ線を追加しました。 first cut として、少なくとも `FS` 依存関係を背面レイヤで描画する実装です。

## 変更内容

### SVG の前後関係コネクタ追加

- `src/ts/wbs-svg.ts` で dependency connector の描画を追加
- `Daily` と `Weekly` の native SVG 出力で、task bar より背面に dependency line を描画
- connector は task 本体より細い線で描画
- arrow marker を追加し、依存の向きを示すようにした
- first cut では `FS` 依存関係を対象にしている

### 描画ロジック

- task / phase / milestone の shape geometry を使って connector の始点・終点を算出
- 近接ケースと離れているケースで path の分岐を持つ
- コネクタは bar や label の前面ではなく、背景寄りのレイヤで描画する

### テスト

- `tests/mikuproject-main-preview-export.test.js` に dependency connector 出力確認を追加
- `Daily` / `Weekly` の native SVG に connector と marker が含まれることを確認

## 更新ファイル

- `src/ts/wbs-svg.ts`
- `tests/mikuproject-main-preview-export.test.js`