### PR TITLE
CLI の XML DOM 解決を `@xmldom/xmldom` 優先に切り替え、関連ドキュメントと bundle 出力を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ first cut の対応は次のとおり。
 - `project_draft_view`: `replace` のみ
 - `patch_json`: `patch` のみ
 
-Node 側から `core API` を起動する最小 helper は [`scripts/lib/core-api-loader.mjs`](scripts/lib/core-api-loader.mjs) に置いている。`importExternal()` の利用例は [`scripts/core-api-import-external-example.mjs`](scripts/core-api-import-external-example.mjs) を参照。
+Node 側から `core API` を起動する最小 helper は [`scripts/lib/core-api-loader.mjs`](scripts/lib/core-api-loader.mjs) に置いている。CLI ではこの loader が `globalThis.__mikuprojectXmlDom` を初期化し、XML 系の `DOMParser` / `XMLSerializer` / XML document 生成を環境非依存に扱う。`importExternal()` の利用例は [`scripts/core-api-import-external-example.mjs`](scripts/core-api-import-external-example.mjs) を参照。
 
 `AI JSON spec` 単体の取得用には `globalThis.__mikuprojectAiJsonSpec` も公開しています。
 
@@ -237,7 +237,7 @@ node bundle/mikuproject-cli-bundle/scripts/mikuproject-cli.mjs ai spec
 node bundle/mikuproject-cli-bundle/scripts/mikuproject-cli.mjs export xml --in workbook.json --out project.xml
 ```
 
-bundle 生成時は、repo root の `node_modules` にある `jsdom` とその runtime 依存を取り込む。そのため、bundle 生成前には一度 `npm install` 済みであることを前提とする。
+bundle 生成時は、repo root の `node_modules` にある CLI runtime 依存を取り込む。現時点では `@xmldom/xmldom` を CLI の優先 XML DOM 実装として使い、`jsdom` は HTML / Blob / File など XML 以外の Web API 補完のために同梱する。そのため、bundle 生成前には一度 `npm install` 済みであることを前提とする。
 
 ## 関連ドキュメント
 

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,6 +4,18 @@ This document lists third-party software and reference materials used or referre
 
 ## Third-party software
 
+### `jsdom`
+
+- Usage: Used in the CLI and tests to provide browser-like Web APIs such as `window`, `document`, `Blob`, and `File`. XML processing in the CLI no longer depends on `jsdom` directly, but `jsdom` remains in use for non-XML Web API emulation.
+- License: MIT
+- Source: https://github.com/jsdom/jsdom
+
+### `@xmldom/xmldom`
+
+- Usage: Used in the CLI as the preferred XML DOM implementation for `DOMParser`, `XMLSerializer`, and XML document creation.
+- License: MIT
+- Source: https://github.com/xmldom/xmldom
+
 ## Reference materials
 
 ### `open-msp-viewer`
@@ -25,6 +37,18 @@ This document lists third-party software and reference materials used or referre
 この文書は、`mikuproject` が利用または参照している第三者ソフトウェアおよび参考資料を記載したものです。
 
 ## 第三者ソフトウェア
+
+### `jsdom`
+
+- 用途: CLI とテストで、`window`、`document`、`Blob`、`File` などのブラウザ相当 Web API を補うために利用する。CLI の XML 処理は `jsdom` 直依存ではなくなったが、XML 以外の Web API エミュレーション用途では引き続き利用する。
+- ライセンス: MIT
+- Source: https://github.com/jsdom/jsdom
+
+### `@xmldom/xmldom`
+
+- 用途: CLI で、`DOMParser`、`XMLSerializer`、XML document 生成の優先 XML DOM 実装として利用する。
+- ライセンス: MIT
+- Source: https://github.com/xmldom/xmldom
 
 ## 参考資料
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,6 +70,17 @@ single-file web app としての配布を維持しつつ、外部再利用向け
 
 これにより、従来の UI 実装都合で分散していた `ProjectModel` 周りの入口を、外部利用者が 1 箇所から辿れるようにする。
 
+## XML DOM 方針
+
+XML の parse / serialize は、ブラウザ DOM 直依存ではなく `globalThis.__mikuprojectXmlDom` を介して解決する。
+
+- `msproject-xml` と `excel-io` は `DOMParser` を `__mikuprojectXmlDom` から優先取得する
+- `msproject-xml` の XML export は `XMLSerializer` と `createDocument` も同じ経路で解決する
+- Web ではブラウザ標準の XML DOM を使う
+- CLI では `scripts/lib/core-api-loader.mjs` が `@xmldom/xmldom` を優先して注入し、未導入時のみ `jsdom` の XML 実装へフォールバックする
+
+この方針により、CLI の XML 処理は `jsdom` 全体に依存せず、XML 用 DOM 実装だけを差し替えられる。`jsdom` は引き続き CLI 上の HTML / Blob / File など、XML 以外の Web API 補完に使う。
+
 ## リポジトリ構成
 
 - `mikuproject.html`: 生成済みの単一 HTML アプリ
@@ -81,6 +92,7 @@ single-file web app としての配布を維持しつつ、外部再利用向け
 - `tests/`: Vitest ベースのテスト
 - `testdata/`: XML テストデータ
 - `scripts/`: ビルド補助スクリプト
+- `scripts/lib/core-api-loader.mjs`: CLI / 外部再利用向けに core API と XML DOM 実装を初期化する
 - `docs/spec.md`: 現行仕様メモ
 - `docs/gap-notes.md`: 保持項目や互換性のギャップメモ
 

--- a/docs/core-api-import-export-notes.md
+++ b/docs/core-api-import-export-notes.md
@@ -15,6 +15,8 @@
 
 外部再利用向けには、single-file web app 向けの既存 global を維持しつつ、集約入口として `globalThis.__mikuprojectCoreApi` を公開する。
 
+Node / CLI 側では、`scripts/lib/core-api-loader.mjs` が `globalThis.__mikuprojectXmlDom` も初期化する。これにより、`msproject-xml` と `excel-io` の XML parse / serialize はブラウザ DOM 直依存ではなく、CLI では `@xmldom/xmldom` 優先、未導入時は `jsdom` フォールバックで動く。
+
 ## 現状整理
 
 ### format-specific export

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,6 +6,12 @@
 npm install
 ```
 
+補足:
+
+- CLI の XML parse / serialize は `@xmldom/xmldom` を優先利用する
+- `jsdom` は CLI 上の HTML / Blob / File など、XML 以外の Web API 補完にも使っているため依存として残す
+- XML DOM の入口は `globalThis.__mikuprojectXmlDom` で、`msproject-xml` と `excel-io` が参照する
+
 ## よく使うコマンド
 
 ```bash

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1061,6 +1061,7 @@ STEP 1 の中核処理は、次のような責務に分ける。
 - 仕様や表現方法に迷った場合は、`MS Project XML` の持ち方を優先する
 - 独自に扱いやすいモデル化は許容するが、`MS Project XML` との意味対応を壊さないことを優先する
 - 特にタスク階層や依存関係は、独自表現へ寄せすぎず、まず `MS Project` 側の表現を基準に考える
+- XML parser / serializer 実装は差し替え可能にし、モジュール側は `globalThis.__mikuprojectXmlDom` 経由で XML DOM を解決する
 
 ## テスト方針
 

--- a/index.html
+++ b/index.html
@@ -214,7 +214,7 @@
   <main class="card">
     <div class="eyebrow">Local Browser Tool</div>
     <h1>mikuproject</h1>
-    <div class="md-app-meta">Updated: 2026-04-08</div>
+    <div class="md-app-meta">Updated: 2026-04-09</div>
 
     <section aria-label="What is this">
       <h2>What is this?</h2>

--- a/mikuproject.html
+++ b/mikuproject.html
@@ -5772,6 +5772,15 @@ if (!customElements.get("lht-page-menu")) {
  * SPDX-License-Identifier: Apache-2.0
  */
 (() => {
+    function resolveXmlDomEnvironment() {
+        const configured = globalThis.__mikuprojectXmlDom;
+        if (configured && typeof configured.DOMParser === "function") {
+            return configured;
+        }
+        return {
+            DOMParser: globalThis.DOMParser
+        };
+    }
     const TEXT_ENCODER = new TextEncoder();
     const TEXT_DECODER = new TextDecoder();
     const INVALID_SHEET_NAME_PATTERN = /[:\\/?*\[\]]/;
@@ -6708,8 +6717,12 @@ if (!customElements.get("lht-page-menu")) {
         return null;
     }
     function parseXmlDocument(xmlText) {
-        const document = new DOMParser().parseFromString(xmlText, "application/xml");
-        if (document.querySelector("parsererror")) {
+        const environment = resolveXmlDomEnvironment();
+        if (typeof environment.DOMParser !== "function") {
+            throw new Error("XML DOMParser is not available");
+        }
+        const document = new environment.DOMParser().parseFromString(xmlText, "application/xml");
+        if (document.getElementsByTagName("parsererror")[0]) {
             throw new Error("Failed to parse XML document");
         }
         return document;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,12 @@
       "name": "mikuproject",
       "version": "0.1.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.10"
+      },
+      "bin": {
+        "mikuproject": "scripts/mikuproject-cli.mjs"
+      },
       "devDependencies": {
         "jsdom": "^26.1.0",
         "typescript": "^5.8.2",
@@ -1082,6 +1088,15 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -1816,9 +1831,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,12 @@
     "test:full": "node scripts/run-tests.mjs full",
     "test:all": "node scripts/run-tests.mjs all"
   },
+  "dependencies": {
+    "@xmldom/xmldom": "^0.8.10"
+  },
+  "overrides": {
+    "vite": "7.3.2"
+  },
   "devDependencies": {
     "jsdom": "^26.1.0",
     "typescript": "^5.8.2",

--- a/scripts/build-cli-bundle.mjs
+++ b/scripts/build-cli-bundle.mjs
@@ -16,6 +16,9 @@ const bundleName = path.basename(outDir);
 const rootPackageJson = readJson(path.resolve(ROOT, "package.json"));
 const jsdomPackageJsonPath = resolveInstalledPackageJson("jsdom", requireFromRoot);
 const jsdomPackageJson = readJson(jsdomPackageJsonPath);
+const xmldomPackageJsonPath = resolveInstalledPackageJson("@xmldom/xmldom", requireFromRoot);
+const xmldomPackageJson = readJson(xmldomPackageJsonPath);
+const CLI_RUNTIME_DEPENDENCIES = ["jsdom", "@xmldom/xmldom"];
 
 buildCliBundle();
 
@@ -84,7 +87,8 @@ function writeBundlePackageJson() {
       node: ">=18"
     },
     dependencies: {
-      jsdom: jsdomPackageJson.version
+      jsdom: jsdomPackageJson.version,
+      "@xmldom/xmldom": xmldomPackageJson.version
     }
   };
 
@@ -116,7 +120,7 @@ function copyRuntimeNodeModules() {
   fs.mkdirSync(destinationNodeModulesDir, { recursive: true });
 
   const visitedPackageJsonPaths = new Set();
-  const queue = [{ name: "jsdom", requireFn: requireFromRoot }];
+  const queue = CLI_RUNTIME_DEPENDENCIES.map((name) => ({ name, requireFn: requireFromRoot }));
 
   while (queue.length > 0) {
     const current = queue.shift();

--- a/scripts/lib/core-api-loader.mjs
+++ b/scripts/lib/core-api-loader.mjs
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -7,6 +8,7 @@ import { JSDOM } from "jsdom";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const DEFAULT_ROOT_DIR = path.resolve(__dirname, "../..");
+const require = createRequire(import.meta.url);
 
 export const CORE_API_MODULE_RELATIVE_PATHS = [
   "src/js/types.js",
@@ -70,6 +72,7 @@ function clearMikuprojectGlobals() {
   delete globalThis.__mikuprojectAiJsonUtil;
   delete globalThis.__mikuprojectAiJsonSpec;
   delete globalThis.__mikuprojectMainUtil;
+  delete globalThis.__mikuprojectXmlDom;
   delete globalThis.__mikuprojectXml;
   delete globalThis.__mikuprojectMarkdownEscape;
   delete globalThis.__mikuprojectProjectWorkbookSchema;
@@ -83,14 +86,50 @@ function clearMikuprojectGlobals() {
   delete globalThis.__mikuprojectCoreApi;
 }
 
+function loadXmlDomGlobals(window) {
+  try {
+    const xmldom = require("@xmldom/xmldom");
+    const parser = new xmldom.DOMParser();
+    const xmlDocument = parser.parseFromString("<root/>", "application/xml");
+    return {
+      DOMParser: xmldom.DOMParser,
+      XMLSerializer: xmldom.XMLSerializer,
+      createDocument(rootName) {
+        return new xmldom.DOMImplementation().createDocument("", rootName, null);
+      },
+      XMLDocument: xmlDocument.constructor
+    };
+  } catch (_error) {
+    const xmlDocument = new window.DOMParser().parseFromString("<root/>", "application/xml");
+    return {
+      DOMParser: window.DOMParser,
+      XMLSerializer: window.XMLSerializer,
+      createDocument(rootName) {
+        return window.document.implementation.createDocument("", rootName, null);
+      },
+      XMLDocument: xmlDocument.constructor
+    };
+  }
+}
+
 export function loadMikuprojectCoreApi(options = {}) {
   const rootDir = options.rootDir ? path.resolve(options.rootDir) : DEFAULT_ROOT_DIR;
   const dom = new JSDOM("<!doctype html><html><body></body></html>", {
     url: "http://localhost/"
   });
   const restoreWindowGlobals = installWindowGlobals(dom.window);
-
   clearMikuprojectGlobals();
+  const xmlDomGlobals = loadXmlDomGlobals(dom.window);
+  Object.assign(globalThis, {
+    DOMParser: xmlDomGlobals.DOMParser,
+    XMLSerializer: xmlDomGlobals.XMLSerializer,
+    XMLDocument: xmlDomGlobals.XMLDocument,
+    __mikuprojectXmlDom: {
+      DOMParser: xmlDomGlobals.DOMParser,
+      XMLSerializer: xmlDomGlobals.XMLSerializer,
+      createDocument: xmlDomGlobals.createDocument
+    }
+  });
   const combinedCode = CORE_API_MODULE_RELATIVE_PATHS
     .map((relativePath) => fs.readFileSync(path.resolve(rootDir, relativePath), "utf8"))
     .join("\n");

--- a/src/js/excel-io.js
+++ b/src/js/excel-io.js
@@ -3,6 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 (() => {
+    function resolveXmlDomEnvironment() {
+        const configured = globalThis.__mikuprojectXmlDom;
+        if (configured && typeof configured.DOMParser === "function") {
+            return configured;
+        }
+        return {
+            DOMParser: globalThis.DOMParser
+        };
+    }
     const TEXT_ENCODER = new TextEncoder();
     const TEXT_DECODER = new TextDecoder();
     const INVALID_SHEET_NAME_PATTERN = /[:\\/?*\[\]]/;
@@ -939,8 +948,12 @@
         return null;
     }
     function parseXmlDocument(xmlText) {
-        const document = new DOMParser().parseFromString(xmlText, "application/xml");
-        if (document.querySelector("parsererror")) {
+        const environment = resolveXmlDomEnvironment();
+        if (typeof environment.DOMParser !== "function") {
+            throw new Error("XML DOMParser is not available");
+        }
+        const document = new environment.DOMParser().parseFromString(xmlText, "application/xml");
+        if (document.getElementsByTagName("parsererror")[0]) {
             throw new Error("Failed to parse XML document");
         }
         return document;

--- a/src/ts/excel-io.ts
+++ b/src/ts/excel-io.ts
@@ -3,6 +3,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 (() => {
+  function resolveXmlDomEnvironment(): { DOMParser?: typeof DOMParser } {
+    const configured = (globalThis as typeof globalThis & {
+      __mikuprojectXmlDom?: {
+        DOMParser?: typeof DOMParser;
+      };
+    }).__mikuprojectXmlDom;
+    if (configured && typeof configured.DOMParser === "function") {
+      return configured;
+    }
+    return {
+      DOMParser: globalThis.DOMParser
+    };
+  }
+
   type XlsxPrimitiveValue = string | number | boolean;
   type XlsxNumberFormat = "general" | "integer" | "decimal" | "date" | "datetime" | "percent" | "text";
   type XlsxHorizontalAlign = "left" | "center" | "right";
@@ -1190,8 +1204,12 @@
   }
 
   function parseXmlDocument(xmlText: string): XMLDocument {
-    const document = new DOMParser().parseFromString(xmlText, "application/xml");
-    if (document.querySelector("parsererror")) {
+    const environment = resolveXmlDomEnvironment();
+    if (typeof environment.DOMParser !== "function") {
+      throw new Error("XML DOMParser is not available");
+    }
+    const document = new environment.DOMParser().parseFromString(xmlText, "application/xml");
+    if (document.getElementsByTagName("parsererror")[0]) {
       throw new Error("Failed to parse XML document");
     }
     return document;


### PR DESCRIPTION
## 概要

CLI 側の XML 処理で、`jsdom` 直依存ではなく `@xmldom/xmldom` を優先利用するように変更しました。 あわせて、`excel-io` の XML パースも同じ XML DOM 解決経路に寄せ、CLI bundle に `@xmldom/xmldom` が含まれるように修正しています。

## 変更内容

- `package.json` / `package-lock.json`
  - `@xmldom/xmldom` を追加
  - `vite` を `7.3.2` に override
- `scripts/lib/core-api-loader.mjs`
  - `globalThis.__mikuprojectXmlDom` の初期化を追加
  - CLI では `@xmldom/xmldom` を優先し、未導入時は `jsdom` にフォールバックするように変更
- `src/ts/excel-io.ts` / `src/js/excel-io.js`
  - XML パース時に `globalThis.__mikuprojectXmlDom` 経由の `DOMParser` を使うように変更
  - `parsererror` 判定を `getElementsByTagName("parsererror")` ベースに変更
- `scripts/build-cli-bundle.mjs`
  - CLI bundle の runtime dependency に `@xmldom/xmldom` を追加
  - bundle 内 `node_modules` へ `jsdom` と `@xmldom/xmldom` の両方を取り込むように変更
- ドキュメント更新
  - `README.md`
  - `THIRD-PARTY-NOTICES.md`
  - `docs/architecture.md`
  - `docs/core-api-import-export-notes.md`
  - `docs/development.md`
  - `docs/spec.md`
- 生成物更新
  - `mikuproject.html`
  - `index.html`

## 意図

- CLI の XML parse / serialize を、HTML 系の DOM 実装全体から切り離しやすくするため
- XML DOM 実装の差し替え方針を `globalThis.__mikuprojectXmlDom` に統一するため
- CLI bundle の実体とドキュメント記述を一致させるため
- 第三者告知に `jsdom` / `@xmldom/xmldom` を反映するため

## 補足

- `jsdom` は削除していません
  - ドキュメント記載どおり、CLI 上の HTML / Blob / File など XML 以外の Web API 補完用途で引き続き利用します