### PR TITLE
mikuシリーズの設計方針ドキュメントを追加

### DIFF
--- a/docs/miku-soft-10-mainapp-design-v20260425.md
+++ b/docs/miku-soft-10-mainapp-design-v20260425.md
@@ -1,0 +1,921 @@
+# Miku Software Main Application Design v20260425
+
+This memo organizes design characteristics commonly seen across the software series whose names start with `miku`.
+
+The initial versions of these tools were created by `Mikuku` and Toshiki Iga.
+
+The current contents are based on this repository and public `igapyon` GitHub repositories checked on 2026-04-25.
+
+## Design Summary
+
+The `miku` software series can be summarized as follows.
+
+> A family of small, local-first conversion / bridge tools that turn existing domain files into AI-friendly, script-friendly, human-reviewable structured outputs.
+
+What characterizes this series is not a specific technology stack or UI style. It is a repeated set of product constraints.
+
+- Keep each tool small enough to understand
+- Run locally whenever possible
+- Expose structured data
+- Make AI and automation easier
+- Do not pretend to replace full specialist software
+- Prefer practical conversion and review workflows over visual fidelity
+
+## Role of This Document
+
+This document is not a strict specification for any individual repository. It is a cross-repository memo that organizes design decisions common to main applications in the miku software series.
+
+This document separates the following levels.
+
+- **Cross-cutting principles**: design policies that should generally be kept for new main applications and major feature additions.
+- **Recommended conventions**: implementation, distribution, and documentation shapes that make maintenance easier when shared across many main applications.
+- **Observed tendencies**: design habits and decisions visible in existing miku repositories.
+- **Product-specific notes**: design decisions for specific products, recorded as concrete examples of the cross-cutting principles.
+
+When a specification is unclear, read the cross-cutting principles before individual implementation convenience. However, the way a principle appears can differ depending on each product's canonical source, target format, users, and existing assets.
+
+This document is not a replacement for README files. A README is the user-facing entry point, individual files under `docs/` are detailed technical specifications, and this document is a higher-level memo for aligning design decisions across the series.
+
+## Scope
+
+The series whose names start with `miku` includes small tools such as the following.
+
+Main applications:
+
+- `miku-abc-player`
+- `miku-docx2md`
+- `miku-indexgen`
+- `miku-unicode-guard`
+- `miku-xlsx2md`
+- `mikuproject`
+- `mikuscore`
+
+Java straight-conversion versions:
+
+- `miku-indexgen-java`
+- `miku-xlsx2md-java`
+
+Agent Skills versions:
+
+- `mikuproject-skills`
+- `mikuscore-skills`
+
+Projects with the `-java` suffix are positioned as straight Java conversions of the original suffixless tools.
+
+Projects with the `-skills` suffix are positioned as Agent Skills versions that make the original products easier for AI agents to use.
+
+Main applications in the miku series, excluding Java versions and Agent Skills versions, are generally implemented as Node.js applications. When they have a Web UI, they use the `lht-cmn` Web Components as shared UI components.
+
+## Shared Direction
+
+This series is naturally understood as a set of small, practical bridge tools.
+
+Each tool converts, extracts, inspects, or normalizes existing files or domain data, then bridges that information into forms that humans, scripts, and AI agents can handle more easily.
+
+The shared direction is as follows.
+
+- local-first processing
+- small and understandable implementation shape
+- machine-readable output
+- data exchange that is easy to pass to AI agents
+- human-readable companion output when useful
+- no server dependency for core functionality
+- reproducibility where practical
+
+## Role of Main Applications
+
+In this document, a main application means an application in the miku series that is neither a Java straight-conversion version nor an Agent Skills version, and that uses Node.js as its basic runtime.
+
+Main applications may be Web UI applications, CLI-only applications, or applications that provide both. A Web UI is common but not required. A CLI-only tool such as an index generator is still a main application when it stands as the primary product, accepts real local input, and produces verifiable artifacts.
+
+Main applications are practical tools for safely reading existing files in a local environment, structuring them, and passing them to another representation.
+
+Main applications are not mere demos or libraries. They should stand as products that have a UI or CLI directly usable by humans, accept real files as input, and produce verifiable artifacts.
+
+At the same time, main applications do not aim to fully replace specialist software. Their primary role is to stand between existing specialist software, file formats, AI agents, and scripts, then bridge information into easier-to-handle forms.
+
+## Cross-Cutting Principles
+
+miku main applications emphasize the following cross-cutting principles.
+
+1. Handle inputs locally, and do not make server communication a prerequisite for core functionality.
+2. Do not aim to fully replace specialist software; make format bridging and inspection the main role.
+3. Choose a canonical source or semantic base for each target domain, and do not confuse it with derived views.
+4. Prefer reusable structured output and traceability over perfect visual reproduction.
+5. Make unconvertible content, fallback, loss, and unsupported areas visible as diagnostics.
+6. Push processing called from UI, CLI, tests, and Agent Skills toward the same core as much as possible.
+7. Treat AI agents and scripts as first-class users, and do not make them depend on brittle screen operations or string parsing.
+8. Make artifacts savable, comparable, and rerunnable as files.
+
+The following sections elaborate these cross-cutting principles from the viewpoints of data design, conversion quality, distribution, UI, CLI, and individual products.
+
+### Basic Philosophy of Main Applications
+
+Main applications emphasize the following philosophy.
+
+- Process input files on the user's machine
+- Complete processing without sending files to a server
+- Keep Web UI applications distributable as Single-file Web Apps
+- Extract as much semantic structure as practical from existing files
+- Prefer reusable structured output over perfect visual reproduction
+- Provide representations that both AI agents and humans can verify
+- Do not hide unconvertible content or lost information
+- Keep implementation small, understandable, and maintainable
+- Implement core processing from scratch where practical
+- Add dependencies only when the user value and maintenance reason are clear
+- Respect both automation-friendly CLI usage and human-checkable UI usage
+
+The value of a main application is not universality. It is the ability to reliably run a specific conversion, extraction, or inspection workflow locally.
+
+### Common Principles for Main Applications
+
+Main applications use the following principles as defaults.
+
+- Use Node.js as the basic runtime
+- Use `lht-cmn` Web Components when a Web UI exists
+- Distribute Web UI applications as Single-file Web Apps
+- Do not require server communication for core functionality
+- Accept input from local files, CLI arguments, or standard text/JSON representations
+- Generate output as files that are easy to pass to other tools, such as Markdown, JSON, XML, SVG, XLSX, or ZIP
+- Build UI flow around load, preview, diagnostics, and export
+- Make CLI usable for batch processing, tests, and AI agent workflows
+- Make major artifacts savable as files
+- Treat warning, diagnostics, and summary as structured data where possible
+- State conversion limitations and unsupported areas clearly
+- Try to obtain the same output from the same input and same settings
+
+Main applications keep the user flow short: load, verify, export, and pass to another tool or AI.
+
+### Scratch Implementation and Dependency Principles
+
+Main applications implement core processing from scratch where practical.
+
+This does not mean that external libraries must never be used. In cases such as `mikuscore`, third-party libraries may be necessary because of domain complexity or the need to connect with existing assets.
+
+External libraries are also appropriate when specification compliance is too large or risky for a small tool, when implementing the behavior ourselves would create security risk, or when integration with an existing ecosystem is the main user value. Examples include complex media rendering, archive or cryptographic correctness, format parsing whose edge cases are security-sensitive, and domain-specific engines maintained by a broader ecosystem.
+
+However, the central conversion policy, data model, diagnostics, output assembly, and AI-facing view generation should remain under our control as much as possible.
+
+This principle appears in decisions such as the following.
+
+- Do not delegate the meaning of conversion entirely to an external library
+- Read and write the necessary parts of file formats ourselves where practical
+- Even when ZIP input/output is needed, avoid heavy general-purpose libraries if the use case is limited
+- Even when Excel input/output is needed, avoid handing the whole process to large libraries such as Apache POI; handle the required workbook structure on the miku side
+- Implement XLSX, XML, SVG, Markdown, JSON, and similar generation with a clear scope limited to the purpose
+- Use third-party libraries to realistically reduce implementation burden or compatibility risk, not to hide general processing
+- Place miku-series data models and diagnostics around adopted libraries
+- Be cautious about adopting dependencies when they make output or behavior opaque
+
+Even when `mikuproject` handles ZIP or XLSX-like artifacts, the core assembly should remain understandable. Even for Excel input/output, processing should not be handed wholesale to comprehensive libraries such as Apache POI; the required workbook structure should be handled on the miku side. Even when `mikuscore` needs third-party libraries around music formats or rendering, the miku-side value should remain in format bridging, diagnostics, normalization, and handoff to AI workflows.
+
+The point of reducing dependencies is not simply to reduce package count. It is to keep the meaning, constraints, and failure modes of processing understandable and explainable to users and AI agents.
+
+### Data Design Principles
+
+Main applications emphasize internal and output data design.
+
+In particular, they prioritize the following ideas.
+
+- Place a canonical format or semantic base for each target domain
+- Treat surrounding formats as views derived from that canonical format
+- Separate human-facing output and AI-facing output when useful
+- Make JSON easy for AI and programs to handle
+- Use Markdown as context that humans can read and AI can also consume
+- Treat SVG, XLSX, ZIP, and similar formats as artifacts or reports
+- Expose warnings and loss that occur during conversion as diagnostics
+
+Data design prefers meaningful structure, diffability, reuse, and reimportability over visual reproduction.
+
+### Canonical Source, Primary Output, and Derived View Principles
+
+Main applications declare what they treat as the canonical source for each target domain and design around it.
+
+The canonical source is the semantic center that the application must preserve. In extraction tools, it is often useful to call the original file or data being extracted the canonical input. The primary output is the artifact the user mainly wants from the tool, such as Markdown, JSON, XML, SVG, XLSX, or ZIP. Derived views are additional surfaces generated from the canonical source or from the primary output for inspection, handoff, reimport, or reporting.
+
+Input/output, internal models, UI, CLI, AI-facing views, and report outputs are positioned to preserve the canonical source and transfer its meaning to other uses.
+
+Examples:
+
+- `mikuscore` treats MusicXML as the semantic anchor
+- `mikuproject` treats MS Project XML as the semantic base and uses `ProjectModel` internally
+- `miku-xlsx2md` treats the Excel workbook as the canonical input, and Markdown as the primary extracted representation for design-document structure
+- `miku-docx2md` treats the Word document as the canonical input, and Markdown as the primary extracted representation for document structure
+
+Use-specific views are placed around the canonical source.
+
+- Markdown, SVG, and XLSX reports for humans
+- Projections, draft views, task edit views, and phase detail views for AI
+- Workbook JSON, patch JSON, summaries, and diagnostics for reimport and comparison
+- ZIP bundles for distribution and handoff
+
+The important point is not to confuse canonical source, canonical input, primary output, and derived views. Primary output is allowed to be the main user-visible result without becoming the canonical source. Derived views are useful work surfaces, but they should be generated only within the range that does not break the semantic center. When reimport is possible, the affected range must be explicit.
+
+When a design decision is unclear, prefer the option that best preserves the meaning of the canonical source. Appearance, convenient editing surfaces, and AI handoff are important, but they should not take priority when they would lose the meaning of the canonical source.
+
+### Product Boundary Principles
+
+Main applications clarify what the tool does and, just as importantly, what it does not do.
+
+Examples:
+
+- `mikuscore` is a score converter / handoff tool, not a powerful notation editor
+- `miku-abc-player` is a playback-first / preview-first ABC-centered app, not a broad score conversion workbench
+- `miku-xlsx2md` aims to turn design-document structure into Markdown, not to reproduce Excel appearance
+- `mikuproject` bridges MS Project XML with WBS / AI / reports, and does not replace every project-management feature
+
+This boundary is reflected in README, docs, UI copy, and CLI help. Even if a capability exists internally, it should not be placed too prominently if it is not central to the product.
+
+### Conversion Quality Principles
+
+Main applications do not evaluate conversion quality only by whether the result looks similar.
+
+The important axes are as follows.
+
+- Do not drift unnecessarily away from the semantic center or canonical format
+- Preserve existing information first, and do not over-infer ambiguous information
+- When full fidelity is difficult, make loss, fallback, and unsupported areas visible as diagnostics
+- Give conversion results traceability, leaving clues back to the original file / sheet / range / anchor / node
+- In round trips, prioritize semantic and structural stability over whitespace identity
+- For conversions that can round-trip, include round-trip cases in tests and verify that the original semantic structure can be recovered
+- Keep conversion bounded and local, avoiding unrelated global rewrites
+- Treat failing operations atomically so they do not leave partially broken state
+
+Quality assurance uses unit tests, golden tests, fixtures, and regression cases to fix quality while increasing known edge patterns.
+
+### Display Value and Internal Value Principles
+
+Main applications distinguish between values humans see and values kept internally.
+
+For conversions such as `miku-xlsx2md`, standard output is biased toward Excel display values. This is because, when humans share existing file contents with AI, it is important that the values seen on screen and the values in Markdown are close.
+
+At the same time, raw values, resolution paths, fallback reasons, and unsupported reasons are kept as internal information or diagnostics when needed.
+
+This principle satisfies both of the following.
+
+- Humans and AI can more easily share the same visible interpretation
+- Implementers and automation tools can trace the origin of values and conversion decisions
+
+### Small Impact Radius Principles
+
+Main applications separate the impact radius of import, edit, and AI integration.
+
+Representative categories are as follows.
+
+- `replace`: replace the whole state
+- `merge`: reflect only limited columns or limited regions into the existing state
+- `patch`: validate and apply only local differences returned by AI or similar tools
+
+When safely modifying existing data, local projections and patches are preferred over whole replacement. Inputs passed to AI are also cut down into necessary overviews, task edits, phase details, and similar small pieces rather than whole bundles.
+
+This design keeps AI context small, makes returned changes easier to validate, and makes diffs easier for humans to review.
+
+### Artifact Pipeline for Generative AI Interactive Tools
+
+For miku software such as `mikuproject` and `mikuscore`, which have generative AI interaction or AI agent workflows, AI integration is not treated merely as a convenient UI feature. It is designed as a pipeline with intermediate artifacts.
+
+Inputs passed to AI, outputs returned by AI, validation results, applied state, and diffs are each made into units that can be saved, inspected, and rerun.
+
+A representative flow is as follows.
+
+- Output an AI-facing projection from the target state
+- AI returns structured JSON such as a draft, edit view, or patch
+- Validate the returned JSON's kind, schema, reference IDs, and impact radius
+- Apply only what passes validation to the state
+- Diff the applied state against the original state
+- Expand into human-facing artifacts such as XML, XLSX, Markdown, or SVG when needed
+
+This property does not appear with the same intensity in every miku main application. In tools whose main purpose is extraction or conversion, such as `miku-xlsx2md` and `miku-docx2md`, AI-readable output and diagnostics are central. In tools that edit existing state through interaction with AI, projection, patch, validate, apply, and diff move closer to the center of the product workflow.
+
+This pipeline may fit CLI and Agent Skills better than Web UI. When intermediate artifacts are JSON and staged validation or diff review is important, CLI and Agent Skills should be treated as regular paths rather than making the UI too heavy.
+
+Web UI is useful as a lightweight entry point for creating projections, checking import results, previewing, and downloading. The center of AI editing, however, is the ability to handle saved projections, patches, diagnostics, and diffs in order.
+
+## Recommended Conventions
+
+The following sections turn the cross-cutting principles into practical repository operations. They do not force every product into exactly the same shape, but new implementations and cleanups should first consider this shape as the default.
+
+### Distribution and Build Principles
+
+For main applications with a Web UI, split development-time source files from distribution-time single-file artifacts.
+
+Distribution artifacts should generally be designed as Single-file Web Apps. They should open in a Web browser, require no additional installation or server startup, and allow core functionality to be used offline.
+
+For Web distribution, the basic structure is to place `index.html` as a landing page and launch the actual main HTML from it. The main HTML is generated as a product-named single-file app, such as `miku-xlsx2md.html`, `miku-docx2md.html`, `mikuproject.html`, or `mikuscore.html`.
+
+The landing page generally displays the build date. Links from the landing page to the main HTML include URL parameters such as the build date so old single-file apps are less likely to be opened from the browser cache.
+
+The basic shape is as follows.
+
+- Place TypeScript source under `src/`
+- Edit source template HTML
+- Treat `index.html` as the landing page
+- Display the build date on the landing page
+- Generate the main HTML as a product-named single-file app
+- Add cache-busting parameters to URLs from the landing page to the main HTML
+- Bundle CSS / JS / required assets into a single HTML file during build
+- Do not directly edit generated single HTML artifacts
+- Make generated artifacts work as offline runtime
+- Keep required JS / CSS local or vendored
+- Make builds locally deterministic
+
+This shape balances development-time maintainability with ease of distribution for users.
+
+### `workplace/` Directory Principles
+
+The repository root of a main application contains a `workplace/` directory for local work.
+
+`workplace/` is a place for generated artifacts, temporary files, local verification data, local run results, and similar files. The directory itself is kept with `.gitkeep`, but its contents are generally outside git management.
+
+The expected repository shape is to keep `workplace/.gitkeep` under version control and ignore normal contents below `workplace/` through `.gitignore`. If a product needs a checked-in sample or fixture, it should be placed under an explicit fixture or docs directory rather than hidden inside `workplace/`.
+
+`workplace/` is not included as input or an inspection target for standard test, lint, or release checks. However, it may be used at the end of a build as an output destination for artifacts generated by the current product itself. This directory may contain sibling repository clones, real documents, verification outputs, and similar files; if standard commands pick them up, quality checks for the current product become mixed with the state of the local verification environment.
+
+The name is standardized as `workplace`. If past text or typos use `workspace`, those references should be moved to `workplace` over time.
+
+### Role Split Between README and docs
+
+`README.md` is an entry document for ordinary users.
+
+README should mainly contain the following.
+
+- What the software does
+- Representative usage
+- Installation or startup method
+- Major inputs and outputs
+- Major options
+- Links to additional information
+
+Developer details, design memos, internal structure, implementation specifications, test policy, and future notes are stored as Markdown under `docs/`.
+
+README may link to `docs/`, but its body should stay as the first explanation users read. Do not make README too heavy with internal design or developer details.
+
+### Managing External-Publishing Documents Under `docs/articles`
+
+Main applications may place drafts and outlines for external publishing under `docs/articles/`, separate from user-facing README and developer-facing docs.
+
+`docs/articles/` is not the product specification itself. It is a working area for organizing product introductions, development experience, implementation knowledge, and problem awareness for external media. Original manuscripts, article notes, outlines, and drafts for published articles are kept as Markdown.
+
+The basic shape is as follows.
+
+- Separate directories by medium
+- Use one Markdown file per article by default
+- Keep pre-publication thinking as Markdown
+- Keep original manuscripts or supplementary notes for published articles when useful
+- Provide article templates that organize topic, intended reader, constraints, and related links
+- Use filenames that expose date and topic, such as `YYYYMMDD-topic-outline.md`, `YYYYMMDD-topic-draft.md`, or `topic-memo.md`
+
+The roles of media-specific directories are also separated.
+
+- `docs/articles/qiita/` contains articles for developers or technically interested readers, such as technical background, implementation policy, usage, constraints, and development logs
+- `docs/articles/note/` contains articles that emphasize narrative flow, such as background, problem awareness, experience, and thinking
+
+This separation keeps technical articles and experience articles from mixing too much, even when they discuss the same subject. For example, feature introductions and Markdown output specifications for `miku-xlsx2md` can be organized for Qiita, while the experience of implementing and documenting with generative AI can be organized for Note.
+
+`docs/articles/` is not a replacement for README or specifications. Constraints, implementation knowledge, bugs, and improvement ideas found while writing articles are returned to README, formal docs, TODO, or test fixtures as needed. Article writing is external publishing, but it is also treated as a review workflow for making the product explainable.
+
+### Task Management With `TODO.md`
+
+In many cases, in-progress tasks, improvement ideas, unresolved topics, and next actions are recorded in `TODO.md`.
+
+`TODO.md` is not so much a replacement for an issue tracker as it is a lightweight work memo for keeping context inside the repository.
+
+More detailed design memos or specifications can be split into `docs/` as needed. `TODO.md` should contain short entry points to those files and lists of unfinished items.
+
+### Exceptions and Derived Relationships
+
+#### Exception for Derived Apps With Upstream
+
+miku main applications generally do not have another main application as upstream.
+
+`miku-abc-player` is a subset made by picking up ABC-related functionality from `mikuscore`. Its use of `mikuscore` as upstream is a special circumstance caused by this subset extraction. `mikuscore` itself also refers to another upstream in some parts, but this is treated as an exception among exceptions. Product-specific details for `miku-abc-player` are gathered in the product-specific notes below.
+
+Such upstream references and derived relationships are not the standard shape for main applications as a whole.
+
+Derived applications that exceptionally have an upstream emphasize the following.
+
+- Keep future intake from upstream easy
+- Prefer thin wrappers, thin adapters, and entry-point level customization
+- Narrow feature scope through UI surface, input mode, and product messaging
+- Do not delete upstream-derived code broadly only because the current UI does not use it
+- Prefer ease of upstream sync over visual local cleanup
+- Allow downstream-specific divergence only when the practical benefit is clear
+
+This policy permits a little extra code only when an upstream exists. Normal main applications do not assume upstream synchronization and instead prefer a small, understandable structure aligned with the application's own purpose.
+
+### Core and Thin Entry Principles
+
+Main applications push processing called from UI, CLI, tests, and Agent Skills toward the same core as much as possible.
+
+CLI and Web UI are designed as thin entry points that call a shared core, not as separate implementations.
+
+This principle appears in forms such as the following.
+
+- Separate the body of conversion, inspection, normalization, import, and export from UI
+- Implement CLI as a thin wrapper around core
+- Let Web UI display core results and handle file selection and saving
+- Write tests not only for UI but also for core APIs
+- Provide small public entry points that Agent Skills and external automation can call easily
+- Use the same defaults, diagnostics, and output policy in Web UI and CLI
+
+When adding a thin layer to publish a CLI, keep that layer responsible for option parsing, file I/O, stdout / stderr, and exit codes. Do not duplicate conversion meaning or business logic on the CLI side.
+
+### Public API Surface Principles
+
+Main applications provide a UI-independent public API surface when needed.
+
+The public API surface does not expose everything inside the application. It gathers operations needed by Agent Skills, CLI, tests, MCP, or future integrations as small, stable entry points.
+
+The public API surface emphasizes the following.
+
+- Provide format-aware import / export entry points
+- Put verification operations such as validate, summarize, diff, and apply on the core side
+- Make AI-facing specs and projections stably retrievable
+- Do not depend on UI DOM state
+- Structure input, output, and diagnostics
+- Do not turn the detailed internal module graph into an external contract
+
+This policy lets features built for Web UI be used with the same meaning from CLI and Agent Skills.
+
+### Runtime Difference Adapter Principles
+
+Main applications may run in both Web browsers and Node.js CLI.
+
+In that case, runtime-specific parts such as DOM, XML parser, file, Blob, download, encoding, and ZIP saving should not be scattered directly through core logic.
+
+Runtime differences are contained in adapters or loaders as follows.
+
+- Use browser standard APIs on Web
+- Inject required APIs through loaders or adapters in Node.js
+- Do not hard-code XML DOM or serializer to a global
+- Treat file I/O and download as separate responsibilities
+- Let core pass around bytes, text, document objects, and structured data
+
+This separation makes it easier to use the same core in both Single-file Web Apps and CLI.
+
+### Diagnostics and Summary Principles
+
+Main applications treat diagnostics and summaries as formal output surfaces, not as byproducts.
+
+Diagnostics are not mere error messages. They are information for users, developers, and AI agents to trace conversion decisions, fallback, unsupported areas, loss, warnings, suspicious input, and output constraints.
+
+Summaries are used to quickly understand the whole input or conversion result.
+
+The principles are as follows.
+
+- Diagnostics have code / message / severity / source location where practical
+- Source location is kept in a form suited to the target domain, such as file / sheet / range / anchor / node / command
+- CLI can output diagnostics to stderr or as structured diagnostics
+- Web UI provides a place to inspect diagnostics and summaries
+- AI-facing workflows use diagnostics as material for patch validation and diff decisions
+- Unsupported information is not silently discarded; it is kept as trace or metadata when useful
+- To keep normal primary output readable, detailed trace is emitted in debug / diagnostics mode
+- Debug trace is not a replacement for the body; it is supporting information for tracing conversion decisions and lost information
+
+This makes it possible to judge not only whether conversion succeeded, but also how trustworthy it is and where constraints remain.
+
+### Option and Mode Principles
+
+Main applications avoid adding too many options and modes.
+
+However, important trade-offs that users must choose because of the target conversion should be exposed as modes.
+
+Examples:
+
+- display / raw / both
+- plain / github
+- balanced / border / planner-aware
+- replace / merge / patch
+- diagnostics text / json
+
+When adding a mode, satisfy the following.
+
+- It is explainable what the mode switches
+- The meaning is aligned between UI and CLI
+- The default is appropriate for normal use
+- The mode can be traced from output filenames or summaries
+- Tests fix representative cases for each mode
+
+Modes are placed for users to choose conversion policy, not to expose internal convenience.
+
+### UI Design Principles
+
+Main applications with a Web UI use `lht-cmn` Web Components to keep consistency across the series.
+
+UI is centered on the actual work surface rather than an explanatory landing page.
+
+The basic UI flow is as follows.
+
+- Load an input file
+- Run conversion or analysis
+- Inspect results, summaries, and diagnostics
+- Save required artifacts
+
+The UI clearly treats processing as local so users do not mistakenly think their files are being sent to an external server.
+
+Even when a Web UI exists, the center of the main application is not the UI itself. It is the processing that reads local files, structures them, and outputs artifacts. Avoid states whose meaning exists only in the UI.
+
+- Do not create important information that exists only in UI state
+- Do not trap core logic inside DOM event handlers
+- Make the same processing callable from CLI and tests
+- Use UI copy to clarify product boundaries
+- Separate the landing page as an entry point from the main HTML as the work surface
+
+For this reason, miku main applications prefer reliable operations on real files and verifiable outputs over visual luxury.
+
+### CLI Design Principles
+
+Main applications with a CLI consider both batch workflows that replace manual work and invocation from AI agents.
+
+CLI emphasizes the following.
+
+- Keep commands and options few
+- Make input and output files explicit
+- Output artifacts to stdout or specified files
+- Treat warnings and diagnostics as stderr or structured diagnostics
+- For long-running processing or processing where progress matters, make progress and timing output available through `--verbose` or similar options
+- Make success and failure judgeable by exit code
+- Make the same operation reproducible in tests and CI
+
+CLI is not a helper for UI. It is a formal entry point for AI agent workflows and automation.
+
+As in `miku-indexgen --verbose`, target, output destination, current scan location, discovered files, and timing breakdowns are emitted incrementally when useful, rather than only summarized at the end. This lets humans and AI agents notice stalls, incorrect target ranges, or unexpected input earlier during processing.
+
+This kind of progress / timing output is not confused with primary output or structured diagnostics. Artifacts remain stable through file or stdout contracts; incremental logs use an easy-to-identify prefix such as `verbose:`, and representative lines are fixed in tests.
+
+## Common Patterns Observed Across the Series
+
+The following sections are not specifications for individual products. They organize tendencies observed across existing miku repositories. They are not as strong as cross-cutting principles, but new main applications should first consider whether the same shape can be reproduced.
+
+### AI and Automation as Users
+
+AI agents and programs are treated as first-class users.
+
+This is explicit in `miku-indexgen`: it is described as a tool for AI agents and programs to get an overview of available files before reading full file contents.
+
+Across the series, this appears in forms such as the following.
+
+- JSON views for AI handoff
+- Markdown output as model-readable context
+- Diagnostics and summaries for downstream tools
+- `*-skills` repositories that teach AI agents how to use tools
+- CLI surfaces that allow scripted use without depending on browser UI
+
+The design preference is not merely to produce human-readable output. It is to keep structures simple enough for other programs and agents to use without brittle parsing.
+
+### Local-first and Privacy
+
+Many tools run in the browser or as local CLI.
+
+This is important because input files often contain private or business-sensitive data.
+
+Representative inputs include the following.
+
+- Excel workbook
+- Word document
+- project plan
+- score file
+- source repository
+
+Across the series, core functionality does not assume hosted backends or server communication. Single-file Web Apps and local CLI keep processing complete inside the local environment by default.
+
+### Prefer Conversion Over Full Editing
+
+These tools usually do not try to replace full-featured specialist applications.
+
+Examples:
+
+- `mikuscore` is a score conversion and inspection tool, not a full engraving editor.
+- `miku-xlsx2md` extracts meaningful workbook content as Markdown rather than perfectly reproducing Excel appearance.
+- `miku-docx2md` is not a Word layout engine; it extracts document structure as Markdown.
+- `mikuproject` bridges MS Project XML, WBS reports, AI JSON, and visual output, but does not replace every project-management feature.
+
+The repeated pattern is not to promise complete round-trip fidelity. It is to preserve or expose meaningful structure and make information lost during conversion visible.
+
+### Canonical Format, Primary Output, and Companion Format
+
+Some projects choose a canonical format or central format and place companion formats around it.
+
+Examples:
+
+- `miku-indexgen`: flat `index.json` is canonical. `index.md` is optional companion output.
+- `mikuscore`: MusicXML is the central interchange format.
+- `mikuproject`: MS Project XML is the semantic base. AI JSON, workbook JSON, XLSX, Markdown, SVG, and Mermaid are surrounding views.
+- `miku-xlsx2md`: the Excel workbook is the canonical input. Markdown is the primary extracted text representation. Assets and summaries are companions.
+- `miku-docx2md`: the Word document is the canonical input. Markdown is the primary extracted text representation. Assets and summaries are companions.
+
+This design supports the formats needed for human verification and tool exchange while keeping the core model simple.
+
+Artifacts are separated by role.
+
+- primary output: the conversion result the user mainly wants. Examples: Markdown, XML, XLSX, SVG.
+- companion summary: a summary for quickly inspecting the input or conversion result.
+- sidecar asset: supporting files referenced by the primary output, such as images, attachments, or split outputs.
+- manifest: a machine-readable index of sidecar asset paths, media types, source traces, location information, and similar data.
+- debug / diagnostic trace: fallback, unsupported, and loss tracking information that is too detailed for normal output.
+
+When sidecar assets are emitted, a manifest is attached where practical. This does more than save files; it helps downstream tools and AI agents reinterpret which input element each asset came from and how it is referenced from primary output.
+
+### Small Tool Shape
+
+This document organizes shared design information across the miku software series, not development notes specific to an individual repository.
+
+Across the series, tools are kept small and direct.
+
+- Keep the whole project small enough to understand
+- Minimize dependencies
+- Prefer machine readability over human-facing decoration
+- Prefer structures that make downstream automation simple
+- Use straightforward input/output through CLI arguments and generated files
+
+Implementation shape differs by project, but the basic product shape is small, readable, and easy for other tools to call.
+
+### Browser and CLI Combination
+
+Several projects combine a browser UI with a CLI path.
+
+Excluding Java versions and Agent Skills versions, main applications use Node.js as the basic runtime. Even when a Web UI exists, build, CLI, tests, and distribution artifact generation are centered on the Node.js toolchain.
+
+Web UI uses `lht-cmn` Web Components to keep a common look and operation feel across the series. App-specific UI is added minimally on top.
+
+Browser UI is suited for the following.
+
+- Interactive local conversion
+- Preview
+- Human inspection
+- Download of generated artifacts
+
+CLI is suited for the following.
+
+- Batch conversion
+- Tests
+- Agent workflows
+- Integration with other tools
+- Reproducible command-line use
+
+This combination allows the same core functionality to be used for both human work and automated workflows.
+
+### Naming Pattern
+
+The `miku` prefix indicates this series of small tools.
+
+Names include both hyphenated names such as `miku-indexgen` and `miku-xlsx2md`, and non-hyphenated names that start with `miku`, such as `mikuscore` and `mikuproject`.
+
+The `-java` suffix indicates a Java straight-conversion version, and the `-skills` suffix indicates an Agent Skills version of the original product.
+
+Many repositories also have the `mikuku` topic, which appears to identify the broader software family.
+
+### License Choice
+
+`miku` repositories consistently use Apache License 2.0.
+
+This is positioned as a practical default for small reusable tools and companion libraries.
+
+## Observed Main-Application Character
+
+In addition to technology choices, miku main applications share common habits in how they are built. This section names tendencies observed from existing products so they can be reused in future specification work.
+
+### Center Artifacts
+
+Main applications are designed around savable artifacts rather than screen state or temporary operation results.
+
+Artifacts should be usable later in the same way by users, CLI, tests, AI agents, and other tools.
+
+For this reason, the following are emphasized.
+
+- Major results can be output as files
+- Output filenames and formats are predictable
+- Results seen in UI and results obtained by CLI do not diverge in meaning
+- Summaries, diagnostics, and manifests inspected in UI and saved by CLI come from the same core
+- Generated files can be placed under work areas such as `workplace/`
+- Input, mode, diagnostics, and summary can be traced from artifacts
+
+UI is an operation surface for producing artifacts, and CLI is an entry point for generating artifacts automatically. Both are aligned as different entry points to the same processing result.
+
+### Inspect Before Handoff
+
+Main applications do not treat conversion as the end. They emphasize workflows where humans or AI inspect conversion results before passing them onward.
+
+For this reason, output may include not only a single final file but also summaries, diagnostics, previews, and companion outputs for inspection.
+
+This idea appears as follows.
+
+- Do not simply push conversion results directly into external tools
+- Provide human-judgeable Markdown, SVG, XLSX reports, and similar outputs
+- Pass input structure and constraints to AI as summaries before AI handles details
+- Pass AI-returned changes through validate, diff, and patch
+- In areas that can round-trip, verify in tests whether they can be converted back
+
+This does not mean that AI or automation is not trusted. The design places inspectable structure before and after automation.
+
+### Keep Distance to the Canonical Source Short
+
+Main applications avoid drifting too far from the canonical source even when adding convenient views or editing surfaces.
+
+AI-facing JSON, Markdown, reports, previews, and patches are surfaces for easier work. They are not the canonical source itself.
+
+For this reason, avoid the following.
+
+- Editing only a derived view and leaving the path back to the canonical source unclear
+- Over-shaping data for AI convenience and losing constraints from the original data
+- Distorting the canonical format or internal model to prioritize UI appearance
+- Over-completing input-side meaning for the convenience of conversion results
+
+What is needed is to create human- and AI-friendly surfaces while separating what came from the canonical source from what is derived, inferred, or auxiliary.
+
+### Keep Input and Output Straightforward
+
+Main applications avoid relying too much on complex project state or implicit work environments. They keep the relationship between input files and output files straightforward.
+
+Typically, they prefer the following shape.
+
+- Explicit input file or input directory
+- Explicit output directory when needed
+- Explainable generated file types
+- Clear meaning for stdout, stderr, and exit code
+- Rerunnable with local files only
+- Same command reproducible in CI and local tests
+
+This straightforwardness applies not only to CLI but also to Web UI. In Web UI, the flow should remain short: load, inspect, save.
+
+### Keep Intermediate Representations Small
+
+Main applications avoid making internal models or AI-facing projections into huge models that fully reproduce the entire target domain.
+
+They provide intermediate representations for extracting necessary meaning, but those representations are not full clones of the target domain. They are limited to the range the product needs.
+
+This policy preserves the following.
+
+- Implementers can understand the whole
+- JSON passed to AI agents does not become overly large
+- Patch and diff impact radius can be limited
+- Unsupported information is not forced into the internal model
+- Added features do not unnecessarily fatten the canonical source or core model
+
+Even when the target domain is complex, the miku-side intermediate representation is designed according to the range the product takes responsibility for.
+
+### Include Failure in the Specification
+
+Main applications treat failures and partial support as part of the specification, not only successful output.
+
+File conversion inevitably encounters inputs that cannot be fully supported. In such cases, the design should not silently discard information, approximate vaguely, or warn only in UI.
+
+The principles are as follows.
+
+- Emit unsupported as unsupported
+- Preserve fallback reasons when fallback occurs
+- Show loss when loss exists
+- Treat suspicious input as warning
+- Attach source location when possible
+- Keep normal output at a granularity that does not obstruct reading, and increase trace in debug mode
+- Fix not only success cases but also failures, warnings, and partial support in tests
+
+By structuring failure information, humans can judge more easily and AI agents can choose next operations more safely.
+
+### Return Real-Data Observations to Fixtures and Specifications
+
+Main applications emphasize returning differences and bugs found in local real data to fixtures, tests, docs, and TODO, rather than ending with one-off fixes.
+
+Real data often contains private or business-sensitive content, so it may not be placed directly in shared fixtures. Even then, the observed feature should be reduced into a minimal `.xlsx`, `.docx`, XML, JSON, or similar fixture and brought into tests in a reproducible form.
+
+This policy appears as follows.
+
+- Organize focus areas using real data outside git management
+- Do not expose real-data filenames or contents too much in public docs
+- Reduce found problems into minimal fixtures
+- Do not leave absolute paths, creators, modifiers, creation timestamps, external links, or unnecessary embedded information in fixtures
+- Connect fixtures with test names, specification topics, and the symptoms they mainly verify
+- Return design decisions learned from real-data observation to README, docs, and TODO
+
+This flow makes quality checks shareable and reproducible while still allowing tools to be local-first and handle private data.
+
+### Preserve Reproducibility Down to Output Bytes
+
+Main applications emphasize reproducibility of saved artifact bytes where practical, not only appearance or strings.
+
+Especially when generating ZIP, XLSX, Markdown, SVG, JSON, and similar outputs, the priority is to obtain artifacts that are easy to compare from the same input and same settings each time.
+
+This policy appears in decisions such as the following.
+
+- Fix metadata unrelated to content, such as ZIP entry timestamps
+- Make output filenames predictable from input name and mode
+- Avoid automatically increasing mode suffixes too much; put necessary mode information in summaries or metadata
+- Explicitly handle save-time settings such as encoding, BOM, line endings, and escaping
+- Share the same save-processing layer across browser UI, CLI, and Markdown inside ZIP
+- Treat runtime-unavailable encoding or save features as constraints rather than silently approximating them
+
+Reproducibility is not only for easier testing. It lets AI agents and scripts diff artifacts, judge changes, and reprocess only what is necessary.
+
+### Stage Fallback
+
+When main applications handle complex input formats, they do not aim for complete compatibility from the start. They use the most reliable information first and stage fallback when something cannot be resolved.
+
+Representative ideas are as follows.
+
+- Prefer saved confirmed values or canonical data inside input files when available
+- Limit in-house parsers / evaluators to ranges that need missing-value handling or completion
+- Keep older resolvers or compatibility paths as safety nets in some cases
+- When resolution fails, preserve the original formula, raw metadata, and unsupported reason
+- Make fallback events traceable through diagnostics or summaries
+
+This design avoids expanding into a complete reimplementation of the target format while reducing practical information loss.
+
+## Product-Specific Notes
+
+This section records how cross-cutting principles appear in individual products. These notes are not the formal specifications of each product; they are memos for organizing design boundaries.
+
+### Notes Specific to `mikuscore`
+
+`mikuscore` is a score converter / handoff tool that uses MusicXML as its semantic anchor. It is positioned as a main application for handing score data among notation software, interchange formats, AI generation workflows, and human preview.
+
+For this kind of tool, the following boundaries are especially important.
+
+- Treat MusicXML as the central interchange format, and do not drift conversion or generation meaning away from the MusicXML structure unnecessarily
+- Treat ABC, MEI, MuseScore, MIDI, SVG, PNG, AI JSON, and similar formats as import / export / preview / handoff views around MusicXML
+- Do not aim to be a powerful notation editor or engraving editor; make conversion, inspection, normalization, and verification before and after specialist editors the main role
+- Place preservation of existing information first, and do not over-infer ambiguous durations, voices, ties, accidentals, ornaments, or layout information
+- For inputs where full fidelity is difficult, keep loss, fallback, unsupported areas, and source locations as diagnostics
+- Prefer consistency among MusicXML usable by downstream tools, structured views readable by AI, and preview checkable by humans over perfect musical visual reproduction
+- For AI score generation or editing, use structured intermediate artifacts such as measure details, AI JSON, diagnostics, and diffs rather than exchanging the whole score as free text
+- Treat UI as an entry point for import, preview, diagnostics, export, and AI handoff, not as a score editing screen
+- Treat CLI and Agent Skills as formal entry points for score conversion, validation, AI workflows, and regression tests
+- Use third-party libraries to reduce the realistic burden of score rendering and existing-format connections, while placing miku-side value in conversion policy, diagnostics, normalization, and handoff models
+
+What matters for `mikuscore` is not becoming a substitute for notation software. It is to keep MusicXML at the center, pass score data to other representations without breaking it, and let humans and AI agents verify the same conversion result.
+
+Therefore, feature priority is judged not by whether more editing can be done on screen, but by whether MusicXML-first conversion quality, diagnostics, round-trip stability, AI handoff, and external tool integration become stronger. Strengthening saved intermediate artifacts, conversion diffs, fixtures, golden tests, and format coverage is more `mikuscore`-like than adding deep editing UI.
+
+### Notes Specific to `miku-abc-player`
+
+`miku-abc-player` is a special main application in the miku series. It is a playback-first and preview-first ABC-centered app derived from `mikuscore`, rather than a fully independent application designed around its own separate conversion engine.
+
+For this kind of tool, the following boundaries are especially important.
+
+- Treat ABC preview and playback as the product center, not broad score conversion or deep notation editing
+- Accept supported non-ABC imports when they are opened into the ABC-centered workflow through inherited `mikuscore` / MusicXML-compatible processing
+- Keep inherited edit and export surfaces secondary, even when they remain available because preserving them reduces implementation or sync cost
+- Reuse `mikuscore` project structure, build model, UI conventions, ABC-related logic, playback logic, and lightweight edit / export surfaces where doing so keeps upstream intake practical
+- Prefer thin adapters, profile-like configuration, entry-point customization, UI visibility controls, and product wording over downstream rewrites of shared conversion behavior
+- Do not delete upstream-derived code broadly only because the current `abc-player` UI does not expose all of it
+- Treat changes to ABC parsing, ABC / MusicXML round-trip behavior, diagnostics, playback, and shared UI/runtime assumptions as upstream-sensitive changes
+- When local divergence becomes substantial, prefer asking for a general `mikuscore` profile / option hook rather than adding `abc-player`-specific fork logic
+- Keep user-facing messaging centered on load, preview, play, and small correction workflows
+
+What matters for `miku-abc-player` is not becoming a smaller clone of all `mikuscore` features. It is to provide a fast local ABC playback and preview entry point while staying close enough to `mikuscore` that improvements to shared score handling can continue to flow into the derived app.
+
+Therefore, feature priority is judged by whether the app becomes better at opening ABC, showing it, playing it, and safely inheriting upstream score-processing improvements. Preserving an easy upstream sync path can be more `miku-abc-player`-like than aggressively removing unused inherited surfaces for local neatness.
+
+### Notes Specific to `mikuproject`
+
+`mikuproject` is a project bridge tool that connects `MS Project XML` as its semantic base with WBS, generative AI, human-facing reports, and visual outputs. For this kind of tool, the following boundaries are especially important.
+
+- Treat `MS Project XML` as a near-canonical semantic base, and use `ProjectModel` internally as a neutral representation
+- Treat `.xlsx` and workbook JSON as surrounding representations for verification, visualization, and limited editing, not as replacement canonical sources for `MS Project XML`
+- Treat `WBS XLSX`, `WBS Markdown`, `SVG`, and `Mermaid` as report / presentation outputs for humans, and do not confuse them with import paths
+- Treat generative-AI-facing JSON as an editing representation separate from workbook JSON, and separate its purpose with an extension such as `.editjson` when useful
+- For safe modification of existing WBS, prefer the local edit pipeline `project-overview -> task-edit / phase-detail -> patch_json -> validate -> apply -> diff` over whole replacement
+- Allow `project_draft_view` as an entry point for drafting new plans, but treat it as a different workflow from local modification of existing WBS
+- In import, make `replace / merge / patch` explicit and reject invalid combinations of `format` and `operation`
+- Validate AI-returned patches for referenced tasks, updatable fields, structural changes, dependencies, assignments, and similar points before applying them
+- Use `CLI` and `Agent Skills` as the main path for the AI editing pipeline; treat Web UI as an entry point for loading, projection saving, preview, download, and result inspection
+- Provide small aggregation entry points as needed so the single-file web app, CLI, Agent Skills, and tests can call the same core
+- Contain differences between Web browser and Node.js CLI in adapters for XML DOM, file I/O, download, encoding, and similar areas
+- Align the meaning of derived artifacts from the same `ProjectModel`, such as `WBS XLSX`, `WBS Markdown`, `Daily SVG`, `Weekly SVG`, `Monthly Calendar SVG`, and `Mermaid`
+- Treat `WBS SVG` not as a replacement for `Mermaid`, but as a separate preview / download output whose appearance is easier to control
+- Align interpretation of date bands, business days, holidays, progress bands, and similar display semantics between `WBS XLSX` and `SVG` where practical
+- Treat bundles such as `ALL` ZIP as useful for sharing and inspection, but too heavy for normal AI editing; prefer local projections first
+
+What matters for `mikuproject` is not increasing project-management features for their own sake. It is to hand the same project information among `MS Project XML`, reports, visualization, AI editing, and CLI automation without breaking meaning.
+
+Therefore, feature priority is judged not by whether the product approaches an MS Project replacement, but by whether bridging, inspection, local editing, diff review, and artifact generation become stronger. Strengthening saved state, limited projections, patch validation, and report export is more `mikuproject`-like than adding heavy UI-contained editing features.
+
+### Notes Specific to `miku-xlsx2md`
+
+`miku-xlsx2md` is a design-document conversion tool that extracts Excel `.xlsx` into Markdown. For this kind of tool, the following boundaries are especially important.
+
+- Do not make complete reproduction of Excel screen layout, cell widths, colors, borders, or shape placement the primary goal
+- Treat `.xlsx` as `design document structure extraction -> Markdown`, extracting prose, tables, images, links, formula results, and auxiliary metadata
+- Convert the whole workbook, and do not assume manual sheet-by-sheet copy-and-paste
+- Prefer display values close to what humans see in Excel as the default for Markdown body text
+- Track raw values, formulas, resolution paths, and fallback reasons as internal information or diagnostics rather than in the body text
+- Do not rely only on Excel table definitions for table detection; also use borders, value density, connected components, header-like features, planner / calendar layouts, and similar clues
+- For layout-centered sheets, prefer decomposing into sections, narrative, tables, images, charts, and shapes rather than absorbing the whole sheet into one huge table
+- Do not aim for a fully Excel-compatible formula evaluator; reduce information loss in the order `cached value -> AST evaluator -> legacy resolver -> fallback_formula`
+- Separate rich text modes into `plain`, which drops decoration, and `github`, which moves toward GitHub Markdown plus some HTML
+- Prefer extracting semantic metadata from charts over image reproduction, and treat shapes as source data or SVG assets where practical
+- Bundle Markdown and assets as ZIP, and make image or shape assets referenceable from the body by relative paths
+- Treat save-time byte-level reproducibility, such as ZIP entry timestamp, Markdown encoding, and BOM, as part of the conversion specification
+
+This policy avoids expanding into redrawing Excel as another Excel-like view, and keeps focus on document content, table structure, auxiliary information, and AI handoff.
+
+### Notes Specific to `miku-docx2md`
+
+`miku-docx2md` is a document conversion tool that extracts Word `.docx` into Markdown. For this kind of tool, the following boundaries are especially important.
+
+- Do not make complete reproduction of Word page layout, floating objects, shape positioning, text box placement, or headers / footers the primary goal
+- Treat Markdown as the primary output for reading document structure and body text
+- Track embedded images and other binary content with sidecar assets and manifests rather than fully repositioning them in the body
+- Make unsupported Word elements inspectable through summaries or debug HTML comment traces without polluting normal Markdown body text
+- Preserve image alt text, relationship targets, document positions, and similar data as companion metadata usable by AI and downstream scripts
+
+This policy avoids expanding into reimplementing the `.docx` layout engine, and keeps focus on extracting document content, order, headings, lists, tables, links, and image references into a locally reusable form.

--- a/docs/miku-soft-20-javaapp-design-v20260425.md
+++ b/docs/miku-soft-20-javaapp-design-v20260425.md
@@ -1,0 +1,968 @@
+# Miku Software Java Application Design v20260425
+
+This memo organizes design characteristics commonly expected for Java application versions in the `miku` software series.
+
+The initial versions of the related tools were created by `Mikuku` and Toshiki Iga.
+
+The current contents are based on current miku Java application examples, the main-application design memo, and the straight-conversion guide checked on 2026-04-25.
+
+## Design Summary
+
+The Java application versions in the `miku` software series can be summarized as follows.
+
+> Java CLI / batch / build-tool versions of miku main applications that preserve upstream semantics, remain easy to trace back to the Node.js / TypeScript upstream, and provide local, reproducible artifact generation for automation and build workflows.
+
+What characterizes Java application versions is not a Java-first redesign of the original products. It is a repeated set of constraints.
+
+- Keep the semantic center of the upstream main application
+- Preserve traceability from upstream files, vocabulary, CLI behavior, and tests
+- Prefer CLI, batch, Maven, and jar distribution over Web UI
+- Keep core processing independent of entrypoint adapters
+- Make automation and build integration first-class use cases
+- Distinguish upstream-derived behavior from Java-side original extensions
+- Keep outputs reproducible and easy to compare
+
+## Role of This Document
+
+This document is not a porting procedure. The procedure for creating a Java version from a Node.js / TypeScript miku main application is described in the straight-conversion guide.
+
+This document instead describes the resulting Java application design that should be preserved after such conversion work.
+
+Use the three shared design documents together as follows.
+
+- main-application design memo
+  - describes the design of upstream miku main applications
+- straight-conversion guide
+  - describes how to create a Java version from such an upstream
+- Java application design memo
+  - describes how Java application versions should be shaped and maintained
+
+This document separates the following levels.
+
+- **Cross-cutting principles**: design policies that should generally be kept for Java application versions.
+- **Recommended conventions**: implementation, packaging, testing, and documentation shapes that make maintenance easier across Java versions.
+- **Observed tendencies**: design habits visible in current Java conversion work.
+- **Product-specific notes**: design decisions for specific Java products, recorded as concrete examples.
+
+When a specification is unclear, first check whether the decision preserves upstream meaning and Java-side operational usefulness. Java convenience is important, but it should not make upstream-following ability, CLI contracts, or output reproducibility unclear.
+
+## Scope
+
+The series whose names start with `miku` includes several related product types.
+
+Main applications:
+
+- `miku-abc-player`
+- `miku-docx2md`
+- `miku-indexgen`
+- `miku-unicode-guard`
+- `miku-xlsx2md`
+- `mikuproject`
+- `mikuscore`
+
+Java application versions:
+
+- `miku-indexgen-java`
+- `mikuproject-java`
+- `miku-xlsx2md-java`
+
+Agent Skills versions:
+
+- `mikuproject-skills`
+- `mikuscore-skills`
+
+Projects with the `-java` suffix are positioned as Java application versions of the original suffixless tools. They are usually created through straight conversion from the Node.js / TypeScript upstream.
+
+Projects with the `-skills` suffix are positioned as Agent Skills versions that make the original products easier for AI agents to use.
+
+This document focuses on Java application versions. It does not define the Web UI conventions for upstream main applications, and it does not define the skill packaging conventions for Agent Skills repositories.
+
+## Shared Direction
+
+Java application versions continue the shared direction of the miku series: small local bridge tools that convert, extract, inspect, or normalize existing files and domain data.
+
+The Java version emphasizes the parts that fit Java particularly well.
+
+- local CLI execution
+- batch processing
+- Maven and build-tool integration
+- jar-based distribution
+- stable public core APIs
+- deterministic artifact generation
+- tests that can be run with standard Java tooling
+- long-term maintainability in environments where Java is already available
+
+The Java version should not become a different product merely because the runtime changed. It should carry forward the upstream application's canonical source, primary outputs, diagnostics, and product boundary as far as practical.
+
+## Relationship to Straight Conversion
+
+Most miku Java application versions are expected to start from the straight-conversion process.
+
+The straight-conversion guide fixes the migration stance:
+
+- do not begin with a Java-first redesign
+- keep upstream file boundaries and vocabulary traceable
+- keep upstream tests and Java tests mapped
+- keep the Node CLI contract close where a CLI exists
+- treat Java-side original extensions separately
+- do not bring in the Web UI itself
+
+This document takes those results as the foundation for Java application design.
+
+In other words, `straight conversion` explains how the Java version is created, while this document explains how the Java version should remain understandable, useful, and maintainable after it exists.
+
+## Role of Java Applications
+
+In this document, a Java application means a `miku` repository with a `-java` suffix that provides a Java runtime implementation of an upstream main application.
+
+A Java application is primarily a local execution tool. It usually exposes one or more of the following.
+
+- CLI runtime jar
+- Maven plugin
+- batch command
+- public core API
+- deterministic file output
+- distribution zip
+
+The Java application is not primarily a Web UI application. If the upstream main application has a Web UI, that UI is generally not brought into the Java version.
+
+The center of the Java version is reusable processing: read local input, create structured output, emit diagnostics, and make the result reproducible from CLI, tests, Maven plugins, or other automation.
+
+## Cross-Cutting Principles
+
+miku Java applications emphasize the following cross-cutting principles.
+
+1. Preserve the semantic center and product boundary of the upstream main application.
+2. Preserve traceability from upstream files, tests, vocabulary, CLI contracts, and artifacts.
+3. Use Java as a local CLI / batch / build integration runtime, not as a reason to redesign the product first.
+4. Keep core processing independent from CLI, Maven plugin, and other adapters.
+5. Treat Java-side original extensions as separate contracts.
+6. Prefer reproducible artifacts and deterministic tests over environment-dependent behavior.
+7. Keep diagnostics, summaries, warnings, and timing output structured enough for automation.
+8. Make maintenance against upstream changes explainable through mapping documents and focused regression commands.
+
+### Basic Philosophy of Java Applications
+
+Java application versions emphasize the following philosophy.
+
+- Run locally without server communication for core functionality
+- Keep the upstream product meaning recognizable
+- Keep the Java implementation small enough to inspect
+- Preserve upstream vocabulary where it helps traceability
+- Use Java packaging for reliable local distribution
+- Make CLI and build-tool execution first-class paths
+- Keep Web UI and browser-specific behavior out of scope unless explicitly required
+- Keep public entrypoints testable without invoking `System.exit`
+- Generate artifacts whose names, bytes, and diagnostics are predictable where practical
+- Record differences from upstream instead of hiding them inside implementation choices
+
+The value of a Java application version is not that it is more Java-like in the abstract. It is that the upstream tool becomes easier to run, package, test, and integrate in Java-centered local and build environments.
+
+### Common Principles for Java Applications
+
+Java applications use the following principles as defaults.
+
+- Use Java source and binary compatibility `1.8`
+- Use Maven as the build tool
+- Use JUnit Jupiter as the test framework
+- Use `mvn test` as the primary verification command
+- Package the runtime as a single executable fat jar
+- Add a distribution zip when it helps users handle runtime artifacts
+- Place runtime implementation in a runtime module when a multi-module repository is needed
+- Place Maven plugin implementation in a separate plugin module when provided
+- Keep core APIs callable from CLI, Maven plugin, and tests
+- Keep CLI stdout, stderr, output files, and exit codes clearly separated
+- Keep `workplace/` at the repository root for local upstream checkout and temporary work
+- Track only `workplace/.gitkeep` under `workplace/`
+- Keep upstream mapping and test mapping documents under `docs/`
+
+These are defaults for the miku Java series. Individual products may add product-specific conventions, but should not change these foundations casually.
+
+### Upstream-Following Principles
+
+Java applications preserve upstream-following ability.
+
+This means the Java side should make it easy to answer the following questions.
+
+- Which upstream file did this Java class or class group come from?
+- Which upstream test intent does this Java test cover?
+- Which CLI option or behavior corresponds to the upstream CLI?
+- Which behavior is an upstream-derived contract, and which behavior is a Java-side extension?
+- Which focused regression command should be run after changing this area?
+
+The following maintenance documents support that operation.
+
+- upstream class mapping
+- upstream test mapping
+- upstream follow-up log
+- remaining migration items
+
+These documents are not secondary paperwork. They are part of the maintainability design of the Java version.
+
+### Java Runtime Boundary Principles
+
+Java versions usually receive upstream core semantics, but not the upstream browser runtime.
+
+Main targets:
+
+- domain model
+- codec / import / export
+- validation
+- summary and diagnostics
+- CLI entrypoint
+- batch entrypoint
+- Maven plugin entrypoint where useful
+- report and artifact generation
+- runtime packaging
+
+Mainly out of scope:
+
+- Web UI itself
+- single-file Web App distribution
+- browser DOM event handling
+- browser preview surfaces
+- download UI behavior
+- UI-only helpers that do not represent product semantics
+
+The Java version translates the runtime environment into CLI, Maven, jar, and file-based workflows while preserving the upstream product meaning.
+
+### Core and Adapter Principles
+
+Java applications keep core processing separate from entrypoints.
+
+The preferred shape is as follows.
+
+- core API owns product processing and output decisions
+- CLI parses arguments, handles file I/O, prints stdout / stderr, and returns exit codes
+- Maven plugin maps plugin parameters to core API options
+- tests call core APIs directly where possible
+- batch helpers are shared by CLI and Maven plugin when both need them
+
+Do not pack real processing into `main(String[] args)`. The CLI main should delegate to a testable method such as `run(String[] args, PrintStream out, PrintStream err)` and confine `System.exit` to the outermost boundary.
+
+This keeps CLI behavior testable and prevents Maven plugin or future automation from reimplementing product logic.
+
+### Java-Side Extension Principles
+
+Java applications may add operationally useful Java-side extensions.
+
+Examples:
+
+- Maven plugin goals
+- batch / directory processing
+- public Java core API wrappers
+- fat jar packaging
+- distribution zip packaging
+- classpath-resource access to runtime markdown or prompt specs
+- Java-specific logging, timing, or progress integration
+
+These extensions are allowed because they make the Java runtime useful. However, they must be documented separately from upstream-derived behavior.
+
+When adding a Java-side extension, satisfy the following.
+
+- State that it is a Java-side extension
+- Keep it outside the upstream mapping unless it has a clear upstream source
+- Add focused tests for the extension itself
+- Do not let it obscure the upstream single-input or core conversion contract
+- Reuse core APIs rather than duplicating conversion logic
+
+Batch and directory processing are especially useful in Java because JVM startup cost and build-tool usage often make grouped execution more practical than launching one process per input.
+
+### Maven and Build Integration Principles
+
+Maven integration is a first-class path when the product naturally participates in build workflows.
+
+This does not mean every Java application version must provide a Maven plugin. A CLI-only or runtime-jar-only repository is acceptable when that is the natural product surface. When a Maven plugin is provided, it should be treated as a first-class adapter over the same core API.
+
+Examples include:
+
+- index generation
+- documentation artifact generation
+- validation
+- conversion
+- report generation
+
+When a Maven plugin is provided, the repository may use a multi-module Maven reactor.
+
+The recommended shape is as follows.
+
+- repository root is an aggregator parent project
+- runtime jar implementation lives under a runtime module
+- Maven plugin implementation lives under a plugin module
+- shared core contracts live in the runtime module or a core module
+- plugin code depends on core contracts
+- core code does not depend on plugin code
+- directory / batch helpers used by both CLI and plugin live on the runtime/core side
+
+Maven plugin lifecycle binding should remain opt-in. The plugin should work through explicit invocation first, and consuming projects can bind it to a lifecycle phase when appropriate.
+
+### Packaging and Distribution Principles
+
+Java applications package local runtime use explicitly.
+
+The default runtime artifact is a single executable fat jar.
+
+When a distribution zip is useful, it should contain the minimal runtime-user-facing items such as:
+
+- runtime jar
+- `README.md`
+- `LICENSE`
+- CLI or runtime docs where useful
+
+Artifact names should be predictable and traceable from Maven coordinates.
+
+The basic naming direction is:
+
+- Maven `groupId`: `jp.igapyon`
+- Maven `artifactId`: product-derived artifact name
+- jar name: `<artifactId>-<version>.jar`
+- distribution zip name: `<artifactId>-dist-<version>.zip` or a similarly traceable form
+
+Runtime artifacts should not depend on source-tree-relative paths. If runtime markdown, prompt specs, or templates are needed inside the jar, copy them to classpath resources and read them through `getResourceAsStream` or an equivalent jar-safe mechanism.
+
+### CLI Design Principles
+
+The CLI is a formal entrypoint for humans, scripts, build tools, and AI agents.
+
+CLI design emphasizes the following.
+
+- Keep options understandable and close to upstream where applicable
+- Use explicit input and output paths
+- Use stdout for normal textual output or declared artifact output
+- Use stderr for diagnostics, usage errors, progress, and verbose logs
+- Make success and failure judgeable by exit code
+- Keep verbose output available for progress and timing when useful
+- Keep binary output file-based by default
+- Test stdout, stderr, exit code, and generated files
+
+When the upstream has a CLI, the Java CLI should respect its interface as far as practical. Differences caused by Java runtime needs should be documented.
+
+CLI help, README usage, and tests should be synchronized closely enough that option descriptions do not drift.
+
+### Diagnostics and Logging Principles
+
+Diagnostics are part of the Java application contract.
+
+Java applications distinguish the following.
+
+- normal output
+- generated artifacts
+- warnings
+- structured result information
+- verbose progress
+- timing information
+- usage errors
+- fatal errors
+
+Warnings and changes that do not stop processing should be accumulated in result objects where practical. Entry contract violations and syntactically invalid inputs should move toward exceptions or explicit failure results.
+
+Verbose output should not be mixed into primary output. For example, progress and timing lines can be emitted to stderr by CLI and to Maven logs by Maven plugins, while the core result keeps structured timings and messages for tests or adapters.
+
+### Data and Artifact Principles
+
+Java applications inherit the upstream application's data design.
+
+They should preserve the distinction between:
+
+- canonical input or semantic base
+- primary output
+- companion output
+- diagnostics
+- debug trace
+- Java-side operational metadata
+
+Java implementation choices should not collapse these roles.
+
+For example, optional Markdown companion output should not become the canonical representation merely because it is easy to emit from Java. A Maven plugin parameter should not become a product semantic if it is only an execution convenience.
+
+When structures affect output order, use deterministic data structures or explicit sorting. `LinkedHashMap` and `LinkedHashSet` are appropriate when insertion order matters.
+
+Text artifacts should use explicit encodings. Binary artifacts should be handled as `byte[]` in core logic where practical, with file paths pushed to CLI, Maven plugin, and test boundaries.
+
+### Reproducibility Principles
+
+Java applications should make outputs reproducible from the same input and settings.
+
+This is especially important for:
+
+- JSON
+- Markdown
+- XML
+- SVG
+- XLSX
+- ZIP
+- distribution archives
+- generated indexes
+
+Reproducibility includes more than string equality.
+
+Consider:
+
+- stable output ordering
+- stable filenames
+- stable archive entry order
+- fixed archive timestamps where needed
+- explicit encoding
+- explicit final newline policy
+- avoiding temporary paths in artifacts
+- avoiding current dates unless they are part of a declared build artifact
+
+Deterministic artifacts are easier to test, diff, cache, and review by humans and AI agents.
+
+### Testing Principles
+
+Java applications use tests to preserve both upstream parity and Java-side contracts.
+
+Test coverage should include:
+
+- core API tests
+- CLI tests
+- Maven plugin tests when a plugin exists
+- encoding tests where text input/output matters
+- artifact tests
+- diagnostics tests
+- Java-side extension tests
+
+Verification grows in this order when building or strengthening a Java version.
+
+1. semantic parity
+2. fixture round-trip
+3. API / CLI regression
+4. deterministic output
+5. byte-level parity
+
+Focused regression commands should be recorded in docs and tied to upstream files, Java classes, and test classes.
+
+`mvn test` remains the primary verification command. Product-specific focused commands are supporting tools, not replacements for the primary command.
+
+### Documentation Principles
+
+Java applications keep README and docs roles separate.
+
+`README.md` is the user-facing entry point. It should explain:
+
+- what the tool does
+- how to run the jar
+- how to use the Maven plugin if provided
+- main inputs and outputs
+- major options
+- where to find development and migration information
+
+Detailed design, mapping, migration, and maintenance notes should live under `docs/`.
+
+Important Java application docs include:
+
+- development notes
+- straight conversion guide
+- upstream class mapping
+- upstream test mapping
+- follow-up log
+- remaining migration items
+- product-specific specifications
+
+Do not make README carry the whole migration history. Link from README to deeper docs instead.
+
+### `workplace/` Directory Principles
+
+Java repositories use `workplace/` for local upstream checkouts, temporary verification data, smoke inputs, generated outputs, and similar local work.
+
+Rules:
+
+- keep `workplace/.gitkeep` tracked
+- do not track normal files under `workplace/`
+- do not use `workplace/` as a source directory
+- do not hide fixtures that tests require under `workplace/`
+- use explicit fixture or testdata directories for checked-in reproducible test data
+
+When an upstream repository needs to be inspected, it may be cloned under `workplace/`. This keeps upstream reference work local without making the Java repository depend on a dirty checkout.
+
+## Recommended Conventions
+
+### Repository Shape
+
+A single-module Java application may be enough when only a runtime jar is needed.
+
+A multi-module Maven reactor is appropriate when the repository provides both runtime jar and Maven plugin.
+
+Representative shape:
+
+```text
+repository root
+  pom.xml
+  README.md
+  LICENSE
+  docs/
+  workplace/.gitkeep
+  <runtime-module>/
+    pom.xml
+    src/main/java/...
+    src/test/java/...
+  <maven-plugin-module>/
+    pom.xml
+    src/main/java/...
+    src/test/java/...
+```
+
+The aggregator root should not contain main Java source unless there is a clear reason.
+
+### Package and Naming Conventions
+
+Use `jp.igapyon.<project>` as the base Java package.
+
+Package and class names should preserve upstream vocabulary where practical.
+
+General direction:
+
+- upstream `kebab-case` file stem becomes Java `UpperCamelCase` class name
+- upstream responsibility names become subpackages where helpful
+- upstream `camelCase` function names remain Java `camelCase` method names where practical
+- large upstream files may be split into Java helper classes if mapping remains clear
+
+Examples:
+
+- `markdown.ts` -> `jp.igapyon.<project>.markdown.Markdown`
+- `json-summary.ts` -> `jp.igapyon.<project>.jsonsummary.JsonSummary`
+- `path-utils.ts` -> `jp.igapyon.<project>.pathutils.PathUtils`
+- `core-api-*.ts` -> `jp.igapyon.<project>.coreapi.*`
+- CLI entrypoint -> `jp.igapyon.<project>.cli.<Project>Cli`
+
+Helper suffixes should describe upstream-derived responsibilities:
+
+- `Public`
+- `Import`
+- `Export`
+- `Validate`
+- `Parse`
+- `Build`
+- `Util`
+- `Adapters`
+- `Registry`
+- `Result`
+- `Warning`
+
+The criterion is whether the split can be explained in the upstream class mapping document.
+
+### Java Compatibility Conventions
+
+Main source and binary compatibility are fixed to Java 1.8.
+
+Avoid APIs and syntax that require newer Java versions, such as:
+
+- `List.of`
+- `Map.of`
+- `record`
+- `var`
+- `Files.readString`
+- text blocks
+
+The compiler may run on a newer JDK, but the produced source and bytecode compatibility should remain aligned with the repository's Java 1.8 policy.
+
+### Public API Conventions
+
+Core APIs should expose stable entrypoints useful to CLI, Maven plugin, tests, and automation.
+
+Prefer:
+
+- options objects for operation settings
+- result objects for multi-artifact output, warnings, changes, and timings
+- direct return of `String`, `byte[]`, or model objects for simple operations
+- explicit defaults at public entrypoints
+
+During initial straight conversion, simple POJOs with public fields are acceptable when they preserve readability and mapping. More Java-style encapsulation can be considered later, but should not break traceability or public contracts without reason.
+
+### CLI Conventions
+
+CLI implementation should provide a testable entrypoint.
+
+Representative shape:
+
+```text
+public static void main(String[] args)
+  -> int run(String[] args, PrintStream out, PrintStream err)
+     -> core API
+```
+
+CLI tests should check:
+
+- parsed options
+- usage text
+- stdout
+- stderr
+- exit code
+- output files
+- no-overwrite or failure behavior where relevant
+
+For normal usage, output files are preferred for generated artifacts. Stdout should be used only when the command contract clearly states it.
+
+### Maven Plugin Conventions
+
+Maven plugins should be thin adapters over the core API.
+
+Plugin parameters should map clearly to core options. Plugin code should not duplicate directory traversal, conversion, validation, or artifact assembly if those operations belong to the runtime module.
+
+Plugin tests should check:
+
+- parameter mapping
+- skip behavior
+- generated output
+- logging behavior where relevant
+- failure behavior
+
+### Mapping Document Conventions
+
+At minimum, keep an upstream class mapping document with this shape.
+
+```text
+upstream file:
+  <upstream-root>/src/<target>.ts
+
+java classes:
+  jp.igapyon.<project>.<package>.<ClassA>
+  jp.igapyon.<project>.<package>.<ClassB>
+
+notes:
+  - facade:
+  - helper split:
+  - Java-side extension:
+```
+
+`<upstream-root>` may be a vendored upstream snapshot, a local checkout under `workplace/`, or another repository-specific upstream reference location. The mapping should make the chosen reference method explicit without requiring this shared memo to fix the physical path.
+
+At minimum, keep an upstream test mapping document with this shape.
+
+```text
+upstream test / intent:
+  <upstream test name or behavior>
+
+java tests:
+  <JavaTestClass.testMethod>
+
+fixtures:
+  <fixture path>
+
+focused regression:
+  mvn test -Dtest=<JavaTestClass>
+```
+
+These mappings are used both during initial conversion and during maintenance.
+
+## Common Patterns Observed Across Java Versions
+
+### CLI and Maven as Peer Entrypoints
+
+For Java application versions, CLI and Maven plugin can both be first-class paths.
+
+The CLI is natural for direct local execution, scripts, CI, and AI agents.
+
+The Maven plugin is natural when generated artifacts belong to a Java project's build, documentation, validation, or reporting flow.
+
+Both should call the same core API.
+
+### Core API as the Center
+
+Java applications tend to place a clear core API at the center.
+
+A typical shape is a product-named facade or core class that receives an options object, executes the main operation, and returns structured results or generated artifacts.
+
+That shape lets:
+
+- CLI convert arguments into options
+- Maven plugin convert parameters into options
+- tests call the same operation directly
+- batch behavior be shared instead of duplicated
+
+This is the Java counterpart of the main-application principle that UI, CLI, tests, and Agent Skills should call the same core where possible.
+
+### Upstream Traceability Over Java Redesign
+
+Java applications do not initially optimize for the most idiomatic Java architecture.
+
+They first optimize for:
+
+- easy upstream comparison
+- stable mapping
+- clear responsibility correspondence
+- test intent preservation
+- explainable diffs
+
+Later Java-side cleanup is allowed, but should be done only after the upstream-following path is secure.
+
+### Local Batch Workflows
+
+Java applications often benefit from batch and directory workflows.
+
+This is practical because:
+
+- Java process startup has cost
+- Maven plugins usually work over project directories
+- generated artifacts often need to be produced for many inputs
+- build and CI workflows prefer one invocation per task group
+
+Batch workflows should be documented as Java-side extensions unless they already exist in the upstream contract.
+
+### Reproducible Outputs for Automation
+
+Java applications are often used in environments where generated artifacts are checked, compared, cached, or committed.
+
+Therefore deterministic output is more than a testing convenience. It is part of the user value.
+
+Stable byte output lets users and AI agents answer:
+
+- Did the generated artifact actually change?
+- Which input caused the change?
+- Can this output be reviewed in a normal diff?
+- Can the command be rerun in CI?
+
+## Product-Specific Notes
+
+### Notes Specific to `miku-indexgen-java`
+
+`miku-indexgen-java` is a Java implementation of `miku-indexgen`.
+
+It scans a directory and generates `index.json`. When Markdown output is enabled, it also generates `index.md`.
+
+The Java version currently has two main execution paths.
+
+- runtime jar / CLI
+- Maven plugin
+
+The central core API is:
+
+- `jp.igapyon.mikuindexgen.coreapi.Indexgen.createIndexes(IndexgenOptions)`
+
+CLI and Maven plugin layers map their inputs into `IndexgenOptions` and call the same core API.
+
+Important design points:
+
+- `index.json` is the primary structured output
+- `index.md` is optional companion output
+- directory scanning behavior is shared by CLI and Maven plugin through runtime-side code
+- verbose progress and timing information are kept separate from primary output
+- Maven plugin goals are Java-side extensions
+- child-directory batch mode is a Java-side extension and should not be confused with the upstream single-input contract
+- upstream class and test mappings are recorded under `docs/`
+
+#### Child-Directory Batch Mode in `miku-indexgen-java`
+
+`miku-indexgen-java` has a Java-side child-directory batch mode.
+
+This mode is specific to `miku-indexgen-java` and should not be read as a cross-cutting requirement for all miku Java applications. The cross-cutting principle is only that Java versions may add batch / directory processing when it is useful and documented as a Java-side extension.
+
+The current contract is as follows.
+
+- CLI option `--input-parent-directory <dir>` selects a parent directory
+- Maven plugin goal `index-child-directories` selects a parent directory through `inputParentDirectory`
+- the parent directory itself is not indexed as one input base
+- each direct child directory under the parent is processed independently
+- direct child files under the parent are ignored
+- hidden child directories are skipped
+- recursive scanning still means recursion inside each selected child directory
+- when `--output-directory` or plugin `outputDirectory` is omitted, outputs are written under each child directory
+- when an output directory is specified, outputs are written under child-specific paths such as `<outputDirectory>/<child>/index.json`
+- the same core API, `Indexgen.createIndexes(IndexgenOptions)`, handles both single-directory mode and child-directory batch mode
+
+This feature exists because `miku-indexgen-java` is often useful for generating many small directory indexes in one Java process or Maven execution. It is therefore an operational extension on the Java side, not a change to the upstream `miku-indexgen` single-directory contract.
+
+The repository is a multi-module Maven reactor.
+
+- root aggregator project
+- `miku-indexgen/` runtime jar and CLI implementation
+- `miku-indexgen-maven-plugin/` Maven plugin implementation
+
+This shape is appropriate because the runtime jar and Maven plugin are separate deliverables but use the same core API.
+
+### Notes Specific to `mikuproject-java`
+
+`mikuproject-java` is positioned as a Java version of `mikuproject`.
+
+The upstream product treats `MS Project XML` as the semantic base and uses `ProjectModel` as the internal neutral representation for validation, workbook exchange, AI-facing views, patch application, and report generation.
+
+#### Runtime Entrypoints in `mikuproject-java`
+
+The Java version currently emphasizes the following execution paths.
+
+- runtime jar / CLI
+- Java-side multi-input batch commands
+- public core API facades
+- deterministic report and exchange artifact generation
+- distribution zip for runtime users
+
+Unlike `miku-indexgen-java` and `miku-xlsx2md-java`, the current `mikuproject-java` repository is a single-module Maven project. It does not currently expose a Maven plugin module. This is acceptable because the current Java-side product surface is centered on CLI, core API, report generation, and distribution packaging rather than build-lifecycle integration.
+
+#### Core Facades in `mikuproject-java`
+
+The Java-side public surface is organized around `jp.igapyon.mikuproject.coreapi` facades.
+
+Representative facade groups include:
+
+- `CoreApiPublic` / `CoreApi`
+- `CoreApiMsproject`
+- `CoreApiWorkbook`
+- `CoreApiImport`
+- `CoreApiReport`
+- `CoreApiMsprojectAi`
+- `CoreApiAiJson`
+
+These facades are Java-side aggregation points. They should remain traceable to upstream responsibilities such as MS Project XML import/export, workbook JSON / XLSX exchange, patch JSON, AI-facing views, report generation, and external import. They should not become a reason to hide upstream file boundaries or replace upstream vocabulary with unrelated Java-only abstractions.
+
+#### Product Boundary in `mikuproject-java`
+
+Important design points:
+
+- preserve the upstream goal of bridging `MS Project XML`, WBS reports, workbook exchange, and AI workflows
+- keep `MS Project XML` and `ProjectModel` as the semantic center
+- treat workbook JSON, `.xlsx`, AI JSON, patch JSON, Markdown, SVG, Mermaid, and WBS XLSX as exchange, editing, report, or inspection surfaces around that center
+- keep browser Web UI behavior out of scope
+- keep AI-facing workflows artifact-based, such as project overview, phase detail, task edit, draft request, patch JSON, validate, apply, and diff-oriented outputs
+- keep report outputs such as WBS Markdown, daily / weekly / monthly SVG, Mermaid, WBS XLSX, report directory, and report bundle as derived artifacts, not canonical project state
+- make report bundle and report directory outputs deterministic enough for byte-level comparison where practical
+- keep CLI help, README command lists, mapping documents, and focused tests synchronized
+
+#### Batch Commands in `mikuproject-java`
+
+`mikuproject-java` has many Java-side `*-batch` CLI commands.
+
+These commands are operational extensions for local automation. They are useful because project report and import/export workflows often need to process several XML, workbook, JSON, or patch files in one JVM invocation.
+
+This batch surface should be read as a Java-side extension, not as a change to the upstream `mikuproject` single-operation product contract.
+
+The current direction is:
+
+- keep single-input commands as the clearest counterpart to upstream behavior
+- use `*-batch` names for Java-side multi-input commands
+- keep output root / input / name pair handling explicit
+- reject invalid argument combinations at the CLI boundary
+- test usage errors, command failures, stdout / stderr, and generated files
+- avoid adding more batch commands merely for symmetry when the current operational value is not clear
+
+#### Repository Shape in `mikuproject-java`
+
+The repository currently uses a single Maven project.
+
+The expected runtime artifacts are:
+
+- `target/mikuproject.jar`
+- `target/mikuproject-dist.zip`
+
+The distribution zip contains the runtime jar and minimal runtime-facing documentation such as `README.md`, `LICENSE`, and CLI documentation.
+
+This single-module shape should remain acceptable while there is no Maven plugin deliverable. If a Maven plugin is added later, the repository should be reconsidered as a multi-module Maven reactor so that plugin code remains a thin adapter over the runtime / core API rather than a second implementation.
+
+#### Maintenance Focus in `mikuproject-java`
+
+Because `mikuproject-java` has a broad product surface, maintenance should be organized by upstream file and by major responsibility group.
+
+Practical groups are:
+
+- `MS Project XML` / `ProjectModel` / validation
+- workbook JSON and project XLSX
+- patch JSON and AI JSON import
+- AI-facing project views
+- report outputs such as WBS Markdown, SVG, Mermaid, WBS XLSX, report directory, and report bundle
+- CLI and Java-side batch extensions
+
+For upstream-following work, first use the upstream class mapping and upstream test mapping documents to find the affected Java classes and tests. CLI batch behavior, distribution packaging, and report directory / bundle conveniences should be recorded as Java-side extensions when they do not have direct upstream counterparts.
+
+### Notes Specific to `miku-xlsx2md-java`
+
+`miku-xlsx2md-java` is positioned as a Java version of `miku-xlsx2md`.
+
+The upstream product treats the Excel workbook as canonical input and Markdown as the primary extracted representation for design-document structure.
+
+#### Runtime Entrypoints in `miku-xlsx2md-java`
+
+The Java version currently exposes the following main execution paths.
+
+- runtime jar / CLI
+- Maven plugin
+- Java-side directory batch conversion shared by CLI and Maven plugin
+- selected Node / Java Markdown byte-level comparison script for upstream fixtures
+
+#### Core Facade in `miku-xlsx2md-java`
+
+The central runtime facade is:
+
+- `jp.igapyon.mikuxlsx2md.core.Core`
+
+The main core operations are:
+
+- `Core.parseWorkbook(byte[], String)`
+- `Core.convertWorkbookToMarkdownFiles(ParsedWorkbook, MarkdownOptions)`
+- `Core.convertSheetToMarkdown(ParsedWorkbook, ParsedSheet, MarkdownOptions)`
+- `Core.toExportWorkbook(ParsedWorkbook)`
+
+CLI and Maven plugin layers should remain thin adapters over this runtime side. Directory conversion is implemented as a Java-side operational extension through `jp.igapyon.mikuxlsx2md.directoryconverter.DirectoryConverter`, so that CLI and Maven plugin directory workflows do not duplicate workbook conversion logic.
+
+#### Product Boundary in `miku-xlsx2md-java`
+
+Important design points:
+
+- preserve the upstream goal of workbook-to-Markdown extraction
+- do not turn the Java version into a full Excel renderer
+- treat Excel `.xlsx` workbooks as canonical input
+- treat Markdown as the primary extracted representation
+- keep Markdown, ZIP assets, summaries, formula diagnostics, and Java-side operational metadata separated by role
+- prefer local CLI / batch / build integration over Web UI behavior
+- keep workbook parsing and output generation traceable to upstream responsibilities
+- avoid adopting broad dependencies in a way that hides conversion meaning
+- make ZIP / asset / Markdown output reproducible where practical
+- keep CLI help, README usage, Maven plugin parameters, and tests synchronized
+
+#### Repository Shape in `miku-xlsx2md-java`
+
+The repository is a multi-module Maven reactor.
+
+- root aggregator project
+- `miku-xlsx2md/` runtime jar and CLI implementation
+- `miku-xlsx2md-maven-plugin/` Maven plugin implementation
+
+This shape is appropriate because the runtime jar and Maven plugin are separate deliverables but use the same runtime conversion implementation.
+
+#### Directory Batch Conversion in `miku-xlsx2md-java`
+
+`miku-xlsx2md-java` has Java-side directory batch conversion.
+
+This mode is specific to Java runtime and build-tool operation. It should not be read as a change to the upstream workbook-to-Markdown single-input product contract.
+
+The current contract is as follows.
+
+- CLI option `--input-directory <dir>` selects directory conversion
+- Maven plugin goal `convert-directory` selects directory conversion through `miku-xlsx2md.inputDirectory`
+- `--recursive` and `miku-xlsx2md.recursive` control recursive scanning
+- only files whose names end with `.xlsx` are processed
+- when output directory is omitted, Markdown files are written next to the input workbooks
+- when output directory is specified, relative input paths are mirrored under the output directory
+- ZIP output is not part of directory conversion
+- verbose mode reports processing workbook paths to stderr in CLI and Maven logs in the plugin
+
+This feature exists because workbook conversion often needs to run over many local files in one Java process or Maven execution. It is therefore an operational extension on the Java side, not a replacement for the upstream single-workbook conversion contract.
+
+## Maintenance Policy
+
+After initial conversion, Java applications are maintained by comparing against upstream deliberately.
+
+The maintenance workflow should include:
+
+- check upstream changes by upstream file
+- update mapping documents when responsibility changes
+- update test mapping when upstream test intent changes
+- record known diffs and follow-up items
+- run focused regression commands for affected areas
+- run `mvn test` before release-level confidence
+- keep README, CLI help, and plugin docs synchronized when those surfaces exist
+
+When an upstream bug is found, record it separately from Java-side implementation work. Do not silently redesign the Java side so far that the difference can no longer be explained.
+
+When a Java-side extension is added, test and document it as Java-specific behavior.
+
+## Summary
+
+miku Java application versions are not independent rewrites of the upstream tools.
+
+They are local Java runtimes that preserve upstream product meaning while making CLI, Maven, batch, testing, packaging, and reproducible artifact generation stronger.
+
+The central design question is:
+
+> Can this Java behavior be traced back to upstream meaning, or clearly explained as a Java-side extension?
+
+When the answer remains clear, Java versions can be useful as practical local tools while staying maintainable against their Node.js / TypeScript upstreams.

--- a/docs/miku-soft-30-straight-conversion-v20260425.md
+++ b/docs/miku-soft-30-straight-conversion-v20260425.md
@@ -1,0 +1,1022 @@
+# Miku Software Straight Conversion Guide v20260425
+
+## Purpose
+
+This document is a memo that summarizes the `straight conversion migration` policy used when moving Node.js / TypeScript upstream projects in the miku series to Java.
+
+Each repository should keep this document as a set of shared principles. The canonical implementation details and current status for each repository should be checked in that repository's `README.md`, progress tracking documents, upstream mapping tables, and test mapping tables.
+This document exists to preserve the reasoning behind why this conversion approach was chosen.
+
+This document also aims to align the workflow and artifact granularity closely enough that straight conversion work can be reproduced in another miku-series project.
+
+## How to Use This Document
+
+Use this document not merely as a policy collection, but as a procedure manual from the start of straight conversion through the maintenance phase.
+However, this document fixes shared principles. It is not the canonical source for repository-specific progress or current status.
+
+The basic usage is as follows.
+
+1. Review the decision criteria in `Basic Stance` and `Why Choose Straight Conversion`
+2. Fill in `What to Fix at the Start` and `Start Checklist`
+3. Follow `Reproducible Work Procedure` to inventory, map, implement, and verify
+4. Reflect `Artifacts to Keep` in documents and tests at each stage
+5. After implementation, operate according to `Handling in the Maintenance Phase` and `Docs and Upstream-Following Operation`
+
+When asking a generative AI to read this document, assume the following reading order.
+
+1. Read `What to Fix at the Start` as fixed policy, including the decision rationale
+2. Read `Start Checklist` as a short pre-execution confirmation
+3. Read `Reproducible Work Procedure` as the actual work order
+4. Read the later individual policies as decision criteria when implementation choices are unclear
+
+The same policy may appear repeatedly in this document as fixed policy, checklist item, and reproducible procedure.
+This is intentional, so that generative AI is less likely to miss important premises even when it references only one section. Do not remove these repetitions too aggressively as simple duplication.
+
+Read the strength of wording as follows.
+
+- `fix`, `fixed`, `must`, `out of scope`, and `do not` indicate fixed policy to align first in that miku Java version
+- `basically`, `principle`, and `prefer` indicate the default policy when in doubt
+- `may`, `allow`, and `can choose` indicate acceptable patterns as long as upstream-following ability is not broken
+- `tendency`, `finding`, `example`, and `visible in this repository` indicate decision material, not rules to force directly onto other miku-series projects
+- `fixed in this repository` indicates an application example in `mikuproject-java`; distinguish it from the shared principle itself
+
+## Basic Stance
+
+Java conversion here does not mean a port that first redesigns the project for Java.
+The first goal is `straight conversion`: moving the Node.js / TypeScript upstream into a form that remains trackable on Java.
+
+`Straight conversion` here does not mean simple mechanical translation.
+The important points are as follows.
+
+- Make upstream file boundaries and responsibility divisions easy to follow
+- Make upstream vocabulary and naming easy to trace on the Java side
+- Make it explainable where to compare when upstream changes
+- Avoid drifting too far into a Java-only redesign that looks like a different product
+
+Therefore, in the initial porting stage, upstream-following ability was prioritized over the neatness of Java-style abstraction or reorganization.
+
+## Why Choose Straight Conversion
+
+Many miku-series upstream projects have clear file boundaries, responsibility divisions, vocabulary, and input/output contracts.
+If this structure is rebuilt into a different architecture from the beginning on the Java side, the following problems tend to occur.
+
+- It becomes hard to tell which upstream file an implementation came from
+- It becomes hard to understand the impact range of upstream changes
+- The work tends to become a reimplementation rather than a port
+- It becomes hard to distinguish whether a difference found on the Java side is a specification difference or a design difference
+
+For this reason, the adopted order is to first establish a Java version in a form that can faithfully trace upstream, then consider Java-side reorganization later if needed.
+
+## What to Fix at the Start
+
+At the start of straight conversion, fix at least the following items first.
+
+- Confirm that the source upstream for straight conversion is organized enough to support porting
+- Fix target Java compatibility to `1.8` for both source and binary compatibility
+- Fix the build tool to `Maven`
+- Fix the test framework to `JUnit Jupiter`
+- Fix the primary test entrypoint to `mvn test`
+- Fix runtime packaging to a single fat jar
+- Decide whether to adopt a distribution zip depending on the processing target
+- Create `workplace/` at the repository root, and track only `workplace/.gitkeep` in Git
+- Exclude all files under `workplace/` except `workplace/.gitkeep` from Git tracking
+- Do not add new features during straight conversion
+- Do not perform Java-first redesign before conversion
+- Respect upstream file boundaries and responsibility divisions
+- Make it possible to trace `upstream file -> Java class group`
+- Use `jp.igapyon.<project>` as the base Java package, and decide subpackages from upstream Node-side file names and responsibilities
+- Translate class names into Java conventions while preserving upstream vocabulary
+- If an upstream function name is `camelCase`, keep the Java-side method name basically unchanged
+- Do not bring in the GUI; the Java-side target is basically the CLI runtime
+- For upstream projects that have a CLI, make the Java-side CLI respect the Node CLI interface as much as possible
+- Treat Java-side original extensions that do not exist upstream separately from the main contract
+- Even when an upstream bug is found, first record it as a communication item and continue conversion as-is
+
+If naming, responsibility boundaries, CLI contracts, and out-of-scope areas are left vague at this stage, upstream-following ability becomes hard to recover later.
+Similarly, if the Java version, build tool, test framework, and packaging are changed midstream, effort tends to be spent on absorbing runtime environment differences rather than on the port itself.
+If new features are added during porting, the boundary between straight conversion and original extension becomes unclear, making it hard to explain what is upstream support and what is added specification.
+Likewise, if porting stops every time an upstream bug is found, straight conversion becomes too dependent on waiting for upstream fixes.
+
+Among the items above, the environment premises are fixed in the following sense for miku-series Java versions.
+
+- target Java compatibility
+  - Fix the source version and binary target version to `1.8`
+  - The actual compiler does not necessarily have to be `JDK 1.8`
+  - Users may use a newer Java runtime
+- build tool
+  - Fix to `Maven`
+- test framework
+  - Fix to `JUnit Jupiter`
+- primary test entrypoint
+  - Fix to `mvn test`
+- runtime packaging
+  - Fix to a single fat jar
+  - Add a distribution zip depending on the processing target
+- local workspace
+  - Place `workplace/` at the repository root
+  - Track `workplace/.gitkeep` in Git
+  - Exclude all other files under `workplace/` from Git tracking
+
+The important point is not to later shift toward what looks optimal in general terms, but to fix the foundation used by that straight conversion at the beginning.
+
+It is also important that upstream itself is sufficiently organized before porting.
+If upstream file boundaries or responsibility divisions are still unstable, it is better to refactor upstream before moving it to Java.
+
+For CLI / batch / report-centered tools of this kind, target Java compatibility should be fixed as low as maintainably possible so that a wide range of user runtime environments can be supported.
+For this reason, miku-series Java versions fix source / binary compatibility to `1.8`.
+
+## Start Checklist
+
+When starting straight conversion, fill in at least the following.
+
+- The source upstream for straight conversion has been sufficiently organized and refactored at least for the porting unit
+- Target Java compatibility has been fixed to `1.8` for both source and binary compatibility
+- The build tool has been fixed to `Maven`
+- The test framework has been fixed to `JUnit Jupiter`
+- The primary test entrypoint has been fixed to `mvn test`
+- Runtime packaging has been fixed to a single fat jar
+- Whether to create a distribution zip has been decided depending on the processing target
+- The policy to create `workplace/` at the repository root and track only `.gitkeep` in Git has been confirmed
+- The scope for not bringing in the GUI has been decided
+- If a CLI exists, how far the Node interface will be respected has been decided
+- The source file list has been obtained
+- The test file / fixture list has been obtained
+- The import / export / report artifact list has been obtained
+- The location of the `upstream file -> Java class` mapping table has been decided
+- The location of the `upstream test intent -> Java test` mapping table has been decided
+- The location of the follow-up log has been decided
+- The location of focused regression commands has been decided
+
+If the source upstream for straight conversion is not yet organized, the Java side easily ends up carrying both `porting` and `upstream-side structural cleanup` at the same time.
+In that state, the `upstream file -> Java class` mapping becomes unstable, and the work tends to become redesign rather than straight conversion.
+Therefore, before starting, the upstream-side files to be ported should be organized enough to be cleanly traceable.
+
+## Reproducible Work Procedure
+
+When reproducing straight conversion in another miku-series project, proceed at least in the following order.
+
+### 1. Fix the Premises
+
+First fix the following.
+
+- The source upstream for straight conversion is sufficiently organized
+- target Java compatibility
+  - Fix both source and binary compatibility to `1.8`
+  - Do not limit the actual compiler to `JDK 1.8`
+- build tool
+  - Fix to `Maven`
+- test framework
+  - Fix to `JUnit Jupiter`
+- primary test entrypoint
+  - Fix to `mvn test`
+- runtime packaging
+  - Fix to a single fat jar
+  - Add a distribution zip depending on the processing target
+- local workspace
+  - Create `workplace/` at the repository root
+  - Track only `workplace/.gitkeep` in Git
+  - Exclude all other files under `workplace/` from Git tracking
+- Do not add new features during straight conversion
+- Where to record upstream bugs and how to handle them
+- Do not bring in the GUI
+- Compatibility policy when a CLI exists
+- Basic rules for class names / method names / package names
+  - Use `jp.igapyon.<project>` as the package base name
+  - Decide subpackages from upstream Node-side file names and responsibilities
+
+Artifacts at this stage:
+
+- Confirmation that upstream is in a state that can support starting the port
+- Basic policy in the repository top README
+- Reference to this guide
+- Build file with the development foundation fixed
+- Agreement that new feature additions are outside the porting scope
+- Location for keeping upstream bugs as communication items
+
+### 2. Decide How to Reference Upstream
+
+For miku-series Java versions, use one of the following three upstream reference methods.
+
+1. Include upstream wholesale by subtree
+2. Connect to upstream as a Git remote without keeping the upstream body in the repository
+3. Clone upstream under `workplace/` when needed and obtain the latest version
+
+Across the miku series, subtree is often preferred because it can keep an upstream snapshot in the repository.
+On the other hand, for straight conversion work, cloning under `workplace/` as needed is also often preferred because it is easy to compare against the latest upstream without dirtying it.
+
+Usage guidelines:
+
+- Use subtree when you want to keep the source snapshot in the repository and be able to revisit the same file set at any time
+- Use Git remote only when you do not want to bring the upstream body into the repository and want to check diffs or history with Git operations
+- Use as-needed clones under `workplace/` when you want to temporarily check the latest upstream or avoid leaving the upstream body in the main repository
+
+Whichever method is chosen, keep `upstream file -> Java class` and `upstream test intent -> Java test` traceable in documents.
+Also, upstream cloned under `workplace/` is a temporary reference, and files other than `workplace/.gitkeep` should not be tracked in Git.
+
+### 3. Inventory Upstream
+
+List the following.
+
+- source files
+- public APIs / facades
+- CLI commands / options
+- test files
+- fixtures / testdata
+- import / export / report artifacts
+
+Artifacts at this stage:
+
+- `upstream file` list
+- main fixture list
+- Java-side target scope and out-of-scope items
+
+### 4. Create Mapping Tables First
+
+Before implementation or at the initial implementation stage, fix at least the following in documents.
+
+- `upstream file -> Java class / package`
+- `upstream test intent -> Java test`
+- `upstream CLI -> Java CLI`
+
+Artifacts at this stage:
+
+- class mapping document
+- test mapping document
+- CLI mapping document or README section if needed
+
+### 5. Implement from Core
+
+The basic implementation order is as follows.
+
+1. domain model
+2. codec / import / export
+3. validation
+4. report / artifact
+5. CLI
+6. packaging
+
+Here, prioritize receiving responsibilities for each upstream file over rebuilding for Java.
+
+Artifacts at this stage:
+
+- Java classes
+- minimal round-trip
+- focused unit tests
+
+### 6. Align the CLI and Public Entrypoints
+
+Once the core implementation starts working, organize the CLI and public entrypoints.
+
+Important points:
+
+- Bring Node CLI commands / options / argument order close enough that the same wording can be used in descriptions and usage markdown
+- Treat Java-side original extensions separately from upstream straight conversion
+- Align help / README / test wording
+- Synchronize README / docs / CLI help deeply enough to reuse not only command and option names but also descriptions
+- Align AI-facing prompt markdown as an API / CLI retrieval contract, not as a source file reference
+- Even when adding Java-side original directory / batch processing, state it as an additional contract instead of mixing it with the upstream CLI single-input contract
+
+Artifacts at this stage:
+
+- Java CLI entrypoint
+- help / usage contract
+- AI-facing prompt markdown retrieval contract
+- CLI regression tests
+- regression tests for Java-side original extensions
+
+### 7. Strengthen Verification Gradually
+
+Verification is easier to grow in the following order.
+
+1. semantic parity
+2. fixture round-trip
+3. API / CLI regression
+4. deterministic output
+5. byte-level parity
+
+Byte-level parity is especially effective when first applied to final artifacts such as reports and archives.
+
+Artifacts at this stage:
+
+- focused regression commands
+- parity tests
+- determinism tests
+
+### 8. Move to Maintenance Operation
+
+Once the main paths are aligned, move the focus from new implementation to upstream-following operation.
+
+Important points:
+
+- Check diffs by `upstream file`
+- Record diff check results in documents
+- Treat docs-only updates and code changes separately
+- Fix the necessary regression units
+- Record upstream bugs separately from Java-side temporary workarounds
+
+Artifacts at this stage:
+
+- remaining items document
+- follow-up log
+- focused regression list
+
+## Minimal Document Templates
+
+To improve reproducibility, document granularity should also be aligned.
+
+### 1. class mapping
+
+At minimum, keep the following shape.
+
+```text
+upstream file:
+  vendor/<project>/src/ts/<target>.ts
+
+java classes:
+  <package>.<ClassA>
+  <package>.<ClassB>
+
+notes:
+  - facade:
+  - helper split:
+  - Java-side extension:
+```
+
+### 2. test mapping
+
+At minimum, keep the following shape.
+
+```text
+upstream test / intent:
+  <upstream test name or behavior>
+
+java tests:
+  <JavaTestClass.testMethod>
+
+fixtures:
+  <fixture path>
+
+focused regression:
+  <command>
+```
+
+### 3. follow-up log
+
+At minimum, keep the following shape.
+
+```text
+upstream file:
+  vendor/<project>/src/ts/<target>.ts
+
+java classes:
+  <package>.<ClassA>
+  <package>.<ClassB>
+
+tests:
+  <RelatedTest1>
+  <RelatedTest2>
+
+diff summary:
+  behavior differences:
+  naming differences:
+  unported differences:
+  Java-side original extensions:
+
+follow-up:
+  - checks performed:
+  - fixture:
+  - next check viewpoint:
+```
+
+### 4. remaining items
+
+At minimum, keep the following.
+
+- current position
+- `done / maintenance check / pending`
+- focused regression list
+- latest passing result
+- next unit to check
+
+## Basic Conversion Method
+
+The basic porting unit is the upstream source file set.
+
+- Translate `kebab-case` upstream file names into Java `UpperCamelCase` class names
+- Use `jp.igapyon.<project>` as the base package name
+- Decide subpackage names from upstream Node-side file names and responsibilities
+- If an upstream function name is `camelCase`, keep the Java-side method name as much as possible
+- Basically receive one upstream file with one Java class, but splitting into helper classes is allowed to preserve readability in Java
+- Even in that case, make upstream responsibilities inferable from the split class names
+
+Generalized examples:
+
+- `feature-a.ts` -> `FeatureA`
+- `feature-b.ts` -> `FeatureB`, `FeatureBHelper`, `FeatureBValidate`
+- `core-api-x.ts` -> `CoreApiX`, `CoreApiXImport`, `CoreApiXPublic`
+- `excel-io.ts` -> `jp.igapyon.<project>.excelio.ExcelIo`
+- `excel-io-normalize.ts` -> `jp.igapyon.<project>.excelio.ExcelIoNormalize`
+
+This policy keeps the verification unit as `upstream file -> Java class group`, even if the Java side splits classes.
+Also, by placing responsibility packages derived from upstream file names under the project name, such as `jp.igapyon.mikuproject.excelio`, the upstream verification unit is easier to trace from Java packages.
+
+Examples of naming patterns visible in this repository:
+
+These naming pattern examples are not meant to be forced directly onto other miku-series projects.
+However, when the same file names, responsibilities, and vocabulary appear, they are strong initial values for preserving upstream-following ability.
+
+- The `kebab-case` upstream file stem becomes lowercase concatenation in packages
+- Example: `wbs-svg.ts` -> `jp.igapyon.<project>.wbssvg`
+- Example: `wbs-xlsx.ts` -> `jp.igapyon.<project>.wbsxlsx`
+- Example: `project-xlsx.ts` -> `jp.igapyon.<project>.projectxlsx`
+- Example: `project-workbook-json.ts` -> `jp.igapyon.<project>.projectworkbookjson`
+- Example: `project-patch-json.ts` -> `jp.igapyon.<project>.projectpatchjson`
+- Example: close responsibility groups such as `msproject-xml.ts` / `msproject-codec.ts` / `msproject-validate.ts` -> `jp.igapyon.<project>.msprojectxml`
+- Example: `core-api-*.ts` -> `jp.igapyon.<project>.coreapi`
+
+For class-name vocabulary conversion, preserve upstream vocabulary while moving toward Java `UpperCamelCase`.
+In this repository, at least the following translations are implicitly used.
+
+- `wbs` -> `Wbs`
+- `xlsx` -> `Xlsx`
+- `xml` -> `Xml`
+- `svg` -> `Svg`
+- `json` -> `Json`
+- `ai` -> `Ai`
+- `io` -> `Io`
+- `msproject` -> `MsProject`
+
+When one upstream file is large, the Java side may split classes with responsibility suffixes.
+In that case, suffixes should not be based only on Java-side convenience; they should use vocabulary that lets the responsibilities inside the upstream file be traced.
+
+- `Public`: public facade / public wrapper
+- `Import`: import-side processing
+- `Export`: export-side processing
+- `Validate`: validate-side processing
+- `Parse`: parse-side processing
+- `Build`: build / serialize-side processing
+- `Util`: small helper processing
+- `Helpers`: helpers for validation or conversion
+- `Adapters`: bridge between core API and individual implementations
+- `Registry`: registration / facade that groups public APIs
+- `Result`: API result object
+- `Warning`: warning object
+- `Document`: external exchange document object
+- `Operation`: patch / edit operation object
+- `Zip`: archive / zip artifact processing
+
+Examples:
+
+- `wbs-svg.ts` -> `WbsSvg`, `WbsSvgPublic`, `WbsSvgRender`, `WbsSvgCalendar`, `WbsSvgZip`
+- `wbs-xlsx.ts` -> `WbsXlsx`, `WbsXlsxExport`, `WbsXlsxLayout`, `WbsXlsxCells`, `WbsXlsxPublic`
+- `project-xlsx.ts` -> `ProjectXlsx`, `ProjectXlsxImport`, `ProjectXlsxExport`, `ProjectXlsxImportProject`, `ProjectXlsxExportCalendars`
+- `project-workbook-json.ts` -> `ProjectWorkbookJson`, `ProjectWorkbookJsonImport`, `ProjectWorkbookJsonExport`, `ProjectWorkbookJsonValidate`
+- `project-patch-json.ts` -> `ProjectPatchJson`, `ProjectPatchJsonCore`, `ProjectPatchJsonTasks`, `ProjectPatchJsonUpdates`
+- `core-api-report.ts` -> `CoreApiReport`, `CoreApiReportAdapters`, `CoreApiReportPublic`
+- `core-api-import.ts` -> `CoreApiImport`, `CoreApiExternalImport`, `CoreApiExternalDocument`, `CoreApiExternalBinary`
+- `msproject-validate.ts` -> `MsProjectValidate`, `MsProjectValidateHelpers`
+
+When scratch-implementing replacements for external libraries or browser APIs, minimal compatibility wrappers may be placed with a `Like` suffix.
+This is not to reproduce the entire upstream dependency API, but to make only the range needed for straight conversion explainable.
+Even in areas such as xlsx where Apache POI comes to mind easily, the miku series may avoid assuming even POI, scratch-implement only the needed range, and create minimal compatibility with `Like` wrappers.
+
+- `XlsxWorkbookLike`
+- `XlsxSheetLike`
+- `XlsxRowLike`
+- `XlsxCellLike`
+- `XlsxColumnLike`
+- `XlsxFreezePaneLike`
+- `XlsxDataValidationLike`
+
+Internal models are placed in the `model` package in principle, and are separated from external representations and packages derived from upstream file names.
+Model classes use a `Model` suffix, such as `ProjectModel`, `TaskModel`, `ResourceModel`, `AssignmentModel`, and `CalendarModel`.
+On the other hand, external exchange documents / warnings / operations / results prioritize suffixes that express their responsibilities, and do not necessarily move toward `Model`.
+
+Notes:
+
+- These are not naming rules for freely redesigning the Java side; they are practical rules for preserving correspondence with upstream files / responsibilities / tests
+- When adding suffixes, use whether they can be explained in `docs/upstream-class-mapping.md` as `upstream file -> Java class group` as the criterion
+- Even if the same simple name such as `ImportChange` appears in multiple packages, it is acceptable when responsibility packages are separated and the upstream correspondence can be explained
+
+Other viewpoints derived from this repository:
+
+This section summarizes fixed policies, default policies, acceptable patterns, and concrete examples visible from implementation.
+Read the strength of individual sentences according to wording such as `fix`, `basically`, `allow`, and `example`.
+
+- Maven coordinates basically use `groupId = jp.igapyon` and `artifactId = <project>`
+- Artifact names for single fat jar, Maven plugin jar, and distribution zip are aligned to an `artifactId-version` style that is easy to trace from Maven coordinates
+- Runtime jar names inside distribution zips are also versioned like distribution file names
+- Place the CLI main class at `jp.igapyon.<project>.cli.<Project>Cli`
+- The CLI should not pack real processing into `main(String[] args)`; delegate to a testable entrypoint such as `run(String[] args, PrintStream out, PrintStream err)`
+- In principle, confine `System.exit` to the end of the CLI main, and return exit codes from core APIs and CLI implementation logic
+- Use CLI stdout for normal output and artifact bodies; use stderr for diagnostics / usage errors / progress, and do not mix them
+- When handling binary artifacts in CLI, output files are the default; if stdout is used, state that as a command contract
+- Keep CLI command dispatch as simple branching that lets upstream command names be read and traced; do not over-abstract it
+- If creating a distribution zip, include the minimal runtime-user-facing items such as the jar, `README.md`, `LICENSE`, and runtime CLI docs
+- Java main source must observe source / binary `1.8` compatibility, and must not assume newer Java APIs / syntax such as `List.of`, `Map.of`, `record`, `var`, or `Files.readString`
+- Test source should also move toward Java 1.8 assumptions where possible, but final judgment should be checked with Maven compiler settings and CI / runtime environments
+- Java source should have the copyright / SPDX header adopted in that repository
+- Keep the root class as a facade close to the upstream file name, and if the implementation is large, delegate to responsibility classes such as `Public`, `Import`, `Export`, and `Validate`
+- Facade classes should preserve upstream-derived public method names and overloads, and should not expose Java-side helper classes too much to users
+- Even during straight conversion, public APIs touched by external users should be stabilized around root facades, while helper classes may change according to upstream-following work
+- In initial straight conversion, POJOs / result objects / warning objects may be simple classes with public fields
+- Small immutable value objects such as report entries or archive entries may be represented as simple classes with constructors and public final fields
+- Options objects may be nested classes with public fields, and `null` options should be translated into default options at entrypoints
+- For structures where order affects output, such as JSON / reports / workbooks, prefer `LinkedHashMap` / `LinkedHashSet`, and sort explicitly if needed
+- Treat text artifacts as `String` with explicit `UTF-8`
+- Treat binary artifacts as `byte[]`, and push file paths to CLI / test / runtime boundaries
+- Core API return values should directly return `String` / `byte[]` / model for single artifacts, and group warnings / changes / multiple artifacts into result objects
+- Archive artifacts such as zip / xlsx / report bundles should fix determinism so entry names, entry order, timestamps, and bytes do not fluctuate
+- Entry names in report bundles and zips should be fixed user-readable names, and should not include values derived from temporary paths, versions, or the current date
+- When adding text entries to archives, fix final newline presence if needed and include it in byte-level parity comparisons
+- Use fixed zip timestamps if needed, and do not mix current timestamps that interfere with byte-level parity
+- AI-facing prompt / spec markdown should not require users to reference source tree paths; move it toward classpath resources and API / CLI retrieval contracts
+- When using vendor-derived markdown at runtime, copy it to classpath resources at build time so it can be read from inside the JAR
+- Classpath resources should be read in a way that works inside a JAR, such as `getResourceAsStream`, and should not depend on relative paths in a development checkout
+- Prefer upstream `testdata` for fixtures, and make fixture names inferable from test names
+- Test names should make the upstream test intent readable in English, and should include `Upstream` and fixture names if needed
+- Keep focused regression commands in docs, and make them traceable from the changed upstream file / Java class / Java test
+- Allow docs-only updates to skip additional tests, and run target tests only for code changes or regression command updates
+- Include README / docs / CLI help synchronization in tests, and detect mismatches between usage wording and implementation through CLI regression
+- CLI tests should check stdout / stderr / exit code / output files / archive entries to detect mismatches between README / usage and implementation early
+- Accumulate warnings / changes in result objects as records of differences where processing can continue
+- Entry contract violations and inputs that cannot be parsed syntactically should move toward exceptions, not warnings
+- Modes such as `replace` / `merge` / `patch` should be explicit string contracts, and modes that require a base model should be checked at entrypoints
+- Upstream vocabulary that conflicts with Java keywords, such as `import`, should be avoided with minimal changes such as `imports` or an `Import` suffix, and should not be replaced with entirely different vocabulary too much
+- Java-side batch / directory processing should use names easy to distinguish from normal single-input commands, such as `*-batch`, `*-directory`, or `--input-directory`, and should not be mixed into core API responsibilities
+- Even when Java-side original batch commands and diagnostics are convenient, separate them in documentation from the core straight conversion contract
+
+The same idea applies to method names.
+
+- If an upstream function name is `camelCase`, basically keep the Java-side method name unchanged
+- Avoid large Java-convention translations like class names; preserve vocabulary correspondence
+- Static / instance differences, argument grouping, return types, and exception design may be adjusted on the Java side
+- However, do not move central verbs and responsibility names far away from upstream
+
+Examples:
+
+- `importFromXml` -> `importFromXml`
+- `exportToXml` -> `exportToXml`
+- `parseAiJsonText` -> `parseAiJsonText`
+- `importIntoProjectModel` -> `importIntoProjectModel`
+
+## What Was Ported and What Was Excluded
+
+The Java version does not aim to bring in the entire upstream as-is.
+The targets are mainly core / CLI / batch / packaging paths that are natural to handle in a Java runtime.
+
+Main targets:
+
+- domain model
+- codec / import / export
+- validation
+- CLI / batch entrypoint
+- runtime packaging
+- report / artifact / exchange formats that are natural to handle in the Java runtime
+
+Mainly out of scope:
+
+- paths premised on browser / Web UI
+- bringing the GUI itself to the Java side
+- the distribution form itself as a single-file web app
+- browser-specific DOM / preview / event handling
+- helper implementations for UI convenience that are not natural on the Java side
+
+In other words, the upstream semantic structure is received, but the GUI is not brought in, and the runtime environment is translated into Java CLI / jar distribution.
+
+## Things Intentionally Added on the Java Side
+
+Even in `straight conversion`, the Java side adds operationally necessary wrappers and packaging.
+
+Main examples:
+
+- Organization of public entrypoints such as `CoreApi*`
+- Java CLI entrypoint
+- Java-side wrapper module for adding Maven plugin goals
+- API / CLI entrypoints for retrieving AI-facing prompt markdown
+- single fat jar packaging
+- distribution zip packaging depending on the processing target
+- auxiliary paths for Java-side operation, such as batch / directory commands
+
+These are not mixed as the same responsibility as the upstream body; they are treated separately as `Java-side original extensions`.
+
+In addition to the CLI runtime, Java-side execution paths such as Maven plugins may be considered first-class, high-priority paths for CLI / batch conversion tools.
+Especially for tools that fit naturally into a build process, such as artifact generation, validation, conversion, and index creation, Maven plugin support is highly worth considering.
+
+In that case, a multi-module Maven reactor repository structure may be used.
+
+- The repository root is an aggregator parent `pom`
+- In principle, do not place `src/main/java` or `src/test/java` under the aggregator root
+- Runtime jar implementation is under `<repo>/<runtime-module>/src/...`
+- Maven plugin implementation is under `<repo>/<plugin-module>/src/...`
+- Shared core contracts should live in the runtime module or core module, and should not flow backward into the plugin module
+- Directory / batch processing used by both CLI and Maven plugin should live in the runtime module or a core-adjacent runtime helper, not in the plugin module
+
+At this time, it is not a problem that Java source becomes one level deeper than the repository root.
+The important points are that the reason for multi-module structure can be explained as `separation of Java-side original extensions` and `reuse of shared core API`, and that README / mapping / regression docs follow that structure.
+
+Directory / batch processing is especially valuable in Java in practical terms.
+Maven plugins often need to process multiple files as part of a build process, and even in CLI usage, considering JVM startup cost, batch processing can be more natural than starting a Java process for each file.
+However, this is not the core specification of upstream straight conversion; treat it as added value for Java-side execution paths.
+
+Design notes:
+
+- Preserve the single-file conversion core API as-is, and place directory / batch processing in a runtime helper that repeatedly calls it
+- If CLI and Maven plugin both provide the same directory / batch specification, reuse the same helper and do not confine the processing specification only to the plugin side
+- When input directory and output directory are part of the contract, decide whether output may be placed beside the input when no output destination is specified only after confirming generated artifacts will not become inputs again
+- Limit directory search targets to explicit input extensions, and do not include generated artifacts or temporary files
+- Use `false` as the conservative default for recursive processing; when recursion is enabled, preserve relative directory structure to avoid output collisions
+- If an option for single-file input, such as archive / zip output, is ambiguous in directory mode, forbid it
+- Explicitly reject conflicting options such as `inputDirectory` and `outputFile` at the entrypoint
+- Explain the same constraints in CLI help, README, Maven plugin parameter docs, and regression docs
+
+## Naming When Adding a Maven Plugin
+
+When adding a Maven plugin as a Java-side original extension, align the artifact name, prefix, and goal name at the beginning.
+Maven has its own conventions here, and fixing these later tends to widen the range of user-facing command and README changes.
+
+Basic policy:
+
+- Use the normal reverse-domain style for `groupId`
+- Prefer `${prefix}-maven-plugin` for the plugin artifactId as a third-party plugin convention
+- Do not choose `maven-${prefix}-plugin` for normal miku Java versions, because that form follows Apache Maven official plugin conventions
+- Align the command prefix desired for short-form usage with the artifactId
+- Explicitly set the prefix with `goalPrefix` in `maven-plugin-plugin` if needed
+- Make goal names short and descriptive of the processing content
+- Treat plugin version as something specified explicitly in the consuming `pom.xml`
+
+For example, if the artifactId is `miku-indexgen-maven-plugin`, the prefix is `miku-indexgen`; if the goal is `index`, the short form becomes `mvn miku-indexgen:index`.
+
+However, even if artifactId and `goalPrefix` are correct, short form is not always resolved.
+If the user's Maven cannot search that plugin group for prefix resolution, specifying full coordinates is more reliable.
+Especially for third-party plugins, `mvn ${prefix}:${goal}` can fail unless the plugin group is included in the user's `settings.xml` or project configuration.
+Therefore, README and development docs should describe `an execution example that reliably passes with full coordinates` separately from `preconditions for short form to pass`.
+
+Parameter naming should also be fixed in the early stage.
+
+- Move plugin parameter names toward the vocabulary of upstream CLI options and core options objects
+- Do not replace semantic vocabulary too much just because it is Maven-side
+- Make list / collection parameters explainable in terms of correspondence between XML element names and Java field names
+- Align plugin parameter defaults with README / plugin help / core defaults
+- When adding directory / batch goals, use the same vocabulary as Java-original CLI options and preserve semantic correspondence such as `inputDirectory`, `outputDirectory`, and `recursive`
+- If a parameter cannot be used mutually between directory / batch goals and single-file goals, reject it explicitly at plugin execution and write the constraint in README
+
+Findings:
+
+- Plugin naming is not just appearance; it directly affects prefix resolution and user-facing commands
+- If `artifactId`, `goalPrefix`, and `goal` drift apart, README and execution method explanations tend to become hard to understand
+- Whether short form succeeds depends not only on naming but also on plugin group resolution settings
+- If parameter names use different vocabulary in CLI and Maven plugin, synchronization cost increases across README, help, tests, and adapter implementation
+- If the main target of straight conversion is CLI / batch / report work and it naturally fits into a build process, plugin naming should be fixed early
+- If the same directory / batch feature exists in both CLI and Maven plugin, keep the plugin goal as a thin adapter, and fix traversal, relative path resolution, output name decisions, and repeated conversion in runtime helper tests
+
+## CLI Handling
+
+When moving an upstream that has a CLI to Java, the Java-side CLI should respect the Node CLI interface as much as possible.
+
+Important points are as follows.
+
+- Bring command names and subcommand structure close enough that upstream descriptions and usage markdown can reuse the same wording
+- Bring option names and argument order as close as possible to upstream
+- Do not break text / json / binary output contracts
+- Keep diagnostics and usage error categories traceable
+- Provide AI-facing prompt markdown as a CLI / API retrieval contract, not as source file references
+
+However, the following may be added for Java-side operational convenience.
+
+- batch command
+- directory input option
+- Maven plugin goal
+- minimal startup method differences for fat jar execution
+- auxiliary diagnostics that match Java runtime / file APIs
+
+Even in this case, keep the upstream CLI body contract separate from Java-side original extensions, and preserve the ability to explain where the added part begins.
+
+Findings:
+
+- If the CLI contract is vague at the beginning, synchronization cost for help / README / tests / diagnostics tends to increase later
+- For CLIs that naturally fit into a build process, providing a Maven plugin often greatly improves practicality for Java users
+- Java-side original batch / directory commands are convenient, but mixing them with upstream straight conversion easily breaks the upstream-following unit
+- Because JVM startup cost exists, it is reasonable for Java CLI to provide directory / batch processing even apart from Maven plugins
+- In directory mode, allowing `outputFile` or archive options from single-file mode as-is often makes meaning ambiguous, so mutual exclusion should be fixed in entrypoint validation
+- Maintenance is easier when `core contract` and `Java-side operational extensions` are treated separately
+
+## Operational Decisions Reflected Back into Documents
+
+Straight conversion is not complete with the initial policy alone.
+For this reason, update this document each time straight conversion is applied, and try to reduce the amount of operational judgment that must be fixed individually along the way.
+
+- Fix upstream diff check units by `upstream file`
+- Fix `upstream file -> Java class -> Java test` correspondence in documents
+- Distinguish docs-only updates and code changes operationally
+- Manage Java-side original extensions separately by categories such as `batch command`, packaging, and diagnostics
+- For major artifacts, use byte-level parity in addition to semantic comparison
+- Fix determinism with tests so the same input produces the same output
+- In the maintenance phase, prioritize checking existing implementation and following upstream diffs over adding new features
+
+Byte-level parity is especially worth explicitly adopting as a quality criterion along the way.
+When text / json / xml / zip / xlsx / report artifacts can be compared down to bytes, implicit specifications such as ordering, line endings, entry names, default value completion, and incidental metadata become easier to see.
+This suppresses unconscious Java-side redesign or formatting differences, and makes differences from upstream easier to discuss concretely.
+
+Findings:
+
+- Byte-level parity does not need to be applied everywhere from the beginning, but it is highly worth applying early to final artifacts such as reports and archives
+- Instead of demanding the same strictness for all outputs at once, it is easier to expand gradually from artifacts where comparison has high value
+
+## Core API Boundary
+
+In straight conversion, fix the boundary between core API and CLI / runtime API early.
+
+Important points are as follows.
+
+- Core packages should not depend on file system APIs such as file paths or `Files`
+- Text documents should use `String` as the canonical representation
+- Binary artifacts should use `byte[]` as the canonical representation
+- Core APIs should not write directly to standard I/O, and should return model / result object / `String` / `byte[]`
+- APIs that return only a single artifact should directly return `String` or `byte[]`; APIs that need warnings / changes / multiple artifacts / metadata should return result objects
+- User-facing documents such as AI-facing prompt markdown should also be treated as artifacts retrievable via API / CLI, not as source tree file path references
+- `InputStream` / `OutputStream` are mainly used for internal implementation or runtime boundaries
+- File read / write and bridging to standard I/O should be pushed to the CLI layer
+- CLI should emit normal output and artifact bodies to stdout or output files, and diagnostics / usage errors / progress to stderr
+- Java CLI / Maven plugins that process long-running or multiple-file work should provide verbose / progress diagnostics that reveal the file being processed
+- Binary artifacts should be written to output files in principle; if stdout is used, state it as a command contract
+- Stdin input should be limited to things compatible with streams, such as text / json, and file path arguments should be preferred for binary or multiple-input-file processing
+
+If this boundary is vague, core implementation becomes pulled by Java runtime convenience, and the correspondence with upstream responsibilities becomes harder to see.
+
+Findings:
+
+- Using `String` and `byte[]` as canonical representations, and pushing file paths and streams to boundaries, tends to work well
+- When core starts holding `Path` or `Files`, CLI convenience fixes tend to flow backward into core
+- Fixing stdout / stderr usage makes it easier for CLI tests to check normal output and diagnostics separately
+- Verbose / progress diagnostics are easier to handle when they are not mixed into core output contracts, but are confined to stderr in CLI and Maven logs in Maven plugins
+
+## Holding Values
+
+How the internal model represents the presence or absence of values should also not fluctuate midstream.
+
+Basic policy:
+
+- Use `null` as the internal representation of `no value`
+- Empty strings may be kept if needed, but may also be normalized to `null` at entrypoints
+- Use `0` only when it is a valid value, and do not use it as a substitute for `no value`
+- Do not bring values substituted for report or CLI display convenience directly into the internal canonical representation
+
+The important point is to avoid confusing `blank` / `null` / `0`.
+
+Findings:
+
+- This policy generally works well
+- Especially in workbook import and report display, it becomes easier to separate missing input from valid value `0`
+- On the other hand, XML import entrypoints and human-facing output require local rules, so the whole system cannot be simplified uniformly
+- Therefore, the practical organization is `do not confuse values in the internal canonical representation` and `allow local conversion at input and display boundaries`
+
+## Returning Exceptions and Warnings
+
+It is easier to stay consistent if `parse` / `import` / `validate` return behavior is fixed as a shared principle.
+
+Basic division:
+
+- Entry contract violation
+  - Return as an exception
+- Semantic validation problem
+  - Return as an issue / warning
+- Local difference where processing can continue
+  - Accumulate in result warnings or changes
+
+Deciding this line first makes it easier to keep Java APIs consistent about what they throw and what they demote to warnings.
+Separate diagnostic granularity by layer.
+CLI returns user-facing messages and exit codes, core API aggregates into exceptions or result objects, and tests fix them as expected differences.
+This separation makes it harder for human-facing display convenience to flow backward into core exception design or internal models.
+
+Findings:
+
+- Without this line, the same kind of inconsistency easily splits into throw in one API and warning in another
+- Separating `entry contract violation` from `semantic validation` alone tends to stabilize CLI diagnostics considerably
+
+## Handling Options Objects
+
+Decide early how to represent Node.js upstream options objects in Java.
+
+Basic policy:
+
+- Do not make the builder pattern mandatory in initial porting
+- Do not move too far toward JavaBeans; prioritize field names that make upstream option names and meanings easy to trace
+- `overload without options` and `overload with options` may coexist
+- Preserve correspondence with upstream instead of replacing option names with Java-side original vocabulary
+
+Findings:
+
+- Adding too many builders or abstract request classes during initial porting tends to obscure correspondence with upstream option objects
+- It is easier to preserve upstream-following ability by first porting with simple POJOs and reorganizing later if needed
+
+## Library Policy
+
+Java has many convenient libraries, but straight conversion does not prioritize replacing things merely because it is convenient.
+
+Decision criteria:
+
+1. Whether upstream uses an external library
+2. Whether upstream has a scratch implementation
+3. Whether a Java-side library fits well enough
+4. Whether it is maintainable under target Java compatibility
+5. Whether it preserves upstream-following ability
+
+For this reason, miku-series Java versions often tend to implement from scratch instead of forcing library usage.
+For locations where upstream has a scratch implementation, following the same structure and logic on the Java side first makes diff comparison easier.
+For example, even in areas such as xlsx where Apache POI comes to mind easily, if the required range of generation / reading / validation is limited and byte-level parity or upstream-following ability is prioritized, choosing scratch implementation without even using POI is acceptable.
+
+Findings:
+
+- Even if Java has a convenient existing library, replacing early tends to make the work closer to `reimplementation` than `porting`
+- On the other hand, where upstream uses an external library, considering a corresponding Java library is often natural
+
+## Docs and Upstream-Following Operation
+
+Straight conversion has shared principles not only for implementation but also for upstream-following operation.
+
+Important points are as follows.
+
+- Fix `upstream file -> Java class -> Java test` correspondence in documents
+- Record diff check results by `upstream file`
+- Distinguish docs-only updates and code changes operationally
+- Prepare focused regressions that can be executed according to the change unit
+- Keep a location for communication items when upstream bugs are found
+- Keep shared principles and decision criteria in this guide; make README and development docs the canonical source for repository-specific current values, artifact names, and execution examples
+
+For docs-only updates, it is effective to avoid additional tests in principle, and check target units only for code changes or regression command updates.
+In repositories that introduce Maven plugins, at least the following may be kept as the minimal check set.
+
+1. `mvn test`
+2. `mvn package`
+3. Maven plugin smoke execution with full coordinates
+
+Because short-form smoke depends on plugin group resolution settings, it may be treated separately from the permanent minimal check set.
+
+When an upstream bug is found, handle it in the following order in principle.
+
+1. Record it as a communication item for upstream
+2. Leave enough information to identify the related upstream file / responsibility
+3. Do not stop Java-side straight conversion itself; continue as-is
+4. If adding a temporary workaround on the Java side, record that it is caused by an upstream bug
+
+Findings:
+
+- If the Java-side design is changed immediately every time an upstream bug is found, the work tends to move toward original fixes rather than straight conversion
+- Recording first and porting first is better for preserving upstream-following ability
+
+## Artifacts to Keep
+
+To make straight conversion reproducible, keep not only code but also the following artifacts.
+
+- repository top README
+- straight conversion guide
+- remaining items / current status document
+- `upstream file -> Java class` mapping
+- `upstream test intent -> Java test` mapping
+- follow-up log
+- focused regression command list
+- CLI help / usage contract
+- AI-facing prompt markdown API / CLI retrieval contract
+- fixture / parity / determinism tests
+
+When these are in place, another person can join midway and resume porting and upstream-following work at the same granularity.
+
+## Completion Criteria
+
+To treat the initial stage of straight conversion as complete, it should satisfy at least the following.
+
+- Main core paths work on the Java side
+- Minimal round-trip works
+- `upstream file -> Java class` mapping table exists
+- `upstream test intent -> Java test` mapping table exists
+- focused regression commands exist
+- If a CLI exists, contracts for main commands / options / diagnostics are fixed
+- The follow-up log contains at least several concrete `upstream file` examples
+- Determinism has been confirmed for major artifacts
+- Byte-level parity has been confirmed for artifacts with high comparison value, or the reason for not applying it has been documented
+
+The important point is not just that the code works, but that upstream-following ability and verification units remain.
+
+## Example Plan for the First Week
+
+### Day 1
+
+- Fix target Java compatibility, build tool, test framework, primary test entrypoint, and single fat jar packaging
+- Confirm whether the processing target needs a distribution zip
+- Create `workplace/` at the repository root and track only `.gitkeep` in Git
+- Start inventorying upstream files / tests / fixtures / CLI
+- Write the basic policy in README
+
+### Day 2
+
+- Create the first version of `upstream file -> Java class`
+- Create the first version of `upstream test intent -> Java test`
+- Decide the minimal core target
+
+### Day 3
+
+- Implement the domain model and minimal codec
+- Pass the minimal round-trip test
+
+### Day 4
+
+- Add validation and main fixture import
+- Decide the minimal focused regression unit
+
+### Day 5
+
+- Create the CLI entrypoint
+- Fix the help / usage / diagnostics contract with tests
+
+### Day 6
+
+- Implement high-comparison-value report / artifact items
+- Fix determinism with tests
+
+### Day 7
+
+- Start comparison from artifacts where byte-level parity can be introduced
+- Organize remaining items and follow-up log
+- Separate docs-only and code-change operation
+
+Findings:
+
+- Requiring tests every time even for docs-only updates tends to slow document maintenance
+- Instead, fixing the canonical focused regression commands in documents makes it easier to choose the necessary check units for code changes
+
+## Improving Quality
+
+In straight conversion, explainable upstream correspondence and output equivalence are more important than writing Java-side implementation that merely looks plausible.
+
+The verification pillars are as follows.
+
+- `docs/upstream-class-mapping.md`
+  - Fixes `upstream file -> Java class` correspondence
+- `docs/upstream-test-mapping.md`
+  - Fixes `upstream test intent -> Java test` correspondence
+- `docs/upstream-followup-log.md`
+  - Records diff check results by `upstream file`
+
+In addition, for artifacts such as text / json / xml / zip / xlsx / report artifacts, use byte-level comparison in addition to semantic comparison.
+
+This verification has the following effects.
+
+- Implicit specifications such as ordering, line endings, entry names, and default value completion become visible
+- It becomes easier to suppress unconscious Java-side redesign or formatting differences
+- Upstream differences become easier to discuss concretely in terms of `what differs`
+- It becomes easier to fix determinism so the same input produces the same output
+
+## Handling in the Maintenance Phase
+
+After passing the initial straight conversion implementation and having the main Java-side paths in place, treat the work as the maintenance phase.
+
+However, the basic stance does not change even at this stage.
+
+- Prioritize checking existing implementation and following upstream diffs over adding new features
+- Before proceeding with Java-side original cleanup, keep mapping tables, tests, and follow-up logs consistent
+- When upstream is updated, check by `upstream file`
+
+In particular, do not mix new features while straight conversion is in progress.
+Needed new features or Java-side original value should be handled on a separate track after the main straight conversion paths are in place and the upstream-following units and verification units have been fixed.
+
+For this reason, it is appropriate to describe this porting work not as `work to rebuild for Java`, but as `work to map Node.js / TypeScript upstream into Java while keeping it trackable, then maintain its equivalence`.
+
+## Application Example in This Repository
+
+In this repository, the shared principles above are applied to `mikuproject`.
+
+- upstream:
+  - `vendor/mikuproject/src/ts/*.ts`
+- main Java-side responsibilities:
+  - `MS Project XML`
+  - `ProjectModel`
+  - validation
+  - workbook JSON / XLSX
+  - patch / AI JSON
+  - report (`Markdown`, `SVG`, `WBS XLSX`, `Mermaid`)
+  - CLI entrypoint
+- representative Java-side original extensions:
+  - `CoreApi*`
+  - `MikuprojectCli`
+  - single fat jar packaging
+  - distribution zip packaging depending on the processing target
+
+When shared principles are fixed first and repository-specific application examples are placed under them, the same approach becomes easier to reuse in other miku-series projects.
+
+Environment premises fixed in this repository:
+
+- target Java compatibility:
+  - source / binary compatibility with `1.8`
+  - the actual compiler is not limited to `JDK 1.8`
+- build tool:
+  - `Maven`
+- test framework:
+  - `JUnit Jupiter 5.14.1`
+- primary test entrypoint:
+  - `mvn test`
+- runtime packaging:
+  - single fat jar fixed (`target/mikuproject.jar`)
+  - distribution zip added depending on the processing target (`target/mikuproject-dist.zip`)
+
+For progress, remaining items, and the latest check results in this repository, treat `README.md`, `docs/remaining-migration-items.md`, `docs/upstream-class-mapping.md`, `docs/upstream-test-mapping.md`, and `docs/upstream-followup-log.md` as canonical, not this application example.


### PR DESCRIPTION
## 概要

mikuシリーズの設計方針を整理したドキュメントを追加しました。

## 変更内容

- `docs/miku-soft-10-mainapp-design-v20260425.md` を追加
  - mikuシリーズのメインアプリケーションに共通する設計方針、推奨規約、製品別メモを整理
- `docs/miku-soft-20-javaapp-design-v20260425.md` を追加
  - mikuシリーズのJavaアプリケーション版に求められる設計方針、CLI/Maven/パッケージング/テスト方針を整理
- `docs/miku-soft-30-straight-conversion-v20260425.md` を追加
  - Node.js / TypeScript upstream から Java へ straight conversion する際の方針と手順を整理

## 補足

- 変更はドキュメント追加のみです。
- 追加行数は合計 2911 行です。