### PR TITLE
CLI に report 系エクスポートコマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ Node 側から `core API` を薄く包む最小 CLI first cut として、次の
 - `mikuproject export workbook-json`
 - `mikuproject export xml`
 - `mikuproject export xlsx`
+- `mikuproject report wbs-xlsx`
+- `mikuproject report daily-svg`
+- `mikuproject report weekly-svg`
+- `mikuproject report monthly-calendar-svg`
+- `mikuproject report wbs-markdown`
+- `mikuproject report mermaid`
 
 主成果物は `stdout`、warning / diagnostics は `stderr` を基本とする。
 
@@ -190,9 +196,15 @@ mikuproject state from-draft --in draft.json --out workbook.json
 mikuproject state apply-patch --state workbook.json --in patch.json --out workbook.next.json
 mikuproject export xml --in workbook.json --out project.xml
 mikuproject export xlsx --in workbook.json --out project.xlsx
+mikuproject report wbs-xlsx --in workbook.json --out project-wbs.xlsx
+mikuproject report daily-svg --in workbook.json --out project-daily.svg
+mikuproject report weekly-svg --in workbook.json --out project-weekly.svg
+mikuproject report monthly-calendar-svg --in workbook.json --out project-monthly.zip
+mikuproject report wbs-markdown --in workbook.json --out project-wbs.md
+mikuproject report mermaid --in workbook.json --out project.mmd
 ```
 
-`report` 系の派生出力 CLI は次段候補として分離して扱う。
+`report monthly-calendar-svg` は月別 SVG 一式をまとめた ZIP を出力する。
 
 ## CLI bundle first cut
 

--- a/scripts/mikuproject-cli.mjs
+++ b/scripts/mikuproject-cli.mjs
@@ -138,6 +138,55 @@ async function runCommand(command, options, api) {
     }
   }
 
+  if (scope === "report" && subaction === undefined) {
+    const stateDocument = parsePlainJson(await readTextInput(options.in));
+    ensureWorkbookJson(api, stateDocument, `report ${action}`);
+    const model = api.workbookJson.importAsProjectModel(stateDocument).model;
+
+    if (action === "wbs-xlsx") {
+      return {
+        output: api.report.wbsXlsx.exportBytes(model),
+        diagnostics: []
+      };
+    }
+
+    if (action === "daily-svg") {
+      return {
+        output: `${api.report.svg.exportDaily(model)}\n`,
+        diagnostics: []
+      };
+    }
+
+    if (action === "weekly-svg") {
+      return {
+        output: `${api.report.svg.exportWeekly(model)}\n`,
+        diagnostics: []
+      };
+    }
+
+    if (action === "monthly-calendar-svg") {
+      const archive = api.report.svg.exportMonthlyCalendar(model);
+      return {
+        output: archive.zipBytes,
+        diagnostics: []
+      };
+    }
+
+    if (action === "wbs-markdown") {
+      return {
+        output: `${api.report.wbsMarkdown.export(model)}\n`,
+        diagnostics: []
+      };
+    }
+
+    if (action === "mermaid") {
+      return {
+        output: `${api.report.mermaid.exportGantt(model)}\n`,
+        diagnostics: []
+      };
+    }
+  }
+
   throw new Error(`未対応のコマンドです: ${command.join(" ")}`);
 }
 
@@ -239,7 +288,13 @@ function writeHelp(stream) {
     "  mikuproject state apply-patch --state workbook.json [--in patch.json] [--out workbook.next.json]",
     "  mikuproject export workbook-json [--in workbook.json] [--out workbook.json]",
     "  mikuproject export xml [--in workbook.json] [--out project.xml]",
-    "  mikuproject export xlsx [--in workbook.json] [--out project.xlsx]"
+    "  mikuproject export xlsx [--in workbook.json] [--out project.xlsx]",
+    "  mikuproject report wbs-xlsx [--in workbook.json] [--out report.xlsx]",
+    "  mikuproject report daily-svg [--in workbook.json] [--out report.svg]",
+    "  mikuproject report weekly-svg [--in workbook.json] [--out report.svg]",
+    "  mikuproject report monthly-calendar-svg [--in workbook.json] [--out report.zip]",
+    "  mikuproject report wbs-markdown [--in workbook.json] [--out report.md]",
+    "  mikuproject report mermaid [--in workbook.json] [--out report.mmd]"
   ].join("\n"));
   stream.write("\n");
 }

--- a/tests/mikuproject-cli.test.js
+++ b/tests/mikuproject-cli.test.js
@@ -113,6 +113,66 @@ describe("mikuproject cli", () => {
     expect(result.stdout.subarray(0, 2).toString("utf8")).toBe("PK");
   });
 
+  it("exports report wbs-xlsx bytes from workbook state", () => {
+    const workbookPath = writeTempJson("workbook.json", buildWorkbookState("CLI report wbs-xlsx"));
+
+    const result = runCli(["report", "wbs-xlsx", "--in", workbookPath], { encoding: "buffer" });
+
+    expect(result.status).toBe(0);
+    expect(Buffer.isBuffer(result.stdout)).toBe(true);
+    expect(result.stdout.subarray(0, 2).toString("utf8")).toBe("PK");
+  });
+
+  it("exports report daily-svg from workbook state", () => {
+    const workbookPath = writeTempJson("workbook.json", buildWorkbookState("CLI report daily-svg"));
+
+    const result = runCli(["report", "daily-svg", "--in", workbookPath]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("<svg");
+    expect(result.stdout).toContain("CLI report daily-svg");
+  });
+
+  it("exports report weekly-svg from workbook state", () => {
+    const workbookPath = writeTempJson("workbook.json", buildWorkbookState("CLI report weekly-svg"));
+
+    const result = runCli(["report", "weekly-svg", "--in", workbookPath]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("<svg");
+    expect(result.stdout).toContain("CLI report weekly-svg");
+  });
+
+  it("exports report monthly-calendar-svg as zip bytes from workbook state", () => {
+    const workbookPath = writeTempJson("workbook.json", buildWorkbookState("CLI report monthly-calendar-svg"));
+
+    const result = runCli(["report", "monthly-calendar-svg", "--in", workbookPath], { encoding: "buffer" });
+
+    expect(result.status).toBe(0);
+    expect(Buffer.isBuffer(result.stdout)).toBe(true);
+    expect(result.stdout.subarray(0, 2).toString("utf8")).toBe("PK");
+  });
+
+  it("exports report wbs-markdown from workbook state", () => {
+    const workbookPath = writeTempJson("workbook.json", buildWorkbookState("CLI report wbs-markdown"));
+
+    const result = runCli(["report", "wbs-markdown", "--in", workbookPath]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("# プロジェクト情報");
+    expect(result.stdout).toContain("CLI report wbs-markdown");
+  });
+
+  it("exports report mermaid from workbook state", () => {
+    const workbookPath = writeTempJson("workbook.json", buildWorkbookState("CLI report mermaid"));
+
+    const result = runCli(["report", "mermaid", "--in", workbookPath]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("gantt");
+    expect(result.stdout).toContain("title CLI report mermaid");
+  });
+
   it("builds a self-contained cli bundle that runs outside the repo", () => {
     const bundleRoot = path.join(createTempDir("mikuproject-cli-bundle-test-"), "bundle");
     const buildResult = spawnSync(process.execPath, [cliBundleBuildPath, "--out", bundleRoot], {


### PR DESCRIPTION
## 概要

`mikuproject-cli` から `report` 系の派生出力を実行できるようにしました。`mikuproject_workbook_json` を入力として、core API の report exports を CLI から利用できます。

## 変更内容

- `mikuproject-cli` に `report` サブコマンドを追加
- 以下のコマンドを追加
  - `mikuproject report wbs-xlsx`
  - `mikuproject report daily-svg`
  - `mikuproject report weekly-svg`
  - `mikuproject report monthly-calendar-svg`
  - `mikuproject report wbs-markdown`
  - `mikuproject report mermaid`
- `report monthly-calendar-svg` は月別 SVG 一式をまとめた ZIP を出力するように対応
- CLI の help 表示に上記コマンドを追加
- README に CLI の対応コマンド一覧と実行例を追加
- CLI テストに report 系コマンドの確認を追加
  - `wbs-xlsx`
  - `daily-svg`
  - `weekly-svg`
  - `monthly-calendar-svg`
  - `wbs-markdown`
  - `mermaid`

## 補足

- 入力は `mikuproject_workbook_json`
- `wbs-xlsx` と `monthly-calendar-svg` はバイナリ出力
- `daily-svg` / `weekly-svg` / `wbs-markdown` / `mermaid` はテキスト出力