### PR TITLE
index ページと architecture ドキュメントの表現を README に合わせて更新する

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,9 +6,9 @@
 
 重視しているのは次の 3 点である。
 
-- `MS Project XML` を基軸にした変換・可視化・限定編集
-- 生成AI 連携を意識した projection / 再取込
-- 人が読むための `WBS Excel ブック (.xlsx)` 帳票出力
+- `MS Project XML` を意味の基軸として保つこと
+- 生成AIと人の往復に適した表現変換 / 再取込 / 介在を支えること
+- 人が読むための可視化と、WBS 帳票・SVG を含む成果物出力を提供すること
 
 ## 全体構成
 
@@ -23,11 +23,11 @@
 - `MS Project XML -> ProjectModel -> XLSX`
 - `MS Project XML -> ProjectModel -> mikuproject_workbook_json`
 - `MS Project XML -> ProjectModel -> Mermaid`
-- `MS Project XML -> ProjectModel -> 生成AI向け JSON projection`
+- `MS Project XML -> ProjectModel -> 生成AI向け JSON`
 
 また、新規生成向けには次の流れを持つ。
 
-- `project_draft_view -> ProjectModel -> MS Project XML / WBS Excel ブック (.xlsx)`
+- `project_draft_view -> ProjectModel -> MS Project XML / WBS Excel ブック (.xlsx) / 可視化成果物`
 
 `XLSX Import` と workbook JSON import は、自由編集をそのまま受け入れるのではなく、限定列の部分更新として扱う。
 
@@ -65,8 +65,8 @@
 ### Input
 
 - `Load from file` からの `MS Project XML / XLSX / workbook JSON (.json) / 生成AI向け編集用 JSON (.editjson) / CSV + ParentID` の読込
-- `project_draft_view` ベースで生成したサンプル XML の読込
-- 生成AIが返した `project_draft_view` の JSON 貼り付け取込
+- 生成AIによる WBS 草案（`project_draft_view`）をもとに生成した `MS Project XML` の読込
+- 生成AIが返した WBS 草案（`project_draft_view`）の JSON 貼り付け取込
 
 ### Overview
 
@@ -84,7 +84,7 @@
 - `CSV + ParentID` の保存
 - Mermaid fenced code block を含む `.md` の保存
 - `Daily SVG / Weekly SVG / Monthly Calendar SVG` の保存
-- 生成AI向け `project_overview_view` / `phase_detail_view` / `full bundle` の `.editjson` 保存
+- 生成AI向け `project_overview_view` / `phase_detail_view` / `task_edit_view` / `full bundle` の `.editjson` 保存
 
 ## 生成AI連携
 
@@ -143,7 +143,7 @@ sample 生成も含めた従来相当のフル実行:
 npm run build:full
 ```
 
-`npm run build` は日常開発向けの軽い確認で、`build:web` と `test:fast` を順に実行する。`npm run build:app` は `build:web` と `build:xlsx-sample` を順に実行する。`npm run build:full` は `build:web` と `test:full` を順に実行し、日常で見たい core UI smoke suite までを確認する。`build:xlsx-sample` は必要なときだけ `build:app` か `npm run build:xlsx-sample` で明示実行する。`npm run test:extended` は validation、`XLSX import`、preview 切替、重い patch/export 系、projection/replace 系を追加で確認する。`npm test` / `npm run test:all` はそれらも含めた完全実行である。
+`npm run build` は日常開発向けの軽い確認で、`build:web` と `test:fast` を順に実行する。`npm run build:app` は `build:web` と `build:xlsx-sample` を順に実行する。`npm run build:full` は `build:web` と `test:full` を順に実行し、日常で見たい core UI smoke suite までを確認する。`build:xlsx-sample` は必要なときだけ `build:app` か `npm run build:xlsx-sample` で明示実行する。`npm run test:extended` は validation、`XLSX import`、preview 切替、重い patch/export 系、表現変換/replace 系を追加で確認する。`npm test` / `npm run test:all` はそれらも含めた完全実行である。
 
 スクリプトの役割は次のとおり。
 
@@ -153,7 +153,7 @@ npm run build:full
 - `npm run build:xlsx-sample`: `local-data/` 配下へサンプル XLSX / Markdown を生成する
 - `npm run build:app`: `build:web` と `build:xlsx-sample` を順に実行する
 - `npm run build:full`: `build:web` と `test:full` を順に実行する
-- `npm run test:extended`: validation、`XLSX import`、preview 切替、重い patch/export 系、projection/replace 系 UI suite を実行する
+- `npm run test:extended`: validation、`XLSX import`、preview 切替、重い patch/export 系、表現変換/replace 系 UI suite を実行する
 - `npm run test:all`: `fast + ui + extended` をすべて実行する
 
 `scripts/build-project.mjs` は `--js-only` と `--html-only` を受け取り、JavaScript 生成と HTML 生成を切り替える。

--- a/index-src.html
+++ b/index-src.html
@@ -219,12 +219,13 @@
     <section aria-label="What is this">
       <h2>What is this?</h2>
       <p class="lead">
-        <code>mikuproject</code> は、<code>MS Project XML</code> を基軸に、変換・可視化・限定編集を行う single-file web app です。
+        <code>mikuproject</code> は、<code>MS Project XML</code> を意味の基軸に、生成AIとの往復を支えるために設計されたローカル HTML ツールです。WBS の草案作成から再編集・再取込、人向けの可視化・帳票化までを、ひとつの流れとして扱えます。
       </p>
       <ul>
-        <li><code>MS Project XML</code> を基軸にした変換・可視化・限定編集を重視しています。</li>
-        <li>生成AI 連携を意識した projection の出力と草案の再取込を持ちます。</li>
-        <li>人が読むための <code>WBS Excel ブック (.xlsx)</code> 帳票出力を持ちます。</li>
+        <li>WBS の草案作成から再編集・再取込、人向けの可視化・帳票化までを、ひとつの流れとして扱えます。</li>
+        <li><code>MS Project XML</code> を意味の基軸として保ちます。</li>
+        <li>生成AIと人の往復に適した表現変換 / 再取込 / 介在を支えます。</li>
+        <li>人が読むための可視化と、WBS 帳票・SVG を含む成果物出力を提供します。</li>
         <li>Web ブラウザさえあればインストール不要・ネットワーク不要で利用できます。</li>
       </ul>
     </section>
@@ -236,18 +237,18 @@
       <div class="panel-grid">
         <div class="panel">
           <ul>
-            <li><code>MS Project XML</code> を読み込み、内部モデルへ変換します。</li>
-            <li>内部モデルを JSON とサマリとして確認できます。</li>
+            <li>生成AIに渡すためのプロジェクト概要・工程詳細・一式データを出力できます。</li>
+            <li>生成AIが返した WBS 素案や Patch JSON を取り込んで反映できます。</li>
+            <li><code>MS Project XML</code> を読み込み、内部モデルへ変換して確認できます。</li>
             <li><code>MS Project XML</code> を再生成できます。</li>
-            <li>Mermaid gantt テキストと、native SVG の preview / SVG を出力できます。</li>
           </ul>
         </div>
         <div class="panel">
           <ul>
-            <li><code>Project / Tasks / Resources / Assignments / Calendars</code> workbook を <code>XLSX Export / Import</code> できます。</li>
-            <li>人が読むための <code>WBS Excel ブック (.xlsx)</code> を出力できます。</li>
-            <li><code>CSV + ParentID</code> の生成と解析を行えます。</li>
-            <li>生成AI向け JSON projection の出力と草案 JSON の取込ができます。</li>
+            <li>日次・週次のガント表現や月次カレンダーの <code>SVG</code> を出力できます。</li>
+            <li><code>Project / Tasks / Resources / Assignments / Calendars</code> workbook を、構造を保ったまま <code>XLSX / JSON</code> で入出力できます。</li>
+            <li>人が読むための <code>WBS Excel ブック (.xlsx)</code> と <code>WBS Markdown</code> を出力できます。</li>
+            <li><code>CSV + ParentID</code>、Mermaid、<code>ALL</code> ZIP を出力できます。</li>
           </ul>
         </div>
       </div>
@@ -258,9 +259,9 @@
     <section aria-label="Use cases">
       <h2>Use Cases</h2>
       <ul>
-        <li>管理用の Excel ブックに必要な情報を入力し、<code>WBS Excel ブック (.xlsx)</code> 形式へ変換したい。</li>
-        <li>生成AI に専用プロンプトを与えて WBS 草案を作成し、その結果を取り込んで <code>WBS Excel ブック (.xlsx)</code> にしたい。</li>
-        <li><code>MS Project</code> のデータを <code>MS Project XML</code> 形式でエクスポートし、それを <code>WBS Excel ブック (.xlsx)</code> 形式へ変換したい。</li>
+        <li>生成AIとの対話で WBS 草案を作成し、<code>mikuproject</code> に取り込んで、人と生成AIが確認・修正しながら、帳票や可視化成果物として仕上げたい。</li>
+        <li>既存の <code>MS Project XML</code> を <code>mikuproject</code> に取り込み、内容を確認しながら、<code>WBS Excel ブック (.xlsx)</code> や日次・週次のガント表現や月次カレンダーの <code>SVG</code>、<code>Markdown</code> などの人向け成果物へ展開したい。</li>
+        <li><code>mikuproject</code> で扱う WBS やプロジェクト情報を生成AI向けに表現変換し、生成AIが返した結果を再び取り込みながら、人と生成AIがレビュー・調整・再利用しやすい形へ整えたい。</li>
       </ul>
     </section>
 
@@ -270,9 +271,9 @@
       <h2>How to use</h2>
       <ol>
         <li>Web ブラウザで <code>mikuproject.html</code> を開きます。</li>
-        <li><code>Load from file</code> から project ファイルを読み込むか、サンプルを使います。</li>
-        <li>内部モデル、validation、native SVG preview を確認します。</li>
-        <li>必要に応じて <code>MS Project XML</code>、<code>XLSX</code>、<code>WBS Excel ブック (.xlsx)</code>、Mermaid、CSV を保存します。</li>
+        <li><code>Load from file</code>、<code>サンプル</code>、<code>生成AI連携</code> から <code>MS Project XML / XLSX / workbook JSON / .editjson / CSV + ParentID</code> を入力します。</li>
+        <li>内部モデル、validation、<code>Daily / Weekly / Monthly Calendar</code> preview を確認します。</li>
+        <li>必要に応じて <code>MS Project XML / XLSX / WBS XLSX / WBS Markdown / workbook JSON / CSV + ParentID / Daily SVG / Weekly SVG / Monthly Calendar SVG / Mermaid / .editjson / ALL ZIP</code> を保存します。</li>
       </ol>
       <div class="link-row">
         <a class="link-btn" href="./mikuproject.html">Open mikuproject</a>
@@ -316,7 +317,7 @@
             <img src="./docs/screenshots/screen03.png" alt="mikuproject Output screen" />
           </div>
           <figcaption>
-            Output 画面。<code>MS Project XML</code>、<code>XLSX</code>、<code>JSON</code>、<code>CSV</code>、<code>WBS XLSX</code>、Mermaid、SVG を保存できます。
+            Output 画面。<code>MS Project XML</code>、<code>XLSX</code>、<code>JSON</code>、<code>CSV</code>、<code>WBS XLSX</code>、<code>WBS Markdown</code>、Mermaid、<code>SVG</code>、<code>.editjson</code>、<code>ALL</code> ZIP を保存できます。
           </figcaption>
         </figure>
         <figure class="shot-card">

--- a/index.html
+++ b/index.html
@@ -219,12 +219,13 @@
     <section aria-label="What is this">
       <h2>What is this?</h2>
       <p class="lead">
-        <code>mikuproject</code> は、<code>MS Project XML</code> を基軸に、変換・可視化・限定編集を行う single-file web app です。
+        <code>mikuproject</code> は、<code>MS Project XML</code> を意味の基軸に、生成AIとの往復を支えるために設計されたローカル HTML ツールです。WBS の草案作成から再編集・再取込、人向けの可視化・帳票化までを、ひとつの流れとして扱えます。
       </p>
       <ul>
-        <li><code>MS Project XML</code> を基軸にした変換・可視化・限定編集を重視しています。</li>
-        <li>生成AI 連携を意識した projection の出力と草案の再取込を持ちます。</li>
-        <li>人が読むための <code>WBS Excel ブック (.xlsx)</code> 帳票出力を持ちます。</li>
+        <li>WBS の草案作成から再編集・再取込、人向けの可視化・帳票化までを、ひとつの流れとして扱えます。</li>
+        <li><code>MS Project XML</code> を意味の基軸として保ちます。</li>
+        <li>生成AIと人の往復に適した表現変換 / 再取込 / 介在を支えます。</li>
+        <li>人が読むための可視化と、WBS 帳票・SVG を含む成果物出力を提供します。</li>
         <li>Web ブラウザさえあればインストール不要・ネットワーク不要で利用できます。</li>
       </ul>
     </section>
@@ -236,18 +237,18 @@
       <div class="panel-grid">
         <div class="panel">
           <ul>
-            <li><code>MS Project XML</code> を読み込み、内部モデルへ変換します。</li>
-            <li>内部モデルを JSON とサマリとして確認できます。</li>
+            <li>生成AIに渡すためのプロジェクト概要・工程詳細・一式データを出力できます。</li>
+            <li>生成AIが返した WBS 素案や Patch JSON を取り込んで反映できます。</li>
+            <li><code>MS Project XML</code> を読み込み、内部モデルへ変換して確認できます。</li>
             <li><code>MS Project XML</code> を再生成できます。</li>
-            <li>Mermaid gantt テキストと、native SVG の preview / SVG を出力できます。</li>
           </ul>
         </div>
         <div class="panel">
           <ul>
-            <li><code>Project / Tasks / Resources / Assignments / Calendars</code> workbook を <code>XLSX Export / Import</code> できます。</li>
-            <li>人が読むための <code>WBS Excel ブック (.xlsx)</code> を出力できます。</li>
-            <li><code>CSV + ParentID</code> の生成と解析を行えます。</li>
-            <li>生成AI向け JSON projection の出力と草案 JSON の取込ができます。</li>
+            <li>日次・週次のガント表現や月次カレンダーの <code>SVG</code> を出力できます。</li>
+            <li><code>Project / Tasks / Resources / Assignments / Calendars</code> workbook を、構造を保ったまま <code>XLSX / JSON</code> で入出力できます。</li>
+            <li>人が読むための <code>WBS Excel ブック (.xlsx)</code> と <code>WBS Markdown</code> を出力できます。</li>
+            <li><code>CSV + ParentID</code>、Mermaid、<code>ALL</code> ZIP を出力できます。</li>
           </ul>
         </div>
       </div>
@@ -258,9 +259,9 @@
     <section aria-label="Use cases">
       <h2>Use Cases</h2>
       <ul>
-        <li>管理用の Excel ブックに必要な情報を入力し、<code>WBS Excel ブック (.xlsx)</code> 形式へ変換したい。</li>
-        <li>生成AI に専用プロンプトを与えて WBS 草案を作成し、その結果を取り込んで <code>WBS Excel ブック (.xlsx)</code> にしたい。</li>
-        <li><code>MS Project</code> のデータを <code>MS Project XML</code> 形式でエクスポートし、それを <code>WBS Excel ブック (.xlsx)</code> 形式へ変換したい。</li>
+        <li>生成AIとの対話で WBS 草案を作成し、<code>mikuproject</code> に取り込んで、人と生成AIが確認・修正しながら、帳票や可視化成果物として仕上げたい。</li>
+        <li>既存の <code>MS Project XML</code> を <code>mikuproject</code> に取り込み、内容を確認しながら、<code>WBS Excel ブック (.xlsx)</code> や日次・週次のガント表現や月次カレンダーの <code>SVG</code>、<code>Markdown</code> などの人向け成果物へ展開したい。</li>
+        <li><code>mikuproject</code> で扱う WBS やプロジェクト情報を生成AI向けに表現変換し、生成AIが返した結果を再び取り込みながら、人と生成AIがレビュー・調整・再利用しやすい形へ整えたい。</li>
       </ul>
     </section>
 
@@ -270,9 +271,9 @@
       <h2>How to use</h2>
       <ol>
         <li>Web ブラウザで <code>mikuproject.html</code> を開きます。</li>
-        <li><code>Load from file</code> から project ファイルを読み込むか、サンプルを使います。</li>
-        <li>内部モデル、validation、native SVG preview を確認します。</li>
-        <li>必要に応じて <code>MS Project XML</code>、<code>XLSX</code>、<code>WBS Excel ブック (.xlsx)</code>、Mermaid、CSV を保存します。</li>
+        <li><code>Load from file</code>、<code>サンプル</code>、<code>生成AI連携</code> から <code>MS Project XML / XLSX / workbook JSON / .editjson / CSV + ParentID</code> を入力します。</li>
+        <li>内部モデル、validation、<code>Daily / Weekly / Monthly Calendar</code> preview を確認します。</li>
+        <li>必要に応じて <code>MS Project XML / XLSX / WBS XLSX / WBS Markdown / workbook JSON / CSV + ParentID / Daily SVG / Weekly SVG / Monthly Calendar SVG / Mermaid / .editjson / ALL ZIP</code> を保存します。</li>
       </ol>
       <div class="link-row">
         <a class="link-btn" href="./mikuproject.html">Open mikuproject</a>
@@ -316,7 +317,7 @@
             <img src="./docs/screenshots/screen03.png" alt="mikuproject Output screen" />
           </div>
           <figcaption>
-            Output 画面。<code>MS Project XML</code>、<code>XLSX</code>、<code>JSON</code>、<code>CSV</code>、<code>WBS XLSX</code>、Mermaid、SVG を保存できます。
+            Output 画面。<code>MS Project XML</code>、<code>XLSX</code>、<code>JSON</code>、<code>CSV</code>、<code>WBS XLSX</code>、<code>WBS Markdown</code>、Mermaid、<code>SVG</code>、<code>.editjson</code>、<code>ALL</code> ZIP を保存できます。
           </figcaption>
         </figure>
         <figure class="shot-card">


### PR DESCRIPTION
## 概要

- `index-src.html` と `index.html` の紹介文、機能説明、ユースケース、使い方を更新し、README と同じ説明方針に揃えました。
- `docs/architecture.md` の用語と説明を見直し、生成AIとの往復、表現変換、可視化成果物という整理に寄せました。

## 変更内容

### index ページの更新

- `What is this?` の説明を、`MS Project XML` を意味の基軸として生成AIとの往復を支えるローカル HTML ツール、という表現に更新
- `Features` を、生成AI向けデータ出力、WBS 草案や Patch JSON の取込、SVG、`WBS Markdown`、`ALL` ZIP などの実装内容に合わせて更新
- `Use Cases` を、生成AIとの対話、`MS Project XML` からの展開、生成AI向け表現変換と再取込の流れに更新
- `How to use` を、`Load from file` / `サンプル` / `生成AI連携`、および保存可能な成果物の説明に合わせて更新
- Output スクリーンショットの説明に `WBS Markdown`、`.editjson`、`ALL` ZIP を追加

### architecture ドキュメントの更新

- 重視する3点を README と同じ語彙に更新
- `projection` を `生成AI向け JSON` や `表現変換` ベースの表現へ見直し
- `project_draft_view` 由来の入力説明を、WBS 草案から生成した `MS Project XML` の読込という表現に更新
- Output 説明に `task_edit_view` を追加
- 開発コマンド説明内の `projection/replace` を `表現変換/replace` に更新

## 対象ファイル

- `index-src.html`
- `index.html`
- `docs/architecture.md`

## 補足

- この変更は主にドキュメント・紹介文の更新です。