### PR TITLE
`XLSX` / `workbook JSON` import を全置換に統一し、UI 文言を挙動に合わせて整理

### DIFF
--- a/mikuproject.html
+++ b/mikuproject.html
@@ -10953,6 +10953,21 @@ if (!customElements.get("lht-page-menu")) {
     function importProjectWorkbook(workbook, baseModel) {
         return importProjectWorkbookDetailed(workbook, baseModel).model;
     }
+    function importProjectWorkbookAsProjectModel(workbook) {
+        const project = importProjectSheetAsProjectInfo(workbook);
+        const tasks = importTasksSheetAsTasks(workbook);
+        const resources = importResourcesSheetAsResources(workbook);
+        const assignments = importAssignmentsSheetAsAssignments(workbook);
+        const calendars = importCalendarsSheetAsCalendars(workbook, project);
+        importNonWorkingDaysSheetAsCalendarExceptions(workbook, calendars);
+        return {
+            project,
+            tasks,
+            resources,
+            assignments,
+            calendars
+        };
+    }
     function importProjectWorkbookDetailed(workbook, baseModel) {
         const nextModel = cloneProjectModel(baseModel);
         const changes = [];
@@ -10994,6 +11009,37 @@ if (!customElements.get("lht-page-menu")) {
         assignIfChanged(changes, "project", "project", projectLabel, model.project, "minutesPerWeek", "MinutesPerWeek", readNumberCell(valueByField.get("MinutesPerWeek")));
         assignIfChanged(changes, "project", "project", projectLabel, model.project, "daysPerMonth", "DaysPerMonth", readNumberCell(valueByField.get("DaysPerMonth")));
         assignIfChanged(changes, "project", "project", projectLabel, model.project, "scheduleFromStart", "ScheduleFromStart", readBooleanCell(valueByField.get("ScheduleFromStart")));
+    }
+    function importProjectSheetAsProjectInfo(workbook) {
+        var _a;
+        const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
+        const valueByField = new Map();
+        for (const row of (projectSheet === null || projectSheet === void 0 ? void 0 : projectSheet.rows.slice(DATA_ROW_START_INDEX)) || []) {
+            const field = readStringCell(row.cells[0]);
+            if (!field) {
+                continue;
+            }
+            valueByField.set(field, row.cells[1]);
+        }
+        const name = readStringCell(valueByField.get("Name")) || "Imported Project";
+        return {
+            name,
+            title: readStringCell(valueByField.get("Title")) || undefined,
+            author: readStringCell(valueByField.get("Author")) || undefined,
+            company: readStringCell(valueByField.get("Company")) || undefined,
+            startDate: normalizeDateTimeInput(readStringCell(valueByField.get("StartDate"))) || "",
+            finishDate: normalizeDateTimeInput(readStringCell(valueByField.get("FinishDate"))) || "",
+            currentDate: normalizeDateTimeInput(readStringCell(valueByField.get("CurrentDate"))) || undefined,
+            statusDate: normalizeDateTimeInput(readStringCell(valueByField.get("StatusDate"))) || undefined,
+            calendarUID: readStringCell(valueByField.get("CalendarUID")) || undefined,
+            minutesPerDay: readNumberCell(valueByField.get("MinutesPerDay")),
+            minutesPerWeek: readNumberCell(valueByField.get("MinutesPerWeek")),
+            daysPerMonth: readNumberCell(valueByField.get("DaysPerMonth")),
+            scheduleFromStart: (_a = readBooleanCell(valueByField.get("ScheduleFromStart"))) !== null && _a !== void 0 ? _a : true,
+            outlineCodes: [],
+            wbsMasks: [],
+            extendedAttributes: []
+        };
     }
     function buildProjectSheet(model) {
         const project = model.project;
@@ -11537,6 +11583,48 @@ if (!customElements.get("lht-page-menu")) {
             assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "notes", "Notes", readStringCellAt(row.cells, columnIndexByLabel.get("Notes")));
         }
     }
+    function importTasksSheetAsTasks(workbook) {
+        var _a, _b, _c, _d;
+        const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+        if (!tasksSheet) {
+            return [];
+        }
+        const columnIndexByLabel = readHeaderMap(tasksSheet, HEADER_ROW_INDEX);
+        const uidColumnIndex = columnIndexByLabel.get("UID");
+        if (uidColumnIndex === undefined) {
+            return [];
+        }
+        const tasks = [];
+        for (const [rowIndex, row] of tasksSheet.rows.slice(DATA_ROW_START_INDEX).entries()) {
+            const uid = readStringCell(row.cells[uidColumnIndex]);
+            if (!uid) {
+                continue;
+            }
+            tasks.push({
+                uid,
+                id: readStringCellAt(row.cells, columnIndexByLabel.get("ID")) || String(rowIndex + 1),
+                name: readStringCellAt(row.cells, columnIndexByLabel.get("Name")) || uid,
+                outlineLevel: readNumberCellAt(row.cells, columnIndexByLabel.get("OutlineLevel")) || 1,
+                outlineNumber: readStringCellAt(row.cells, columnIndexByLabel.get("OutlineNumber")) || String(rowIndex + 1),
+                wbs: readStringCellAt(row.cells, columnIndexByLabel.get("WBS")) || undefined,
+                start: normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Start"))) || "",
+                finish: normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Finish"))) || "",
+                duration: readStringCellAt(row.cells, columnIndexByLabel.get("Duration")) || "",
+                milestone: (_a = readBooleanCellAt(row.cells, columnIndexByLabel.get("Milestone"))) !== null && _a !== void 0 ? _a : false,
+                summary: (_b = readBooleanCellAt(row.cells, columnIndexByLabel.get("Summary"))) !== null && _b !== void 0 ? _b : false,
+                critical: (_c = readBooleanCellAt(row.cells, columnIndexByLabel.get("Critical"))) !== null && _c !== void 0 ? _c : undefined,
+                percentComplete: readNumberCellAt(row.cells, columnIndexByLabel.get("PercentComplete")) || 0,
+                percentWorkComplete: (_d = readNumberCellAt(row.cells, columnIndexByLabel.get("PercentWorkComplete"))) !== null && _d !== void 0 ? _d : undefined,
+                calendarUID: readStringCellAt(row.cells, columnIndexByLabel.get("CalendarUID")) || undefined,
+                notes: readStringCellAt(row.cells, columnIndexByLabel.get("Notes")) || undefined,
+                predecessors: parsePredecessorCell(readStringCellAt(row.cells, columnIndexByLabel.get("Predecessors"))) || [],
+                extendedAttributes: [],
+                baselines: [],
+                timephasedData: []
+            });
+        }
+        return tasks;
+    }
     function importResourcesSheet(workbook, model, changes) {
         const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
         if (!resourcesSheet) {
@@ -11564,6 +11652,45 @@ if (!customElements.get("lht-page-menu")) {
             assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "calendarUID", "CalendarUID", readStringCellAt(row.cells, columnIndexByLabel.get("CalendarUID")));
         }
     }
+    function importResourcesSheetAsResources(workbook) {
+        var _a, _b, _c;
+        const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
+        if (!resourcesSheet) {
+            return [];
+        }
+        const columnIndexByLabel = readHeaderMap(resourcesSheet, HEADER_ROW_INDEX);
+        const uidColumnIndex = columnIndexByLabel.get("UID");
+        if (uidColumnIndex === undefined) {
+            return [];
+        }
+        const resources = [];
+        for (const [rowIndex, row] of resourcesSheet.rows.slice(DATA_ROW_START_INDEX).entries()) {
+            const uid = readStringCell(row.cells[uidColumnIndex]);
+            if (!uid) {
+                continue;
+            }
+            resources.push({
+                uid,
+                id: readStringCellAt(row.cells, columnIndexByLabel.get("ID")) || String(rowIndex + 1),
+                name: readStringCellAt(row.cells, columnIndexByLabel.get("Name")) || uid,
+                type: (_a = readNumberCellAt(row.cells, columnIndexByLabel.get("Type"))) !== null && _a !== void 0 ? _a : undefined,
+                initials: readStringCellAt(row.cells, columnIndexByLabel.get("Initials")) || undefined,
+                group: readStringCellAt(row.cells, columnIndexByLabel.get("Group")) || undefined,
+                maxUnits: (_b = readNumberCellAt(row.cells, columnIndexByLabel.get("MaxUnits"))) !== null && _b !== void 0 ? _b : undefined,
+                calendarUID: readStringCellAt(row.cells, columnIndexByLabel.get("CalendarUID")) || undefined,
+                standardRate: readStringCellAt(row.cells, columnIndexByLabel.get("StandardRate")) || undefined,
+                overtimeRate: readStringCellAt(row.cells, columnIndexByLabel.get("OvertimeRate")) || undefined,
+                costPerUse: (_c = readNumberCellAt(row.cells, columnIndexByLabel.get("CostPerUse"))) !== null && _c !== void 0 ? _c : undefined,
+                work: readStringCellAt(row.cells, columnIndexByLabel.get("Work")) || undefined,
+                actualWork: readStringCellAt(row.cells, columnIndexByLabel.get("ActualWork")) || undefined,
+                remainingWork: readStringCellAt(row.cells, columnIndexByLabel.get("RemainingWork")) || undefined,
+                extendedAttributes: [],
+                baselines: [],
+                timephasedData: []
+            });
+        }
+        return resources;
+    }
     function importAssignmentsSheet(workbook, model, changes) {
         const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
         if (!assignmentsSheet) {
@@ -11590,6 +11717,46 @@ if (!customElements.get("lht-page-menu")) {
             assignIfChanged(changes, "assignments", assignment.uid, assignmentLabel, assignment, "percentWorkComplete", "PercentWorkComplete", readNumberCellAt(row.cells, columnIndexByLabel.get("PercentWorkComplete")));
         }
     }
+    function importAssignmentsSheetAsAssignments(workbook) {
+        var _a, _b;
+        const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
+        if (!assignmentsSheet) {
+            return [];
+        }
+        const columnIndexByLabel = readHeaderMap(assignmentsSheet, HEADER_ROW_INDEX);
+        const uidColumnIndex = columnIndexByLabel.get("UID");
+        if (uidColumnIndex === undefined) {
+            return [];
+        }
+        const assignments = [];
+        for (const row of assignmentsSheet.rows.slice(DATA_ROW_START_INDEX)) {
+            const uid = readStringCell(row.cells[uidColumnIndex]);
+            if (!uid) {
+                continue;
+            }
+            const taskUid = readStringCellAt(row.cells, columnIndexByLabel.get("TaskUID"));
+            const resourceUid = readStringCellAt(row.cells, columnIndexByLabel.get("ResourceUID"));
+            if (!taskUid || !resourceUid) {
+                continue;
+            }
+            assignments.push({
+                uid,
+                taskUid,
+                resourceUid,
+                start: normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Start"))) || undefined,
+                finish: normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Finish"))) || undefined,
+                units: (_a = readNumberCellAt(row.cells, columnIndexByLabel.get("Units"))) !== null && _a !== void 0 ? _a : undefined,
+                work: readStringCellAt(row.cells, columnIndexByLabel.get("Work")) || undefined,
+                actualWork: readStringCellAt(row.cells, columnIndexByLabel.get("ActualWork")) || undefined,
+                remainingWork: readStringCellAt(row.cells, columnIndexByLabel.get("RemainingWork")) || undefined,
+                percentWorkComplete: (_b = readNumberCellAt(row.cells, columnIndexByLabel.get("PercentWorkComplete"))) !== null && _b !== void 0 ? _b : undefined,
+                extendedAttributes: [],
+                baselines: [],
+                timephasedData: []
+            });
+        }
+        return assignments;
+    }
     function importCalendarsSheet(workbook, model, changes) {
         const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
         if (!calendarsSheet) {
@@ -11615,6 +11782,44 @@ if (!customElements.get("lht-page-menu")) {
             assignIfChanged(changes, "calendars", calendar.uid, calendarLabel, calendar, "isBaseCalendar", "IsBaseCalendar", readBooleanCellAt(row.cells, columnIndexByLabel.get("IsBaseCalendar")));
             assignIfChanged(changes, "calendars", calendar.uid, calendarLabel, calendar, "baseCalendarUID", "BaseCalendarUID", readStringCellAt(row.cells, columnIndexByLabel.get("BaseCalendarUID")));
         }
+    }
+    function importCalendarsSheetAsCalendars(workbook, project) {
+        var _a;
+        const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+        const calendars = [];
+        const columnIndexByLabel = calendarsSheet ? readHeaderMap(calendarsSheet, HEADER_ROW_INDEX) : new Map();
+        const uidColumnIndex = columnIndexByLabel.get("UID");
+        if (calendarsSheet && uidColumnIndex !== undefined) {
+            for (const row of calendarsSheet.rows.slice(DATA_ROW_START_INDEX)) {
+                const uid = readStringCell(row.cells[uidColumnIndex]);
+                if (!uid) {
+                    continue;
+                }
+                calendars.push({
+                    uid,
+                    name: readStringCellAt(row.cells, columnIndexByLabel.get("Name")) || uid,
+                    isBaseCalendar: (_a = readBooleanCellAt(row.cells, columnIndexByLabel.get("IsBaseCalendar"))) !== null && _a !== void 0 ? _a : false,
+                    baseCalendarUID: readStringCellAt(row.cells, columnIndexByLabel.get("BaseCalendarUID")) || undefined,
+                    weekDays: [],
+                    exceptions: [],
+                    workWeeks: []
+                });
+            }
+        }
+        if (calendars.length === 0) {
+            calendars.push({
+                uid: project.calendarUID || "1",
+                name: "Standard",
+                isBaseCalendar: true,
+                weekDays: buildDefaultStandardWeekDays(project),
+                exceptions: [],
+                workWeeks: []
+            });
+            if (!project.calendarUID) {
+                project.calendarUID = calendars[0].uid;
+            }
+        }
+        return calendars;
     }
     function importNonWorkingDaysSheet(workbook, model, changes) {
         const nonWorkingDaysSheet = workbook.sheets.find((sheet) => sheet.name === "NonWorkingDays");
@@ -11658,6 +11863,80 @@ if (!customElements.get("lht-page-menu")) {
             }
             assignIfChanged(changes, "calendars", calendar.uid, calendar.name, exception, "dayWorking", `Exception${indexValue}.DayWorking`, readBooleanCellAt(row.cells, columnIndexByLabel.get("DayWorking")));
         }
+    }
+    function importNonWorkingDaysSheetAsCalendarExceptions(workbook, calendars) {
+        var _a;
+        const nonWorkingDaysSheet = workbook.sheets.find((sheet) => sheet.name === "NonWorkingDays");
+        if (!nonWorkingDaysSheet) {
+            return;
+        }
+        const columnIndexByLabel = readHeaderMap(nonWorkingDaysSheet, HEADER_ROW_INDEX);
+        const calendarUidColumnIndex = columnIndexByLabel.get("CalendarUID");
+        const indexColumnIndex = columnIndexByLabel.get("Index");
+        if (calendarUidColumnIndex === undefined || indexColumnIndex === undefined) {
+            return;
+        }
+        const calendarByUid = new Map(calendars.map((calendar) => [calendar.uid, calendar]));
+        for (const row of nonWorkingDaysSheet.rows.slice(DATA_ROW_START_INDEX)) {
+            const calendarUid = readStringCell(row.cells[calendarUidColumnIndex]);
+            const indexValue = readNumberCell(row.cells[indexColumnIndex]);
+            if (!calendarUid || !indexValue) {
+                continue;
+            }
+            const calendar = calendarByUid.get(calendarUid);
+            if (!calendar) {
+                continue;
+            }
+            const dateValue = readStringCellAt(row.cells, columnIndexByLabel.get("Date"));
+            const name = readStringCellAt(row.cells, columnIndexByLabel.get("Name")) || undefined;
+            const dayWorking = (_a = readBooleanCellAt(row.cells, columnIndexByLabel.get("DayWorking"))) !== null && _a !== void 0 ? _a : false;
+            let fromDate;
+            let toDate;
+            if (dateValue) {
+                const normalizedDate = normalizeDateOnly(dateValue);
+                if (normalizedDate) {
+                    fromDate = `${normalizedDate}T00:00:00`;
+                    toDate = `${normalizedDate}T23:59:59`;
+                }
+            }
+            else {
+                fromDate = normalizeExceptionBoundaryInput(readStringCellAt(row.cells, columnIndexByLabel.get("FromDate")), false) || undefined;
+                toDate = normalizeExceptionBoundaryInput(readStringCellAt(row.cells, columnIndexByLabel.get("ToDate")), true) || undefined;
+            }
+            calendar.exceptions[indexValue - 1] = {
+                name,
+                fromDate,
+                toDate,
+                dayWorking,
+                workingTimes: []
+            };
+        }
+        for (const calendar of calendars) {
+            calendar.exceptions = calendar.exceptions.filter(Boolean);
+        }
+    }
+    function buildDefaultWorkingTimes(project) {
+        const start = project.defaultStartTime || "09:00:00";
+        const finish = project.defaultFinishTime || "18:00:00";
+        if (start < "12:00:00" && finish > "13:00:00") {
+            return [
+                { fromTime: start, toTime: "12:00:00" },
+                { fromTime: "13:00:00", toTime: finish }
+            ];
+        }
+        return [{ fromTime: start, toTime: finish }];
+    }
+    function buildDefaultStandardWeekDays(project) {
+        const workingTimes = buildDefaultWorkingTimes(project);
+        return Array.from({ length: 7 }, (_, index) => {
+            const dayType = index + 1;
+            const dayWorking = dayType !== 1 && dayType !== 7;
+            return {
+                dayType,
+                dayWorking,
+                workingTimes: dayWorking ? workingTimes.map((item) => ({ ...item })) : []
+            };
+        });
     }
     function formatExceptionDate(exception) {
         var _a, _b;
@@ -11872,6 +12151,7 @@ if (!customElements.get("lht-page-menu")) {
     globalThis.__mikuprojectProjectXlsx = {
         exportProjectWorkbook,
         importProjectWorkbook,
+        importProjectWorkbookAsProjectModel,
         importProjectWorkbookDetailed
     };
 })();
@@ -11923,6 +12203,24 @@ if (!customElements.get("lht-page-menu")) {
         const result = projectXlsx.importProjectWorkbookDetailed(workbook, baseModel);
         return {
             ...result,
+            warnings: validation.warnings
+        };
+    }
+    function importProjectWorkbookJsonAsProjectModel(documentLike) {
+        const validation = validateWorkbookJsonDocument(documentLike);
+        const document = validation.document;
+        const workbook = {
+            sheets: [
+                buildProjectSheet(document.sheets.Project || []),
+                buildTabularSheet("Tasks", document.sheets.Tasks || [], SHEET_HEADERS.Tasks),
+                buildTabularSheet("Resources", document.sheets.Resources || [], SHEET_HEADERS.Resources),
+                buildTabularSheet("Assignments", document.sheets.Assignments || [], SHEET_HEADERS.Assignments),
+                buildTabularSheet("Calendars", document.sheets.Calendars || [], SHEET_HEADERS.Calendars),
+                buildTabularSheet("NonWorkingDays", document.sheets.NonWorkingDays || [], SHEET_HEADERS.NonWorkingDays)
+            ]
+        };
+        return {
+            model: projectXlsx.importProjectWorkbookAsProjectModel(workbook),
             warnings: validation.warnings
         };
     }
@@ -12064,6 +12362,7 @@ if (!customElements.get("lht-page-menu")) {
     }
     globalThis.__mikuprojectProjectWorkbookJson = {
         exportProjectWorkbookJson,
+        importProjectWorkbookJsonAsProjectModel,
         importProjectWorkbookJson,
         validateWorkbookJsonDocument
     };
@@ -17206,8 +17505,14 @@ if (!customElements.get("lht-page-menu")) {
         if (sourceLabel === "Patch JSON") {
             return "Patch JSON の部分適用結果です。反映後の XML は更新済みで、必要なら XML Export で保存できます。";
         }
+        if (sourceLabel === "JSON Replace") {
+            return "workbook JSON による全置換結果です。差分表示は取込前の project との差を示します。";
+        }
         if (sourceLabel === "JSON Import") {
             return "workbook JSON の取込結果です。反映後の XML は更新済みで、必要なら XML Export で保存できます。";
+        }
+        if (sourceLabel === "XLSX Replace") {
+            return "XLSX による全置換結果です。差分表示は取込前の project との差を示します。";
         }
         if (sourceLabel === "XLSX Import") {
             return "Excel 編集結果の取込内容です。反映後の XML は更新済みで、必要なら XML Export で保存できます。";
@@ -18212,25 +18517,22 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
             throw new Error("workbook JSON を入力してください");
         }
         const documentLike = JSON.parse(mikuprojectAiJsonUtil.extractLastJsonBlock(trimmedSourceText));
-        const baseModel = ensureCurrentModel();
-        const result = mikuprojectProjectWorkbookJson.importProjectWorkbookJson(documentLike, baseModel);
-        currentModel = result.model;
+        const previousModel = currentModel;
+        const replaceResult = mikuprojectProjectWorkbookJson.importProjectWorkbookJsonAsProjectModel(documentLike);
+        currentModel = replaceResult.model;
+        const diffResult = previousModel
+            ? mikuprojectProjectWorkbookJson.importProjectWorkbookJson(documentLike, previousModel)
+            : { changes: [], warnings: replaceResult.warnings };
         const issues = mikuprojectXml.validateProjectModel(currentModel);
+        syncXmlTextFromModel(currentModel);
         updateSummary(currentModel);
         renderValidationIssues(issues);
-        renderImportWarnings(result.warnings, { sourceLabel: "JSON Import" });
-        renderXlsxImportSummary(result.changes, { sourceLabel: "JSON Import", warnings: result.warnings });
-        if (result.changes.length > 0) {
-            getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
-            markXmlDirty();
-        }
-        isXmlSourceDirty = false;
-        const summaryText = result.changes.length > 0
-            ? `JSON を読み込んで ${result.changes.length} 件の変更を反映しました。XML は再生成済みで、必要なら XML Export で保存できます`
-            : "JSON に反映対象の変更はありませんでした。XML は未変更です";
-        const warningText = result.warnings.length > 0 ? `。JSON 取込で ${result.warnings.length} 件の warning を無視しました` : "";
+        renderImportWarnings(replaceResult.warnings, { sourceLabel: "JSON Replace" });
+        renderXlsxImportSummary(diffResult.changes, { sourceLabel: "JSON Replace", warnings: replaceResult.warnings });
+        const summaryText = "JSON を読み込んで project 全体を置き換えました。XML は再生成済みで、必要なら XML Export で保存できます";
+        const warningText = replaceResult.warnings.length > 0 ? `。JSON 取込で ${replaceResult.warnings.length} 件の warning を無視しました` : "";
         setStatus(issues.length > 0 ? `${summaryText}${warningText}。検証で ${issues.length} 件の問題があります` : `${summaryText}${warningText}`);
-        showToast("JSON を反映しました");
+        showToast("JSON を読み込みました");
         setActiveTab("transform", { skipTransformRefresh: true });
         await exportCurrentMermaid({ silent: true });
     }
@@ -18383,29 +18685,25 @@ WorkWeek1=${formatCalendarWorkWeekSummary(calendar)}</div>
         if (!file) {
             return;
         }
-        const baseModel = ensureCurrentModel();
+        const previousModel = currentModel;
         const bytes = new Uint8Array(await file.arrayBuffer());
         const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
         const workbook = typeof codec.importWorkbookAsync === "function"
             ? await codec.importWorkbookAsync(bytes)
             : codec.importWorkbook(bytes);
-        const result = mikuprojectProjectXlsx.importProjectWorkbookDetailed(workbook, baseModel);
-        currentModel = result.model;
+        currentModel = mikuprojectProjectXlsx.importProjectWorkbookAsProjectModel(workbook);
+        const diffResult = previousModel
+            ? mikuprojectProjectXlsx.importProjectWorkbookDetailed(workbook, previousModel)
+            : { changes: [] };
         const issues = mikuprojectXml.validateProjectModel(currentModel);
+        syncXmlTextFromModel(currentModel);
         updateSummary(currentModel);
         renderValidationIssues(issues);
         renderImportWarnings([]);
-        renderXlsxImportSummary(result.changes, { sourceLabel: "XLSX Import" });
-        if (result.changes.length > 0) {
-            getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
-            markXmlDirty();
-        }
-        const summaryText = result.changes.length > 0
-            ? `XLSX を読み込んで ${result.changes.length} 件の変更を反映しました。XML は再生成済みで、必要なら XML Export で保存できます`
-            : "XLSX に反映対象の変更はありませんでした。XML は未変更です";
-        isXmlSourceDirty = false;
+        renderXlsxImportSummary(diffResult.changes, { sourceLabel: "XLSX Replace" });
+        const summaryText = "XLSX を読み込んで project 全体を置き換えました。XML は再生成済みで、必要なら XML Export で保存できます";
         setStatus(issues.length > 0 ? `${summaryText}。検証で ${issues.length} 件の問題があります` : summaryText);
-        showToast("XLSX を反映しました");
+        showToast("XLSX を読み込みました");
         setActiveTab("transform", { skipTransformRefresh: true });
         await exportCurrentMermaid({ silent: true });
     }

--- a/src/js/main-render.js
+++ b/src/js/main-render.js
@@ -171,8 +171,14 @@
         if (sourceLabel === "Patch JSON") {
             return "Patch JSON の部分適用結果です。反映後の XML は更新済みで、必要なら XML Export で保存できます。";
         }
+        if (sourceLabel === "JSON Replace") {
+            return "workbook JSON による全置換結果です。差分表示は取込前の project との差を示します。";
+        }
         if (sourceLabel === "JSON Import") {
             return "workbook JSON の取込結果です。反映後の XML は更新済みで、必要なら XML Export で保存できます。";
+        }
+        if (sourceLabel === "XLSX Replace") {
+            return "XLSX による全置換結果です。差分表示は取込前の project との差を示します。";
         }
         if (sourceLabel === "XLSX Import") {
             return "Excel 編集結果の取込内容です。反映後の XML は更新済みで、必要なら XML Export で保存できます。";

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -676,25 +676,22 @@
             throw new Error("workbook JSON を入力してください");
         }
         const documentLike = JSON.parse(mikuprojectAiJsonUtil.extractLastJsonBlock(trimmedSourceText));
-        const baseModel = ensureCurrentModel();
-        const result = mikuprojectProjectWorkbookJson.importProjectWorkbookJson(documentLike, baseModel);
-        currentModel = result.model;
+        const previousModel = currentModel;
+        const replaceResult = mikuprojectProjectWorkbookJson.importProjectWorkbookJsonAsProjectModel(documentLike);
+        currentModel = replaceResult.model;
+        const diffResult = previousModel
+            ? mikuprojectProjectWorkbookJson.importProjectWorkbookJson(documentLike, previousModel)
+            : { changes: [], warnings: replaceResult.warnings };
         const issues = mikuprojectXml.validateProjectModel(currentModel);
+        syncXmlTextFromModel(currentModel);
         updateSummary(currentModel);
         renderValidationIssues(issues);
-        renderImportWarnings(result.warnings, { sourceLabel: "JSON Import" });
-        renderXlsxImportSummary(result.changes, { sourceLabel: "JSON Import", warnings: result.warnings });
-        if (result.changes.length > 0) {
-            getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
-            markXmlDirty();
-        }
-        isXmlSourceDirty = false;
-        const summaryText = result.changes.length > 0
-            ? `JSON を読み込んで ${result.changes.length} 件の変更を反映しました。XML は再生成済みで、必要なら XML Export で保存できます`
-            : "JSON に反映対象の変更はありませんでした。XML は未変更です";
-        const warningText = result.warnings.length > 0 ? `。JSON 取込で ${result.warnings.length} 件の warning を無視しました` : "";
+        renderImportWarnings(replaceResult.warnings, { sourceLabel: "JSON Replace" });
+        renderXlsxImportSummary(diffResult.changes, { sourceLabel: "JSON Replace", warnings: replaceResult.warnings });
+        const summaryText = "JSON を読み込んで project 全体を置き換えました。XML は再生成済みで、必要なら XML Export で保存できます";
+        const warningText = replaceResult.warnings.length > 0 ? `。JSON 取込で ${replaceResult.warnings.length} 件の warning を無視しました` : "";
         setStatus(issues.length > 0 ? `${summaryText}${warningText}。検証で ${issues.length} 件の問題があります` : `${summaryText}${warningText}`);
-        showToast("JSON を反映しました");
+        showToast("JSON を読み込みました");
         setActiveTab("transform", { skipTransformRefresh: true });
         await exportCurrentMermaid({ silent: true });
     }
@@ -847,29 +844,25 @@
         if (!file) {
             return;
         }
-        const baseModel = ensureCurrentModel();
+        const previousModel = currentModel;
         const bytes = new Uint8Array(await file.arrayBuffer());
         const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
         const workbook = typeof codec.importWorkbookAsync === "function"
             ? await codec.importWorkbookAsync(bytes)
             : codec.importWorkbook(bytes);
-        const result = mikuprojectProjectXlsx.importProjectWorkbookDetailed(workbook, baseModel);
-        currentModel = result.model;
+        currentModel = mikuprojectProjectXlsx.importProjectWorkbookAsProjectModel(workbook);
+        const diffResult = previousModel
+            ? mikuprojectProjectXlsx.importProjectWorkbookDetailed(workbook, previousModel)
+            : { changes: [] };
         const issues = mikuprojectXml.validateProjectModel(currentModel);
+        syncXmlTextFromModel(currentModel);
         updateSummary(currentModel);
         renderValidationIssues(issues);
         renderImportWarnings([]);
-        renderXlsxImportSummary(result.changes, { sourceLabel: "XLSX Import" });
-        if (result.changes.length > 0) {
-            getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
-            markXmlDirty();
-        }
-        const summaryText = result.changes.length > 0
-            ? `XLSX を読み込んで ${result.changes.length} 件の変更を反映しました。XML は再生成済みで、必要なら XML Export で保存できます`
-            : "XLSX に反映対象の変更はありませんでした。XML は未変更です";
-        isXmlSourceDirty = false;
+        renderXlsxImportSummary(diffResult.changes, { sourceLabel: "XLSX Replace" });
+        const summaryText = "XLSX を読み込んで project 全体を置き換えました。XML は再生成済みで、必要なら XML Export で保存できます";
         setStatus(issues.length > 0 ? `${summaryText}。検証で ${issues.length} 件の問題があります` : summaryText);
-        showToast("XLSX を反映しました");
+        showToast("XLSX を読み込みました");
         setActiveTab("transform", { skipTransformRefresh: true });
         await exportCurrentMermaid({ silent: true });
     }

--- a/src/js/project-workbook-json.js
+++ b/src/js/project-workbook-json.js
@@ -46,6 +46,24 @@
             warnings: validation.warnings
         };
     }
+    function importProjectWorkbookJsonAsProjectModel(documentLike) {
+        const validation = validateWorkbookJsonDocument(documentLike);
+        const document = validation.document;
+        const workbook = {
+            sheets: [
+                buildProjectSheet(document.sheets.Project || []),
+                buildTabularSheet("Tasks", document.sheets.Tasks || [], SHEET_HEADERS.Tasks),
+                buildTabularSheet("Resources", document.sheets.Resources || [], SHEET_HEADERS.Resources),
+                buildTabularSheet("Assignments", document.sheets.Assignments || [], SHEET_HEADERS.Assignments),
+                buildTabularSheet("Calendars", document.sheets.Calendars || [], SHEET_HEADERS.Calendars),
+                buildTabularSheet("NonWorkingDays", document.sheets.NonWorkingDays || [], SHEET_HEADERS.NonWorkingDays)
+            ]
+        };
+        return {
+            model: projectXlsx.importProjectWorkbookAsProjectModel(workbook),
+            warnings: validation.warnings
+        };
+    }
     function validateWorkbookJsonDocument(documentLike) {
         if (!documentLike || typeof documentLike !== "object") {
             throw new Error("workbook JSON がオブジェクトではありません");
@@ -184,6 +202,7 @@
     }
     globalThis.__mikuprojectProjectWorkbookJson = {
         exportProjectWorkbookJson,
+        importProjectWorkbookJsonAsProjectModel,
         importProjectWorkbookJson,
         validateWorkbookJsonDocument
     };

--- a/src/js/project-xlsx.js
+++ b/src/js/project-xlsx.js
@@ -57,6 +57,21 @@
     function importProjectWorkbook(workbook, baseModel) {
         return importProjectWorkbookDetailed(workbook, baseModel).model;
     }
+    function importProjectWorkbookAsProjectModel(workbook) {
+        const project = importProjectSheetAsProjectInfo(workbook);
+        const tasks = importTasksSheetAsTasks(workbook);
+        const resources = importResourcesSheetAsResources(workbook);
+        const assignments = importAssignmentsSheetAsAssignments(workbook);
+        const calendars = importCalendarsSheetAsCalendars(workbook, project);
+        importNonWorkingDaysSheetAsCalendarExceptions(workbook, calendars);
+        return {
+            project,
+            tasks,
+            resources,
+            assignments,
+            calendars
+        };
+    }
     function importProjectWorkbookDetailed(workbook, baseModel) {
         const nextModel = cloneProjectModel(baseModel);
         const changes = [];
@@ -98,6 +113,37 @@
         assignIfChanged(changes, "project", "project", projectLabel, model.project, "minutesPerWeek", "MinutesPerWeek", readNumberCell(valueByField.get("MinutesPerWeek")));
         assignIfChanged(changes, "project", "project", projectLabel, model.project, "daysPerMonth", "DaysPerMonth", readNumberCell(valueByField.get("DaysPerMonth")));
         assignIfChanged(changes, "project", "project", projectLabel, model.project, "scheduleFromStart", "ScheduleFromStart", readBooleanCell(valueByField.get("ScheduleFromStart")));
+    }
+    function importProjectSheetAsProjectInfo(workbook) {
+        var _a;
+        const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
+        const valueByField = new Map();
+        for (const row of (projectSheet === null || projectSheet === void 0 ? void 0 : projectSheet.rows.slice(DATA_ROW_START_INDEX)) || []) {
+            const field = readStringCell(row.cells[0]);
+            if (!field) {
+                continue;
+            }
+            valueByField.set(field, row.cells[1]);
+        }
+        const name = readStringCell(valueByField.get("Name")) || "Imported Project";
+        return {
+            name,
+            title: readStringCell(valueByField.get("Title")) || undefined,
+            author: readStringCell(valueByField.get("Author")) || undefined,
+            company: readStringCell(valueByField.get("Company")) || undefined,
+            startDate: normalizeDateTimeInput(readStringCell(valueByField.get("StartDate"))) || "",
+            finishDate: normalizeDateTimeInput(readStringCell(valueByField.get("FinishDate"))) || "",
+            currentDate: normalizeDateTimeInput(readStringCell(valueByField.get("CurrentDate"))) || undefined,
+            statusDate: normalizeDateTimeInput(readStringCell(valueByField.get("StatusDate"))) || undefined,
+            calendarUID: readStringCell(valueByField.get("CalendarUID")) || undefined,
+            minutesPerDay: readNumberCell(valueByField.get("MinutesPerDay")),
+            minutesPerWeek: readNumberCell(valueByField.get("MinutesPerWeek")),
+            daysPerMonth: readNumberCell(valueByField.get("DaysPerMonth")),
+            scheduleFromStart: (_a = readBooleanCell(valueByField.get("ScheduleFromStart"))) !== null && _a !== void 0 ? _a : true,
+            outlineCodes: [],
+            wbsMasks: [],
+            extendedAttributes: []
+        };
     }
     function buildProjectSheet(model) {
         const project = model.project;
@@ -641,6 +687,48 @@
             assignIfChanged(changes, "tasks", task.uid, taskLabel, task, "notes", "Notes", readStringCellAt(row.cells, columnIndexByLabel.get("Notes")));
         }
     }
+    function importTasksSheetAsTasks(workbook) {
+        var _a, _b, _c, _d;
+        const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+        if (!tasksSheet) {
+            return [];
+        }
+        const columnIndexByLabel = readHeaderMap(tasksSheet, HEADER_ROW_INDEX);
+        const uidColumnIndex = columnIndexByLabel.get("UID");
+        if (uidColumnIndex === undefined) {
+            return [];
+        }
+        const tasks = [];
+        for (const [rowIndex, row] of tasksSheet.rows.slice(DATA_ROW_START_INDEX).entries()) {
+            const uid = readStringCell(row.cells[uidColumnIndex]);
+            if (!uid) {
+                continue;
+            }
+            tasks.push({
+                uid,
+                id: readStringCellAt(row.cells, columnIndexByLabel.get("ID")) || String(rowIndex + 1),
+                name: readStringCellAt(row.cells, columnIndexByLabel.get("Name")) || uid,
+                outlineLevel: readNumberCellAt(row.cells, columnIndexByLabel.get("OutlineLevel")) || 1,
+                outlineNumber: readStringCellAt(row.cells, columnIndexByLabel.get("OutlineNumber")) || String(rowIndex + 1),
+                wbs: readStringCellAt(row.cells, columnIndexByLabel.get("WBS")) || undefined,
+                start: normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Start"))) || "",
+                finish: normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Finish"))) || "",
+                duration: readStringCellAt(row.cells, columnIndexByLabel.get("Duration")) || "",
+                milestone: (_a = readBooleanCellAt(row.cells, columnIndexByLabel.get("Milestone"))) !== null && _a !== void 0 ? _a : false,
+                summary: (_b = readBooleanCellAt(row.cells, columnIndexByLabel.get("Summary"))) !== null && _b !== void 0 ? _b : false,
+                critical: (_c = readBooleanCellAt(row.cells, columnIndexByLabel.get("Critical"))) !== null && _c !== void 0 ? _c : undefined,
+                percentComplete: readNumberCellAt(row.cells, columnIndexByLabel.get("PercentComplete")) || 0,
+                percentWorkComplete: (_d = readNumberCellAt(row.cells, columnIndexByLabel.get("PercentWorkComplete"))) !== null && _d !== void 0 ? _d : undefined,
+                calendarUID: readStringCellAt(row.cells, columnIndexByLabel.get("CalendarUID")) || undefined,
+                notes: readStringCellAt(row.cells, columnIndexByLabel.get("Notes")) || undefined,
+                predecessors: parsePredecessorCell(readStringCellAt(row.cells, columnIndexByLabel.get("Predecessors"))) || [],
+                extendedAttributes: [],
+                baselines: [],
+                timephasedData: []
+            });
+        }
+        return tasks;
+    }
     function importResourcesSheet(workbook, model, changes) {
         const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
         if (!resourcesSheet) {
@@ -668,6 +756,45 @@
             assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "calendarUID", "CalendarUID", readStringCellAt(row.cells, columnIndexByLabel.get("CalendarUID")));
         }
     }
+    function importResourcesSheetAsResources(workbook) {
+        var _a, _b, _c;
+        const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
+        if (!resourcesSheet) {
+            return [];
+        }
+        const columnIndexByLabel = readHeaderMap(resourcesSheet, HEADER_ROW_INDEX);
+        const uidColumnIndex = columnIndexByLabel.get("UID");
+        if (uidColumnIndex === undefined) {
+            return [];
+        }
+        const resources = [];
+        for (const [rowIndex, row] of resourcesSheet.rows.slice(DATA_ROW_START_INDEX).entries()) {
+            const uid = readStringCell(row.cells[uidColumnIndex]);
+            if (!uid) {
+                continue;
+            }
+            resources.push({
+                uid,
+                id: readStringCellAt(row.cells, columnIndexByLabel.get("ID")) || String(rowIndex + 1),
+                name: readStringCellAt(row.cells, columnIndexByLabel.get("Name")) || uid,
+                type: (_a = readNumberCellAt(row.cells, columnIndexByLabel.get("Type"))) !== null && _a !== void 0 ? _a : undefined,
+                initials: readStringCellAt(row.cells, columnIndexByLabel.get("Initials")) || undefined,
+                group: readStringCellAt(row.cells, columnIndexByLabel.get("Group")) || undefined,
+                maxUnits: (_b = readNumberCellAt(row.cells, columnIndexByLabel.get("MaxUnits"))) !== null && _b !== void 0 ? _b : undefined,
+                calendarUID: readStringCellAt(row.cells, columnIndexByLabel.get("CalendarUID")) || undefined,
+                standardRate: readStringCellAt(row.cells, columnIndexByLabel.get("StandardRate")) || undefined,
+                overtimeRate: readStringCellAt(row.cells, columnIndexByLabel.get("OvertimeRate")) || undefined,
+                costPerUse: (_c = readNumberCellAt(row.cells, columnIndexByLabel.get("CostPerUse"))) !== null && _c !== void 0 ? _c : undefined,
+                work: readStringCellAt(row.cells, columnIndexByLabel.get("Work")) || undefined,
+                actualWork: readStringCellAt(row.cells, columnIndexByLabel.get("ActualWork")) || undefined,
+                remainingWork: readStringCellAt(row.cells, columnIndexByLabel.get("RemainingWork")) || undefined,
+                extendedAttributes: [],
+                baselines: [],
+                timephasedData: []
+            });
+        }
+        return resources;
+    }
     function importAssignmentsSheet(workbook, model, changes) {
         const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
         if (!assignmentsSheet) {
@@ -694,6 +821,46 @@
             assignIfChanged(changes, "assignments", assignment.uid, assignmentLabel, assignment, "percentWorkComplete", "PercentWorkComplete", readNumberCellAt(row.cells, columnIndexByLabel.get("PercentWorkComplete")));
         }
     }
+    function importAssignmentsSheetAsAssignments(workbook) {
+        var _a, _b;
+        const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
+        if (!assignmentsSheet) {
+            return [];
+        }
+        const columnIndexByLabel = readHeaderMap(assignmentsSheet, HEADER_ROW_INDEX);
+        const uidColumnIndex = columnIndexByLabel.get("UID");
+        if (uidColumnIndex === undefined) {
+            return [];
+        }
+        const assignments = [];
+        for (const row of assignmentsSheet.rows.slice(DATA_ROW_START_INDEX)) {
+            const uid = readStringCell(row.cells[uidColumnIndex]);
+            if (!uid) {
+                continue;
+            }
+            const taskUid = readStringCellAt(row.cells, columnIndexByLabel.get("TaskUID"));
+            const resourceUid = readStringCellAt(row.cells, columnIndexByLabel.get("ResourceUID"));
+            if (!taskUid || !resourceUid) {
+                continue;
+            }
+            assignments.push({
+                uid,
+                taskUid,
+                resourceUid,
+                start: normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Start"))) || undefined,
+                finish: normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Finish"))) || undefined,
+                units: (_a = readNumberCellAt(row.cells, columnIndexByLabel.get("Units"))) !== null && _a !== void 0 ? _a : undefined,
+                work: readStringCellAt(row.cells, columnIndexByLabel.get("Work")) || undefined,
+                actualWork: readStringCellAt(row.cells, columnIndexByLabel.get("ActualWork")) || undefined,
+                remainingWork: readStringCellAt(row.cells, columnIndexByLabel.get("RemainingWork")) || undefined,
+                percentWorkComplete: (_b = readNumberCellAt(row.cells, columnIndexByLabel.get("PercentWorkComplete"))) !== null && _b !== void 0 ? _b : undefined,
+                extendedAttributes: [],
+                baselines: [],
+                timephasedData: []
+            });
+        }
+        return assignments;
+    }
     function importCalendarsSheet(workbook, model, changes) {
         const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
         if (!calendarsSheet) {
@@ -719,6 +886,44 @@
             assignIfChanged(changes, "calendars", calendar.uid, calendarLabel, calendar, "isBaseCalendar", "IsBaseCalendar", readBooleanCellAt(row.cells, columnIndexByLabel.get("IsBaseCalendar")));
             assignIfChanged(changes, "calendars", calendar.uid, calendarLabel, calendar, "baseCalendarUID", "BaseCalendarUID", readStringCellAt(row.cells, columnIndexByLabel.get("BaseCalendarUID")));
         }
+    }
+    function importCalendarsSheetAsCalendars(workbook, project) {
+        var _a;
+        const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+        const calendars = [];
+        const columnIndexByLabel = calendarsSheet ? readHeaderMap(calendarsSheet, HEADER_ROW_INDEX) : new Map();
+        const uidColumnIndex = columnIndexByLabel.get("UID");
+        if (calendarsSheet && uidColumnIndex !== undefined) {
+            for (const row of calendarsSheet.rows.slice(DATA_ROW_START_INDEX)) {
+                const uid = readStringCell(row.cells[uidColumnIndex]);
+                if (!uid) {
+                    continue;
+                }
+                calendars.push({
+                    uid,
+                    name: readStringCellAt(row.cells, columnIndexByLabel.get("Name")) || uid,
+                    isBaseCalendar: (_a = readBooleanCellAt(row.cells, columnIndexByLabel.get("IsBaseCalendar"))) !== null && _a !== void 0 ? _a : false,
+                    baseCalendarUID: readStringCellAt(row.cells, columnIndexByLabel.get("BaseCalendarUID")) || undefined,
+                    weekDays: [],
+                    exceptions: [],
+                    workWeeks: []
+                });
+            }
+        }
+        if (calendars.length === 0) {
+            calendars.push({
+                uid: project.calendarUID || "1",
+                name: "Standard",
+                isBaseCalendar: true,
+                weekDays: buildDefaultStandardWeekDays(project),
+                exceptions: [],
+                workWeeks: []
+            });
+            if (!project.calendarUID) {
+                project.calendarUID = calendars[0].uid;
+            }
+        }
+        return calendars;
     }
     function importNonWorkingDaysSheet(workbook, model, changes) {
         const nonWorkingDaysSheet = workbook.sheets.find((sheet) => sheet.name === "NonWorkingDays");
@@ -762,6 +967,80 @@
             }
             assignIfChanged(changes, "calendars", calendar.uid, calendar.name, exception, "dayWorking", `Exception${indexValue}.DayWorking`, readBooleanCellAt(row.cells, columnIndexByLabel.get("DayWorking")));
         }
+    }
+    function importNonWorkingDaysSheetAsCalendarExceptions(workbook, calendars) {
+        var _a;
+        const nonWorkingDaysSheet = workbook.sheets.find((sheet) => sheet.name === "NonWorkingDays");
+        if (!nonWorkingDaysSheet) {
+            return;
+        }
+        const columnIndexByLabel = readHeaderMap(nonWorkingDaysSheet, HEADER_ROW_INDEX);
+        const calendarUidColumnIndex = columnIndexByLabel.get("CalendarUID");
+        const indexColumnIndex = columnIndexByLabel.get("Index");
+        if (calendarUidColumnIndex === undefined || indexColumnIndex === undefined) {
+            return;
+        }
+        const calendarByUid = new Map(calendars.map((calendar) => [calendar.uid, calendar]));
+        for (const row of nonWorkingDaysSheet.rows.slice(DATA_ROW_START_INDEX)) {
+            const calendarUid = readStringCell(row.cells[calendarUidColumnIndex]);
+            const indexValue = readNumberCell(row.cells[indexColumnIndex]);
+            if (!calendarUid || !indexValue) {
+                continue;
+            }
+            const calendar = calendarByUid.get(calendarUid);
+            if (!calendar) {
+                continue;
+            }
+            const dateValue = readStringCellAt(row.cells, columnIndexByLabel.get("Date"));
+            const name = readStringCellAt(row.cells, columnIndexByLabel.get("Name")) || undefined;
+            const dayWorking = (_a = readBooleanCellAt(row.cells, columnIndexByLabel.get("DayWorking"))) !== null && _a !== void 0 ? _a : false;
+            let fromDate;
+            let toDate;
+            if (dateValue) {
+                const normalizedDate = normalizeDateOnly(dateValue);
+                if (normalizedDate) {
+                    fromDate = `${normalizedDate}T00:00:00`;
+                    toDate = `${normalizedDate}T23:59:59`;
+                }
+            }
+            else {
+                fromDate = normalizeExceptionBoundaryInput(readStringCellAt(row.cells, columnIndexByLabel.get("FromDate")), false) || undefined;
+                toDate = normalizeExceptionBoundaryInput(readStringCellAt(row.cells, columnIndexByLabel.get("ToDate")), true) || undefined;
+            }
+            calendar.exceptions[indexValue - 1] = {
+                name,
+                fromDate,
+                toDate,
+                dayWorking,
+                workingTimes: []
+            };
+        }
+        for (const calendar of calendars) {
+            calendar.exceptions = calendar.exceptions.filter(Boolean);
+        }
+    }
+    function buildDefaultWorkingTimes(project) {
+        const start = project.defaultStartTime || "09:00:00";
+        const finish = project.defaultFinishTime || "18:00:00";
+        if (start < "12:00:00" && finish > "13:00:00") {
+            return [
+                { fromTime: start, toTime: "12:00:00" },
+                { fromTime: "13:00:00", toTime: finish }
+            ];
+        }
+        return [{ fromTime: start, toTime: finish }];
+    }
+    function buildDefaultStandardWeekDays(project) {
+        const workingTimes = buildDefaultWorkingTimes(project);
+        return Array.from({ length: 7 }, (_, index) => {
+            const dayType = index + 1;
+            const dayWorking = dayType !== 1 && dayType !== 7;
+            return {
+                dayType,
+                dayWorking,
+                workingTimes: dayWorking ? workingTimes.map((item) => ({ ...item })) : []
+            };
+        });
     }
     function formatExceptionDate(exception) {
         var _a, _b;
@@ -976,6 +1255,7 @@
     globalThis.__mikuprojectProjectXlsx = {
         exportProjectWorkbook,
         importProjectWorkbook,
+        importProjectWorkbookAsProjectModel,
         importProjectWorkbookDetailed
     };
 })();

--- a/src/ts/main-render.ts
+++ b/src/ts/main-render.ts
@@ -195,8 +195,14 @@
     if (sourceLabel === "Patch JSON") {
       return "Patch JSON の部分適用結果です。反映後の XML は更新済みで、必要なら XML Export で保存できます。";
     }
+    if (sourceLabel === "JSON Replace") {
+      return "workbook JSON による全置換結果です。差分表示は取込前の project との差を示します。";
+    }
     if (sourceLabel === "JSON Import") {
       return "workbook JSON の取込結果です。反映後の XML は更新済みで、必要なら XML Export で保存できます。";
+    }
+    if (sourceLabel === "XLSX Replace") {
+      return "XLSX による全置換結果です。差分表示は取込前の project との差を示します。";
     }
     if (sourceLabel === "XLSX Import") {
       return "Excel 編集結果の取込内容です。反映後の XML は更新済みで、必要なら XML Export で保存できます。";

--- a/src/ts/main.ts
+++ b/src/ts/main.ts
@@ -107,6 +107,7 @@
     __mikuprojectProjectXlsx?: {
       exportProjectWorkbook: (model: ProjectModel) => unknown;
       importProjectWorkbook: (workbook: unknown, baseModel: ProjectModel) => ProjectModel;
+      importProjectWorkbookAsProjectModel: (workbook: unknown) => ProjectModel;
       importProjectWorkbookDetailed: (workbook: unknown, baseModel: ProjectModel) => {
         model: ProjectModel;
         changes: Array<{
@@ -128,6 +129,10 @@
   const mikuprojectProjectWorkbookJson = (globalThis as typeof globalThis & {
     __mikuprojectProjectWorkbookJson?: {
       exportProjectWorkbookJson: (model: ProjectModel) => unknown;
+      importProjectWorkbookJsonAsProjectModel: (documentLike: unknown) => {
+        model: ProjectModel;
+        warnings: Array<{ message: string }>;
+      };
       importProjectWorkbookJson: (documentLike: unknown, baseModel: ProjectModel) => {
         model: ProjectModel;
         changes: Array<{
@@ -992,25 +997,22 @@
       throw new Error("workbook JSON を入力してください");
     }
     const documentLike = JSON.parse(mikuprojectAiJsonUtil.extractLastJsonBlock(trimmedSourceText));
-    const baseModel = ensureCurrentModel();
-    const result = mikuprojectProjectWorkbookJson.importProjectWorkbookJson(documentLike, baseModel);
-    currentModel = result.model;
+    const previousModel = currentModel;
+    const replaceResult = mikuprojectProjectWorkbookJson.importProjectWorkbookJsonAsProjectModel(documentLike);
+    currentModel = replaceResult.model;
+    const diffResult = previousModel
+      ? mikuprojectProjectWorkbookJson.importProjectWorkbookJson(documentLike, previousModel)
+      : { changes: [], warnings: replaceResult.warnings };
     const issues = mikuprojectXml.validateProjectModel(currentModel);
+    syncXmlTextFromModel(currentModel);
     updateSummary(currentModel);
     renderValidationIssues(issues);
-    renderImportWarnings(result.warnings, { sourceLabel: "JSON Import" });
-    renderXlsxImportSummary(result.changes, { sourceLabel: "JSON Import", warnings: result.warnings });
-    if (result.changes.length > 0) {
-      getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
-      markXmlDirty();
-    }
-    isXmlSourceDirty = false;
-    const summaryText = result.changes.length > 0
-      ? `JSON を読み込んで ${result.changes.length} 件の変更を反映しました。XML は再生成済みで、必要なら XML Export で保存できます`
-      : "JSON に反映対象の変更はありませんでした。XML は未変更です";
-    const warningText = result.warnings.length > 0 ? `。JSON 取込で ${result.warnings.length} 件の warning を無視しました` : "";
+    renderImportWarnings(replaceResult.warnings, { sourceLabel: "JSON Replace" });
+    renderXlsxImportSummary(diffResult.changes, { sourceLabel: "JSON Replace", warnings: replaceResult.warnings });
+    const summaryText = "JSON を読み込んで project 全体を置き換えました。XML は再生成済みで、必要なら XML Export で保存できます";
+    const warningText = replaceResult.warnings.length > 0 ? `。JSON 取込で ${replaceResult.warnings.length} 件の warning を無視しました` : "";
     setStatus(issues.length > 0 ? `${summaryText}${warningText}。検証で ${issues.length} 件の問題があります` : `${summaryText}${warningText}`);
-    showToast("JSON を反映しました");
+    showToast("JSON を読み込みました");
     setActiveTab("transform", { skipTransformRefresh: true });
     await exportCurrentMermaid({ silent: true });
   }
@@ -1184,29 +1186,25 @@
     if (!file) {
       return;
     }
-    const baseModel = ensureCurrentModel();
+    const previousModel = currentModel;
     const bytes = new Uint8Array(await file.arrayBuffer());
     const codec = new mikuprojectExcelIo.XlsxWorkbookCodec();
     const workbook = typeof codec.importWorkbookAsync === "function"
       ? await codec.importWorkbookAsync(bytes)
       : codec.importWorkbook(bytes);
-    const result = mikuprojectProjectXlsx.importProjectWorkbookDetailed(workbook, baseModel);
-    currentModel = result.model;
+    currentModel = mikuprojectProjectXlsx.importProjectWorkbookAsProjectModel(workbook);
+    const diffResult = previousModel
+      ? mikuprojectProjectXlsx.importProjectWorkbookDetailed(workbook, previousModel)
+      : { changes: [] };
     const issues = mikuprojectXml.validateProjectModel(currentModel);
+    syncXmlTextFromModel(currentModel);
     updateSummary(currentModel);
     renderValidationIssues(issues);
     renderImportWarnings([]);
-    renderXlsxImportSummary(result.changes, { sourceLabel: "XLSX Import" });
-    if (result.changes.length > 0) {
-      getTextArea("xmlInput").value = mikuprojectXml.exportMsProjectXml(currentModel);
-      markXmlDirty();
-    }
-    const summaryText = result.changes.length > 0
-      ? `XLSX を読み込んで ${result.changes.length} 件の変更を反映しました。XML は再生成済みで、必要なら XML Export で保存できます`
-      : "XLSX に反映対象の変更はありませんでした。XML は未変更です";
-    isXmlSourceDirty = false;
+    renderXlsxImportSummary(diffResult.changes, { sourceLabel: "XLSX Replace" });
+    const summaryText = "XLSX を読み込んで project 全体を置き換えました。XML は再生成済みで、必要なら XML Export で保存できます";
     setStatus(issues.length > 0 ? `${summaryText}。検証で ${issues.length} 件の問題があります` : summaryText);
-    showToast("XLSX を反映しました");
+    showToast("XLSX を読み込みました");
     setActiveTab("transform", { skipTransformRefresh: true });
     await exportCurrentMermaid({ silent: true });
   }

--- a/src/ts/project-workbook-json.ts
+++ b/src/ts/project-workbook-json.ts
@@ -127,6 +127,28 @@
     };
   }
 
+  function importProjectWorkbookJsonAsProjectModel(documentLike: unknown): {
+    model: ProjectModel;
+    warnings: WorkbookJsonWarning[];
+  } {
+    const validation = validateWorkbookJsonDocument(documentLike);
+    const document = validation.document;
+    const workbook = {
+      sheets: [
+        buildProjectSheet(document.sheets.Project || []),
+        buildTabularSheet("Tasks", document.sheets.Tasks || [], SHEET_HEADERS.Tasks),
+        buildTabularSheet("Resources", document.sheets.Resources || [], SHEET_HEADERS.Resources),
+        buildTabularSheet("Assignments", document.sheets.Assignments || [], SHEET_HEADERS.Assignments),
+        buildTabularSheet("Calendars", document.sheets.Calendars || [], SHEET_HEADERS.Calendars),
+        buildTabularSheet("NonWorkingDays", document.sheets.NonWorkingDays || [], SHEET_HEADERS.NonWorkingDays)
+      ]
+    };
+    return {
+      model: projectXlsx.importProjectWorkbookAsProjectModel(workbook),
+      warnings: validation.warnings
+    };
+  }
+
   function validateWorkbookJsonDocument(documentLike: unknown): {
     document: WorkbookJsonDocument;
     warnings: WorkbookJsonWarning[];
@@ -279,6 +301,10 @@
   (globalThis as typeof globalThis & {
     __mikuprojectProjectWorkbookJson?: {
       exportProjectWorkbookJson: (model: ProjectModel) => WorkbookJsonDocument;
+      importProjectWorkbookJsonAsProjectModel: (documentLike: unknown) => {
+        model: ProjectModel;
+        warnings: WorkbookJsonWarning[];
+      };
       importProjectWorkbookJson: (documentLike: unknown, baseModel: ProjectModel) => {
         model: ProjectModel;
         changes: ImportChange[];
@@ -291,6 +317,7 @@
     };
   }).__mikuprojectProjectWorkbookJson = {
     exportProjectWorkbookJson,
+    importProjectWorkbookJsonAsProjectModel,
     importProjectWorkbookJson,
     validateWorkbookJsonDocument
   };

--- a/src/ts/project-xlsx.ts
+++ b/src/ts/project-xlsx.ts
@@ -120,6 +120,22 @@
     return importProjectWorkbookDetailed(workbook, baseModel).model;
   }
 
+  function importProjectWorkbookAsProjectModel(workbook: XlsxWorkbookLike): ProjectModel {
+    const project = importProjectSheetAsProjectInfo(workbook);
+    const tasks = importTasksSheetAsTasks(workbook);
+    const resources = importResourcesSheetAsResources(workbook);
+    const assignments = importAssignmentsSheetAsAssignments(workbook);
+    const calendars = importCalendarsSheetAsCalendars(workbook, project);
+    importNonWorkingDaysSheetAsCalendarExceptions(workbook, calendars);
+    return {
+      project,
+      tasks,
+      resources,
+      assignments,
+      calendars
+    };
+  }
+
   function importProjectWorkbookDetailed(workbook: XlsxWorkbookLike, baseModel: ProjectModel): {
     model: ProjectModel;
     changes: ImportChange[];
@@ -165,6 +181,37 @@
     assignIfChanged(changes, "project", "project", projectLabel, model.project, "minutesPerWeek", "MinutesPerWeek", readNumberCell(valueByField.get("MinutesPerWeek")));
     assignIfChanged(changes, "project", "project", projectLabel, model.project, "daysPerMonth", "DaysPerMonth", readNumberCell(valueByField.get("DaysPerMonth")));
     assignIfChanged(changes, "project", "project", projectLabel, model.project, "scheduleFromStart", "ScheduleFromStart", readBooleanCell(valueByField.get("ScheduleFromStart")));
+  }
+
+  function importProjectSheetAsProjectInfo(workbook: XlsxWorkbookLike): ProjectInfo {
+    const projectSheet = workbook.sheets.find((sheet) => sheet.name === "Project");
+    const valueByField = new Map<string, XlsxCellLike | undefined>();
+    for (const row of projectSheet?.rows.slice(DATA_ROW_START_INDEX) || []) {
+      const field = readStringCell(row.cells[0]);
+      if (!field) {
+        continue;
+      }
+      valueByField.set(field, row.cells[1]);
+    }
+    const name = readStringCell(valueByField.get("Name")) || "Imported Project";
+    return {
+      name,
+      title: readStringCell(valueByField.get("Title")) || undefined,
+      author: readStringCell(valueByField.get("Author")) || undefined,
+      company: readStringCell(valueByField.get("Company")) || undefined,
+      startDate: normalizeDateTimeInput(readStringCell(valueByField.get("StartDate"))) || "",
+      finishDate: normalizeDateTimeInput(readStringCell(valueByField.get("FinishDate"))) || "",
+      currentDate: normalizeDateTimeInput(readStringCell(valueByField.get("CurrentDate"))) || undefined,
+      statusDate: normalizeDateTimeInput(readStringCell(valueByField.get("StatusDate"))) || undefined,
+      calendarUID: readStringCell(valueByField.get("CalendarUID")) || undefined,
+      minutesPerDay: readNumberCell(valueByField.get("MinutesPerDay")),
+      minutesPerWeek: readNumberCell(valueByField.get("MinutesPerWeek")),
+      daysPerMonth: readNumberCell(valueByField.get("DaysPerMonth")),
+      scheduleFromStart: readBooleanCell(valueByField.get("ScheduleFromStart")) ?? true,
+      outlineCodes: [],
+      wbsMasks: [],
+      extendedAttributes: []
+    };
   }
 
   function buildProjectSheet(model: ProjectModel) {
@@ -753,6 +800,48 @@
     }
   }
 
+  function importTasksSheetAsTasks(workbook: XlsxWorkbookLike): TaskModel[] {
+    const tasksSheet = workbook.sheets.find((sheet) => sheet.name === "Tasks");
+    if (!tasksSheet) {
+      return [];
+    }
+    const columnIndexByLabel = readHeaderMap(tasksSheet, HEADER_ROW_INDEX);
+    const uidColumnIndex = columnIndexByLabel.get("UID");
+    if (uidColumnIndex === undefined) {
+      return [];
+    }
+    const tasks: TaskModel[] = [];
+    for (const [rowIndex, row] of tasksSheet.rows.slice(DATA_ROW_START_INDEX).entries()) {
+      const uid = readStringCell(row.cells[uidColumnIndex]);
+      if (!uid) {
+        continue;
+      }
+      tasks.push({
+        uid,
+        id: readStringCellAt(row.cells, columnIndexByLabel.get("ID")) || String(rowIndex + 1),
+        name: readStringCellAt(row.cells, columnIndexByLabel.get("Name")) || uid,
+        outlineLevel: readNumberCellAt(row.cells, columnIndexByLabel.get("OutlineLevel")) || 1,
+        outlineNumber: readStringCellAt(row.cells, columnIndexByLabel.get("OutlineNumber")) || String(rowIndex + 1),
+        wbs: readStringCellAt(row.cells, columnIndexByLabel.get("WBS")) || undefined,
+        start: normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Start"))) || "",
+        finish: normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Finish"))) || "",
+        duration: readStringCellAt(row.cells, columnIndexByLabel.get("Duration")) || "",
+        milestone: readBooleanCellAt(row.cells, columnIndexByLabel.get("Milestone")) ?? false,
+        summary: readBooleanCellAt(row.cells, columnIndexByLabel.get("Summary")) ?? false,
+        critical: readBooleanCellAt(row.cells, columnIndexByLabel.get("Critical")) ?? undefined,
+        percentComplete: readNumberCellAt(row.cells, columnIndexByLabel.get("PercentComplete")) || 0,
+        percentWorkComplete: readNumberCellAt(row.cells, columnIndexByLabel.get("PercentWorkComplete")) ?? undefined,
+        calendarUID: readStringCellAt(row.cells, columnIndexByLabel.get("CalendarUID")) || undefined,
+        notes: readStringCellAt(row.cells, columnIndexByLabel.get("Notes")) || undefined,
+        predecessors: parsePredecessorCell(readStringCellAt(row.cells, columnIndexByLabel.get("Predecessors"))) || [],
+        extendedAttributes: [],
+        baselines: [],
+        timephasedData: []
+      });
+    }
+    return tasks;
+  }
+
   function importResourcesSheet(workbook: XlsxWorkbookLike, model: ProjectModel, changes: ImportChange[]): void {
     const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
     if (!resourcesSheet) {
@@ -779,6 +868,45 @@
       assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "maxUnits", "MaxUnits", readNumberCellAt(row.cells, columnIndexByLabel.get("MaxUnits")));
       assignIfChanged(changes, "resources", resource.uid, resourceLabel, resource, "calendarUID", "CalendarUID", readStringCellAt(row.cells, columnIndexByLabel.get("CalendarUID")));
     }
+  }
+
+  function importResourcesSheetAsResources(workbook: XlsxWorkbookLike): ResourceModel[] {
+    const resourcesSheet = workbook.sheets.find((sheet) => sheet.name === "Resources");
+    if (!resourcesSheet) {
+      return [];
+    }
+    const columnIndexByLabel = readHeaderMap(resourcesSheet, HEADER_ROW_INDEX);
+    const uidColumnIndex = columnIndexByLabel.get("UID");
+    if (uidColumnIndex === undefined) {
+      return [];
+    }
+    const resources: ResourceModel[] = [];
+    for (const [rowIndex, row] of resourcesSheet.rows.slice(DATA_ROW_START_INDEX).entries()) {
+      const uid = readStringCell(row.cells[uidColumnIndex]);
+      if (!uid) {
+        continue;
+      }
+      resources.push({
+        uid,
+        id: readStringCellAt(row.cells, columnIndexByLabel.get("ID")) || String(rowIndex + 1),
+        name: readStringCellAt(row.cells, columnIndexByLabel.get("Name")) || uid,
+        type: readNumberCellAt(row.cells, columnIndexByLabel.get("Type")) ?? undefined,
+        initials: readStringCellAt(row.cells, columnIndexByLabel.get("Initials")) || undefined,
+        group: readStringCellAt(row.cells, columnIndexByLabel.get("Group")) || undefined,
+        maxUnits: readNumberCellAt(row.cells, columnIndexByLabel.get("MaxUnits")) ?? undefined,
+        calendarUID: readStringCellAt(row.cells, columnIndexByLabel.get("CalendarUID")) || undefined,
+        standardRate: readStringCellAt(row.cells, columnIndexByLabel.get("StandardRate")) || undefined,
+        overtimeRate: readStringCellAt(row.cells, columnIndexByLabel.get("OvertimeRate")) || undefined,
+        costPerUse: readNumberCellAt(row.cells, columnIndexByLabel.get("CostPerUse")) ?? undefined,
+        work: readStringCellAt(row.cells, columnIndexByLabel.get("Work")) || undefined,
+        actualWork: readStringCellAt(row.cells, columnIndexByLabel.get("ActualWork")) || undefined,
+        remainingWork: readStringCellAt(row.cells, columnIndexByLabel.get("RemainingWork")) || undefined,
+        extendedAttributes: [],
+        baselines: [],
+        timephasedData: []
+      });
+    }
+    return resources;
   }
 
   function importAssignmentsSheet(workbook: XlsxWorkbookLike, model: ProjectModel, changes: ImportChange[]): void {
@@ -808,6 +936,46 @@
     }
   }
 
+  function importAssignmentsSheetAsAssignments(workbook: XlsxWorkbookLike): AssignmentModel[] {
+    const assignmentsSheet = workbook.sheets.find((sheet) => sheet.name === "Assignments");
+    if (!assignmentsSheet) {
+      return [];
+    }
+    const columnIndexByLabel = readHeaderMap(assignmentsSheet, HEADER_ROW_INDEX);
+    const uidColumnIndex = columnIndexByLabel.get("UID");
+    if (uidColumnIndex === undefined) {
+      return [];
+    }
+    const assignments: AssignmentModel[] = [];
+    for (const row of assignmentsSheet.rows.slice(DATA_ROW_START_INDEX)) {
+      const uid = readStringCell(row.cells[uidColumnIndex]);
+      if (!uid) {
+        continue;
+      }
+      const taskUid = readStringCellAt(row.cells, columnIndexByLabel.get("TaskUID"));
+      const resourceUid = readStringCellAt(row.cells, columnIndexByLabel.get("ResourceUID"));
+      if (!taskUid || !resourceUid) {
+        continue;
+      }
+      assignments.push({
+        uid,
+        taskUid,
+        resourceUid,
+        start: normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Start"))) || undefined,
+        finish: normalizeDateTimeInput(readStringCellAt(row.cells, columnIndexByLabel.get("Finish"))) || undefined,
+        units: readNumberCellAt(row.cells, columnIndexByLabel.get("Units")) ?? undefined,
+        work: readStringCellAt(row.cells, columnIndexByLabel.get("Work")) || undefined,
+        actualWork: readStringCellAt(row.cells, columnIndexByLabel.get("ActualWork")) || undefined,
+        remainingWork: readStringCellAt(row.cells, columnIndexByLabel.get("RemainingWork")) || undefined,
+        percentWorkComplete: readNumberCellAt(row.cells, columnIndexByLabel.get("PercentWorkComplete")) ?? undefined,
+        extendedAttributes: [],
+        baselines: [],
+        timephasedData: []
+      });
+    }
+    return assignments;
+  }
+
   function importCalendarsSheet(workbook: XlsxWorkbookLike, model: ProjectModel, changes: ImportChange[]): void {
     const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
     if (!calendarsSheet) {
@@ -833,6 +1001,44 @@
       assignIfChanged(changes, "calendars", calendar.uid, calendarLabel, calendar, "isBaseCalendar", "IsBaseCalendar", readBooleanCellAt(row.cells, columnIndexByLabel.get("IsBaseCalendar")));
       assignIfChanged(changes, "calendars", calendar.uid, calendarLabel, calendar, "baseCalendarUID", "BaseCalendarUID", readStringCellAt(row.cells, columnIndexByLabel.get("BaseCalendarUID")));
     }
+  }
+
+  function importCalendarsSheetAsCalendars(workbook: XlsxWorkbookLike, project: ProjectInfo): CalendarModel[] {
+    const calendarsSheet = workbook.sheets.find((sheet) => sheet.name === "Calendars");
+    const calendars: CalendarModel[] = [];
+    const columnIndexByLabel = calendarsSheet ? readHeaderMap(calendarsSheet, HEADER_ROW_INDEX) : new Map<string, number>();
+    const uidColumnIndex = columnIndexByLabel.get("UID");
+    if (calendarsSheet && uidColumnIndex !== undefined) {
+      for (const row of calendarsSheet.rows.slice(DATA_ROW_START_INDEX)) {
+        const uid = readStringCell(row.cells[uidColumnIndex]);
+        if (!uid) {
+          continue;
+        }
+        calendars.push({
+          uid,
+          name: readStringCellAt(row.cells, columnIndexByLabel.get("Name")) || uid,
+          isBaseCalendar: readBooleanCellAt(row.cells, columnIndexByLabel.get("IsBaseCalendar")) ?? false,
+          baseCalendarUID: readStringCellAt(row.cells, columnIndexByLabel.get("BaseCalendarUID")) || undefined,
+          weekDays: [],
+          exceptions: [],
+          workWeeks: []
+        });
+      }
+    }
+    if (calendars.length === 0) {
+      calendars.push({
+        uid: project.calendarUID || "1",
+        name: "Standard",
+        isBaseCalendar: true,
+        weekDays: buildDefaultStandardWeekDays(project),
+        exceptions: [],
+        workWeeks: []
+      });
+      if (!project.calendarUID) {
+        project.calendarUID = calendars[0].uid;
+      }
+    }
+    return calendars;
   }
 
   function importNonWorkingDaysSheet(workbook: XlsxWorkbookLike, model: ProjectModel, changes: ImportChange[]): void {
@@ -877,6 +1083,81 @@
       }
       assignIfChanged(changes, "calendars", calendar.uid, calendar.name, exception, "dayWorking", `Exception${indexValue}.DayWorking`, readBooleanCellAt(row.cells, columnIndexByLabel.get("DayWorking")));
     }
+  }
+
+  function importNonWorkingDaysSheetAsCalendarExceptions(workbook: XlsxWorkbookLike, calendars: CalendarModel[]): void {
+    const nonWorkingDaysSheet = workbook.sheets.find((sheet) => sheet.name === "NonWorkingDays");
+    if (!nonWorkingDaysSheet) {
+      return;
+    }
+    const columnIndexByLabel = readHeaderMap(nonWorkingDaysSheet, HEADER_ROW_INDEX);
+    const calendarUidColumnIndex = columnIndexByLabel.get("CalendarUID");
+    const indexColumnIndex = columnIndexByLabel.get("Index");
+    if (calendarUidColumnIndex === undefined || indexColumnIndex === undefined) {
+      return;
+    }
+    const calendarByUid = new Map(calendars.map((calendar) => [calendar.uid, calendar]));
+    for (const row of nonWorkingDaysSheet.rows.slice(DATA_ROW_START_INDEX)) {
+      const calendarUid = readStringCell(row.cells[calendarUidColumnIndex]);
+      const indexValue = readNumberCell(row.cells[indexColumnIndex]);
+      if (!calendarUid || !indexValue) {
+        continue;
+      }
+      const calendar = calendarByUid.get(calendarUid);
+      if (!calendar) {
+        continue;
+      }
+      const dateValue = readStringCellAt(row.cells, columnIndexByLabel.get("Date"));
+      const name = readStringCellAt(row.cells, columnIndexByLabel.get("Name")) || undefined;
+      const dayWorking = readBooleanCellAt(row.cells, columnIndexByLabel.get("DayWorking")) ?? false;
+      let fromDate: string | undefined;
+      let toDate: string | undefined;
+      if (dateValue) {
+        const normalizedDate = normalizeDateOnly(dateValue);
+        if (normalizedDate) {
+          fromDate = `${normalizedDate}T00:00:00`;
+          toDate = `${normalizedDate}T23:59:59`;
+        }
+      } else {
+        fromDate = normalizeExceptionBoundaryInput(readStringCellAt(row.cells, columnIndexByLabel.get("FromDate")), false) || undefined;
+        toDate = normalizeExceptionBoundaryInput(readStringCellAt(row.cells, columnIndexByLabel.get("ToDate")), true) || undefined;
+      }
+      calendar.exceptions[indexValue - 1] = {
+        name,
+        fromDate,
+        toDate,
+        dayWorking,
+        workingTimes: []
+      };
+    }
+    for (const calendar of calendars) {
+      calendar.exceptions = calendar.exceptions.filter(Boolean);
+    }
+  }
+
+  function buildDefaultWorkingTimes(project: ProjectInfo): WorkingTimeModel[] {
+    const start = project.defaultStartTime || "09:00:00";
+    const finish = project.defaultFinishTime || "18:00:00";
+    if (start < "12:00:00" && finish > "13:00:00") {
+      return [
+        { fromTime: start, toTime: "12:00:00" },
+        { fromTime: "13:00:00", toTime: finish }
+      ];
+    }
+    return [{ fromTime: start, toTime: finish }];
+  }
+
+  function buildDefaultStandardWeekDays(project: ProjectInfo): WeekDayModel[] {
+    const workingTimes = buildDefaultWorkingTimes(project);
+    return Array.from({ length: 7 }, (_, index) => {
+      const dayType = index + 1;
+      const dayWorking = dayType !== 1 && dayType !== 7;
+      return {
+        dayType,
+        dayWorking,
+        workingTimes: dayWorking ? workingTimes.map((item) => ({ ...item })) : []
+      };
+    });
   }
 
   function formatExceptionDate(exception: CalendarExceptionModel): string | undefined {
@@ -1129,6 +1410,7 @@
     __mikuprojectProjectXlsx?: {
       exportProjectWorkbook: (model: ProjectModel) => XlsxWorkbookLike;
       importProjectWorkbook: (workbook: XlsxWorkbookLike, baseModel: ProjectModel) => ProjectModel;
+      importProjectWorkbookAsProjectModel: (workbook: XlsxWorkbookLike) => ProjectModel;
       importProjectWorkbookDetailed: (workbook: XlsxWorkbookLike, baseModel: ProjectModel) => {
         model: ProjectModel;
         changes: ImportChange[];
@@ -1137,6 +1419,7 @@
   }).__mikuprojectProjectXlsx = {
     exportProjectWorkbook,
     importProjectWorkbook,
+    importProjectWorkbookAsProjectModel,
     importProjectWorkbookDetailed
   };
 })();

--- a/tests/mikuproject-main-xlsx-import.test.js
+++ b/tests/mikuproject-main-xlsx-import.test.js
@@ -269,7 +269,7 @@ describe("mikuproject main xlsx import", () => {
     expect(document.getElementById("modelOutput").value).toContain("\"predecessorUid\": \"2\"");
     expect(document.getElementById("xmlInput").value).toContain("<Name>初期実装 Imported From XLSX</Name>");
     expect(document.getElementById("xmlInput").value).toContain("<PredecessorUID>2</PredecessorUID>");
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 5 件の変更を反映しました");
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで project 全体を置き換えました");
     expect(document.getElementById("statusMessage").textContent).toContain("XML Export で保存できます");
     expect(document.getElementById("xmlSaveState").textContent).toContain("XML 保存状態: 未保存");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("Tasks 1");
@@ -316,7 +316,7 @@ describe("mikuproject main xlsx import", () => {
     expect(document.getElementById("modelOutput").value).toContain("\"group\": \"Dev\"");
     expect(document.getElementById("modelOutput").value).toContain("\"maxUnits\": 1");
     expect(document.getElementById("modelOutput").value).toContain("\"calendarUID\": \"1\"");
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 4 件の変更を反映しました");
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで project 全体を置き換えました");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("Resources 1");
   });
 
@@ -343,9 +343,9 @@ describe("mikuproject main xlsx import", () => {
     await flushAsyncWork();
 
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"初期実装 Imported From JSON\"");
-    expect(document.getElementById("statusMessage").textContent).toContain("JSON を読み込んで 2 件の変更を反映しました");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("JSON Import 反映結果");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("workbook JSON の取込結果です");
+    expect(document.getElementById("statusMessage").textContent).toContain("JSON を読み込んで project 全体を置き換えました");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("JSON Replace 反映結果");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("workbook JSON による全置換結果です");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("PercentComplete");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("100");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("66");
@@ -368,7 +368,7 @@ describe("mikuproject main xlsx import", () => {
     await flushAsyncWork();
 
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"初期実装 Imported From JSON File\"");
-    expect(document.getElementById("statusMessage").textContent).toContain("JSON を読み込んで 2 件の変更を反映しました");
+    expect(document.getElementById("statusMessage").textContent).toContain("JSON を読み込んで project 全体を置き換えました");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("PercentComplete");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("100");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("55");
@@ -428,9 +428,9 @@ describe("mikuproject main xlsx import", () => {
 
     expect(document.getElementById("modelOutput").value).toContain("\"name\": \"Project From XLSX\"");
     expect(document.getElementById("modelOutput").value).toContain("\"minutesPerDay\": 420");
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 2 件の変更を反映しました");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("XLSX Import 反映結果");
-    expect(document.getElementById("xlsxImportSummary").textContent).toContain("Excel 編集結果の取込内容です");
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで project 全体を置き換えました");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("XLSX Replace 反映結果");
+    expect(document.getElementById("xlsxImportSummary").textContent).toContain("XLSX による全置換結果です");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("Project 1");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("MinutesPerDay");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("480");
@@ -460,9 +460,7 @@ describe("mikuproject main xlsx import", () => {
     await flushAsyncWork();
     await flushAsyncWork();
 
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX に反映対象の変更はありませんでした");
-    expect(document.getElementById("statusMessage").textContent).toContain("XML は未変更です");
-    expect(document.getElementById("xmlInput").value).toBe(originalXml);
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで project 全体を置き換えました");
     expect(document.getElementById("xlsxImportSummary").classList.contains("md-hidden")).toBe(true);
   });
 
@@ -494,7 +492,7 @@ describe("mikuproject main xlsx import", () => {
     await flushAsyncWork();
     await flushAsyncWork();
 
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで 1 件の変更を反映しました");
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで project 全体を置き換えました");
     expect(document.getElementById("modelOutput").value).toContain("\"duration\": \"PT99H0M0S\"");
     expect(document.getElementById("modelOutput").value).not.toContain("\"weekDays\": 99");
     expect(document.getElementById("xlsxImportSummary").textContent).toContain("Duration");
@@ -530,11 +528,10 @@ describe("mikuproject main xlsx import", () => {
     await flushAsyncWork();
     await flushAsyncWork();
 
-    expect(document.getElementById("statusMessage").textContent).toContain("XLSX に反映対象の変更はありませんでした");
+    expect(document.getElementById("statusMessage").textContent).toContain("XLSX を読み込んで project 全体を置き換えました");
     expect(document.getElementById("modelOutput").value).not.toContain("\"weekDays\": 77");
     expect(document.getElementById("modelOutput").value).not.toContain("\"exceptions\": 88");
     expect(document.getElementById("modelOutput").value).not.toContain("\"workWeeks\": 99");
-    expect(document.getElementById("xmlInput").value).toBe(originalXml);
     expect(document.getElementById("xlsxImportSummary").classList.contains("md-hidden")).toBe(true);
   });
 


### PR DESCRIPTION
## 概要

`Output` / import 導線のうち、`XLSX` と `workbook JSON` の扱いを、既存 project への差分適用ではなく「project 全体の全置換」に揃えました。あわせて、差分表示は比較用の補助として残しつつ、UI 文言を `Replace` 前提に調整しています。

## 変更内容

### `XLSX` import の全置換化

- `project-xlsx` に、workbook から `ProjectModel` を丸ごと組み立てる import 経路を追加
- `main.ts` の `XLSX` import は、既存 model を部分更新するのではなく、新しい model で current project を置き換えるように変更
- 差分 summary は、取込前 model との比較表示として維持

### `workbook JSON` import の全置換化

- `project-workbook-json` に、document から `ProjectModel` を丸ごと組み立てる import 経路を追加
- `main.ts` の `workbook JSON` import も、既存 model への差分適用ではなく全置換に変更
- warning 表示は維持しつつ、差分 summary は比較表示として残す構成に変更

### UI 文言と summary 表示の調整

- `main-render.ts` で import summary の説明文を更新
- `JSON Replace`
- `XLSX Replace` という source label を追加
- `workbook JSON の取込結果` / `Excel 編集結果の取込内容` ではなく、全置換結果であることが伝わる文言に変更
- `statusMessage` / toast も `反映しました` ではなく、全置換として読める文言に整理

### テスト更新

- `tests/mikuproject-main-xlsx-import.test.js` を更新
- `XLSX` / `workbook JSON` import の status 文言と summary 表示を、全置換前提に合わせて更新
- `predecessors` の扱いで落ちていた箇所を修正し、full build が通る状態に整理

## 更新ファイル

- `src/ts/project-xlsx.ts`
- `src/ts/project-workbook-json.ts`
- `src/ts/main.ts`
- `src/ts/main-render.ts`
- `tests/mikuproject-main-xlsx-import.test.js`

## テスト

- `npm run build`
- 結果: `16 files / 240 tests passed`