### PR TITLE
CLI 向けの自己完結 bundle 出力を追加し、`npm run build` に組み込む

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ local-data
 node_modules/
 coverage/
 *.log
-
+bundle/

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ npm run build
 npm test
 ```
 
-開発用コマンドの詳細、テスト運用、`local-data/` の扱いは [docs/development.md](docs/development.md) を参照してください。
+`npm run build` には `build:web`、`build:cli-bundle`、`test:fast` が含まれる。開発用コマンドの詳細、テスト運用、`local-data/` の扱いは [docs/development.md](docs/development.md) を参照してください。
 
 ## 再利用 API
 
@@ -193,6 +193,35 @@ mikuproject export xlsx --in workbook.json --out project.xlsx
 ```
 
 `report` 系の派生出力 CLI は次段候補として分離して扱う。
+
+## CLI bundle first cut
+
+`mikuproject` 側で CLI 実行に必要な runtime をまとめた自己完結ディレクトリ bundle を出力できるようにしている。
+
+```bash
+npm run build:cli-bundle
+```
+
+既定の出力先は `bundle/mikuproject-cli-bundle/` で、主に次を含む。
+
+```text
+bundle/
+  mikuproject-cli-bundle/
+    README.md
+    package.json
+    scripts/
+    src/
+    node_modules/
+```
+
+この bundle は追加の `npm install` なしで、そのまま CLI 実行に使える first cut を狙っている。たとえば次で動く。
+
+```bash
+node bundle/mikuproject-cli-bundle/scripts/mikuproject-cli.mjs ai spec
+node bundle/mikuproject-cli-bundle/scripts/mikuproject-cli.mjs export xml --in workbook.json --out project.xml
+```
+
+bundle 生成時は、repo root の `node_modules` にある `jsdom` とその runtime 依存を取り込む。そのため、bundle 生成前には一度 `npm install` 済みであることを前提とする。
 
 ## 関連ドキュメント
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,16 +167,17 @@ sample 生成も含めた従来相当のフル実行:
 npm run build:full
 ```
 
-`npm run build` は日常開発向けの軽い確認で、`build:web` と `test:fast` を順に実行する。`npm run build:app` は `build:web` と `build:xlsx-sample` を順に実行する。`npm run build:full` は `build:web` と `test:full` を順に実行し、日常で見たい core UI smoke suite までを確認する。`build:xlsx-sample` は必要なときだけ `build:app` か `npm run build:xlsx-sample` で明示実行する。`npm run test:extended` は validation、`XLSX import`、preview 切替、重い patch/export 系、表現変換/replace 系を追加で確認する。`npm test` / `npm run test:all` はそれらも含めた完全実行である。
+`npm run build` は日常開発向けの標準 build で、`build:web`、`build:cli-bundle`、`test:fast` を順に実行する。`npm run build:app` は `build:web` と `build:xlsx-sample` を順に実行する。`npm run build:full` は `build:web`、`build:cli-bundle`、`test:full` を順に実行し、日常で見たい core UI smoke suite までを確認する。`build:xlsx-sample` は必要なときだけ `build:app` か `npm run build:xlsx-sample` で明示実行する。`npm run test:extended` は validation、`XLSX import`、preview 切替、重い patch/export 系、表現変換/replace 系を追加で確認する。`npm test` / `npm run test:all` はそれらも含めた完全実行である。
 
 スクリプトの役割は次のとおり。
 
 - `npm run build:js`: `src/ts/` から `src/js/` を生成する
 - `npm run build:html`: `index-src.html` と `mikuproject-src.html` から `index.html` と `mikuproject.html` を生成する
 - `npm run build:web`: JavaScript 生成と HTML 生成をまとめて行う
+- `npm run build:cli-bundle`: 自己完結 CLI bundle を `bundle/mikuproject-cli-bundle/` へ生成する
 - `npm run build:xlsx-sample`: `local-data/` 配下へサンプル XLSX / Markdown を生成する
 - `npm run build:app`: `build:web` と `build:xlsx-sample` を順に実行する
-- `npm run build:full`: `build:web` と `test:full` を順に実行する
+- `npm run build:full`: `build:web`、`build:cli-bundle`、`test:full` を順に実行する
 - `npm run test:extended`: validation、`XLSX import`、preview 切替、重い patch/export 系、表現変換/replace 系 UI suite を実行する
 - `npm run test:all`: `fast + ui + extended` をすべて実行する
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,9 +13,9 @@ npm run build
 npm test
 ```
 
-- `npm run build` は日常開発向けの軽い確認で、`build:web` と `test:fast` を順に実行する
+- `npm run build` は日常開発向けの標準 build で、`build:web`、`build:cli-bundle`、`test:fast` を順に実行する
 - `npm run build:app` は `build:web` と `build:xlsx-sample` を順に実行する
-- `npm run build:full` は `build:web` と `test:full` を順に実行し、日常で見たい core UI smoke suite までを確認する
+- `npm run build:full` は `build:web`、`build:cli-bundle`、`test:full` を順に実行し、日常で見たい core UI smoke suite までを確認する
 - `build:xlsx-sample` は必要なときだけ `build:app` か `npm run build:xlsx-sample` で明示実行する
 
 ## テストの使い分け

--- a/package.json
+++ b/package.json
@@ -9,13 +9,14 @@
     "mikuproject": "scripts/mikuproject-cli.mjs"
   },
   "scripts": {
-    "build": "npm run build:web && npm run test:fast",
+    "build": "npm run build:web && npm run build:cli-bundle && npm run test:fast",
     "build:js": "node scripts/build-project.mjs --js-only",
     "build:html": "node scripts/build-project.mjs --html-only",
     "build:web": "node scripts/build-project.mjs",
+    "build:cli-bundle": "node scripts/build-cli-bundle.mjs",
     "build:app": "npm run build:web && npm run build:xlsx-sample",
     "cli": "node scripts/mikuproject-cli.mjs",
-    "build:full": "npm run build:web && npm run test:full",
+    "build:full": "npm run build:web && npm run build:cli-bundle && npm run test:full",
     "build:xlsx-sample": "node scripts/build-project-xlsx-sample.mjs",
     "test": "node scripts/run-tests.mjs all",
     "test:fast": "node scripts/run-tests.mjs fast",

--- a/scripts/build-cli-bundle.mjs
+++ b/scripts/build-cli-bundle.mjs
@@ -1,0 +1,202 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
+
+import { CORE_API_MODULE_RELATIVE_PATHS } from "./lib/core-api-loader.mjs";
+
+const ROOT = process.cwd();
+const requireFromRoot = createRequire(path.resolve(ROOT, "package.json"));
+
+const args = parseArgs(process.argv.slice(2));
+const outDir = path.resolve(
+  args.out || path.join(ROOT, "bundle", "mikuproject-cli-bundle")
+);
+const bundleName = path.basename(outDir);
+
+const rootPackageJson = readJson(path.resolve(ROOT, "package.json"));
+const jsdomPackageJsonPath = resolveInstalledPackageJson("jsdom", requireFromRoot);
+const jsdomPackageJson = readJson(jsdomPackageJsonPath);
+
+buildCliBundle();
+
+function buildCliBundle() {
+  fs.rmSync(outDir, { recursive: true, force: true });
+  fs.mkdirSync(outDir, { recursive: true });
+
+  for (const relativePath of getRuntimeFileRelativePaths()) {
+    copyRepoFile(relativePath);
+  }
+
+  writeBundlePackageJson();
+  writeBundleReadme();
+  copyRuntimeNodeModules();
+
+  console.log(`[build:cli-bundle] generated ${path.relative(ROOT, outDir)}`);
+}
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) {
+      throw new Error(`未対応の引数です: ${token}`);
+    }
+
+    const key = token.slice(2);
+    const value = argv[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`オプション ${token} には値が必要です`);
+    }
+    options[key] = value;
+    index += 1;
+  }
+  return options;
+}
+
+function getRuntimeFileRelativePaths() {
+  const files = new Set([
+    "scripts/mikuproject-cli.mjs",
+    "scripts/lib/core-api-loader.mjs",
+    ...CORE_API_MODULE_RELATIVE_PATHS
+  ]);
+  return Array.from(files).sort();
+}
+
+function copyRepoFile(relativePath) {
+  const sourcePath = path.resolve(ROOT, relativePath);
+  const destinationPath = path.resolve(outDir, relativePath);
+  fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+  fs.copyFileSync(sourcePath, destinationPath);
+}
+
+function writeBundlePackageJson() {
+  const document = {
+    name: `${rootPackageJson.name}-cli-bundle`,
+    version: rootPackageJson.version,
+    private: true,
+    description: "Self-contained mikuproject CLI bundle.",
+    license: rootPackageJson.license,
+    type: "module",
+    bin: {
+      mikuproject: "scripts/mikuproject-cli.mjs"
+    },
+    engines: {
+      node: ">=18"
+    },
+    dependencies: {
+      jsdom: jsdomPackageJson.version
+    }
+  };
+
+  const packageJsonPath = path.resolve(outDir, "package.json");
+  fs.writeFileSync(packageJsonPath, `${JSON.stringify(document, null, 2)}\n`, "utf8");
+}
+
+function writeBundleReadme() {
+  const readmePath = path.resolve(outDir, "README.md");
+  const lines = [
+    `# ${bundleName}`,
+    "",
+    "この bundle は `mikuproject` CLI を追加の `npm install` なしで実行するための配布物です。",
+    "",
+    "## 使い方",
+    "",
+    "```bash",
+    "node scripts/mikuproject-cli.mjs ai spec",
+    "```",
+    "",
+    "または `npm link` / `npm install -g <展開先>` 相当で `mikuproject` を PATH に出せます。"
+  ];
+  fs.writeFileSync(readmePath, `${lines.join("\n")}\n`, "utf8");
+}
+
+function copyRuntimeNodeModules() {
+  const sourceNodeModulesDir = path.resolve(ROOT, "node_modules");
+  const destinationNodeModulesDir = path.resolve(outDir, "node_modules");
+  fs.mkdirSync(destinationNodeModulesDir, { recursive: true });
+
+  const visitedPackageJsonPaths = new Set();
+  const queue = [{ name: "jsdom", requireFn: requireFromRoot }];
+
+  while (queue.length > 0) {
+    const current = queue.shift();
+    const packageJsonPath = resolveInstalledPackageJson(current.name, current.requireFn);
+    if (visitedPackageJsonPaths.has(packageJsonPath)) {
+      continue;
+    }
+    visitedPackageJsonPaths.add(packageJsonPath);
+
+    const packageJson = readJson(packageJsonPath);
+    const packageDir = path.dirname(packageJsonPath);
+    const relativePackageDir = path.relative(sourceNodeModulesDir, packageDir);
+    if (relativePackageDir.startsWith("..")) {
+      throw new Error(`node_modules 配下でない package を検出しました: ${packageDir}`);
+    }
+
+    const destinationPackageDir = path.resolve(destinationNodeModulesDir, relativePackageDir);
+    fs.mkdirSync(path.dirname(destinationPackageDir), { recursive: true });
+    fs.cpSync(packageDir, destinationPackageDir, {
+      recursive: true,
+      force: true,
+      dereference: true
+    });
+
+    const packageRequire = createRequire(packageJsonPath);
+    for (const dependencyName of Object.keys(packageJson.dependencies || {})) {
+      queue.push({ name: dependencyName, requireFn: packageRequire });
+    }
+    for (const dependencyName of Object.keys(packageJson.optionalDependencies || {})) {
+      if (!isPackageInstalled(dependencyName, packageRequire)) {
+        continue;
+      }
+      queue.push({ name: dependencyName, requireFn: packageRequire });
+    }
+  }
+}
+
+function resolveInstalledPackageJson(packageName, requireFn) {
+  try {
+    return requireFn.resolve(`${packageName}/package.json`);
+  } catch (_error) {
+    try {
+      const resolvedEntryPath = requireFn.resolve(packageName);
+      return findNearestPackageJson(resolvedEntryPath, packageName);
+    } catch (_innerError) {
+      throw new Error(
+        `${packageName} が見つかりません。先に repo root で npm install を実行してください`
+      );
+    }
+  }
+}
+
+function isPackageInstalled(packageName, requireFn) {
+  try {
+    requireFn.resolve(`${packageName}/package.json`);
+    return true;
+  } catch (_error) {
+    return false;
+  }
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function findNearestPackageJson(startPath, expectedPackageName) {
+  let currentDir = path.dirname(startPath);
+  while (true) {
+    const packageJsonPath = path.join(currentDir, "package.json");
+    if (fs.existsSync(packageJsonPath)) {
+      const document = readJson(packageJsonPath);
+      if (document.name === expectedPackageName) {
+        return packageJsonPath;
+      }
+    }
+
+    const parentDir = path.dirname(currentDir);
+    if (parentDir === currentDir) {
+      throw new Error(`package.json が見つかりません: ${expectedPackageName}`);
+    }
+    currentDir = parentDir;
+  }
+}

--- a/scripts/lib/core-api-loader.mjs
+++ b/scripts/lib/core-api-loader.mjs
@@ -8,7 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const DEFAULT_ROOT_DIR = path.resolve(__dirname, "../..");
 
-const CORE_API_MODULE_RELATIVE_PATHS = [
+export const CORE_API_MODULE_RELATIVE_PATHS = [
   "src/js/types.js",
   "src/js/ai-json-util.js",
   "src/js/ai-json-spec.js",

--- a/tests/mikuproject-cli.test.js
+++ b/tests/mikuproject-cli.test.js
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,6 +12,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
 const cliPath = path.resolve(repoRoot, "scripts/mikuproject-cli.mjs");
+const cliBundleBuildPath = path.resolve(repoRoot, "scripts/build-cli-bundle.mjs");
 
 const tempDirs = [];
 
@@ -111,6 +112,28 @@ describe("mikuproject cli", () => {
     expect(Buffer.isBuffer(result.stdout)).toBe(true);
     expect(result.stdout.subarray(0, 2).toString("utf8")).toBe("PK");
   });
+
+  it("builds a self-contained cli bundle that runs outside the repo", () => {
+    const bundleRoot = path.join(createTempDir("mikuproject-cli-bundle-test-"), "bundle");
+    const buildResult = spawnSync(process.execPath, [cliBundleBuildPath, "--out", bundleRoot], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    });
+
+    expect(buildResult.status).toBe(0);
+    expect(existsSync(path.join(bundleRoot, "node_modules", "jsdom", "package.json"))).toBe(true);
+
+    const workbookPath = writeTempJson("bundle-workbook.json", buildWorkbookState("Bundled CLI export xml"));
+    const bundledCliPath = path.join(bundleRoot, "scripts", "mikuproject-cli.mjs");
+    const result = spawnSync(process.execPath, [bundledCliPath, "export", "xml", "--in", workbookPath], {
+      cwd: path.dirname(workbookPath),
+      encoding: "utf8"
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("<Project");
+    expect(result.stdout).toContain("<Name>Bundled CLI export xml</Name>");
+  });
 });
 
 function runCli(args, options = {}) {
@@ -121,11 +144,16 @@ function runCli(args, options = {}) {
 }
 
 function writeTempJson(fileName, documentLike) {
-  const dir = mkdtempSync(path.join(os.tmpdir(), "mikuproject-cli-test-"));
-  tempDirs.push(dir);
+  const dir = createTempDir("mikuproject-cli-test-");
   const filePath = path.join(dir, fileName);
   writeFileSync(filePath, `${JSON.stringify(documentLike, null, 2)}\n`, "utf8");
   return filePath;
+}
+
+function createTempDir(prefix) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
 }
 
 function buildWorkbookState(projectName) {


### PR DESCRIPTION
## 概要

`mikuproject` CLI を追加の `npm install` なしで実行しやすくするため、自己完結ディレクトリ bundle の生成を追加します。あわせて、通常の `npm run build` / `npm run build:full` に bundle 生成を含めます。

## 変更内容

- `scripts/build-cli-bundle.mjs` を追加
- `build:cli-bundle` script を追加
- `npm run build` を `build:web` → `build:cli-bundle` → `test:fast` の流れに変更
- `npm run build:full` を `build:web` → `build:cli-bundle` → `test:full` の流れに変更
- `core-api-loader` の runtime file list を bundle build から再利用できるように変更
- CLI bundle が repo 外でも動作することを確認するテストを追加
- README / development / architecture ドキュメントを更新
- `bundle/` を `.gitignore` に追加

## 生成される bundle

既定の出力先は `bundle/mikuproject-cli-bundle/` です。

含まれる内容:
- `scripts/`
- `src/`
- `package.json`
- `node_modules/`

コミット内容上、bundle 生成時には `jsdom` とその runtime 依存を取り込みます。

## 期待する効果

- CLI 実行に必要な runtime を `mikuproject` 側でまとめて出力できる
- 配布先で追加の `npm install` を要求しない first cut の bundle を提供できる
- `npm run build` 実行時に CLI bundle もあわせて生成される

## 確認観点

- `build:cli-bundle` で `bundle/mikuproject-cli-bundle/` が生成されること
- bundle に `jsdom` を含む runtime 依存が入ること
- bundle 化した CLI が repo 外でも `export xml` を実行できること
- `npm run build` / `npm run build:full` に bundle 生成が含まれていること