### PR TITLE
CLI のバージョン出力と source archive 生成を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Node 側から `core API` を起動する最小 helper は [`scripts/lib/core-ap
 Node 側から `core API` を薄く包む最小 CLI first cut として、次の入口を追加している。
 
 - `mikuproject ai spec`
+- `mikuproject --version`
 - `mikuproject ai export project-overview`
 - `mikuproject ai export task-edit`
 - `mikuproject ai export phase-detail`
@@ -210,6 +211,7 @@ Node 側から `core API` を薄く包む最小 CLI first cut として、次の
 例:
 
 ```bash
+mikuproject --version
 mikuproject ai spec
 mikuproject ai export project-overview --in workbook.json --out overview.editjson
 mikuproject ai export task-edit --in workbook.json --task-uid 123 --out task.editjson
@@ -242,8 +244,9 @@ mikuproject report mermaid --in workbook.json --out project.mmd
 npm run build:cli-bundle
 ```
 
-既定の出力先は `bundle/mikuproject.mjs` である。
+既定の出力先は `bundle/mikuproject.mjs` と `bundle/mikuproject-sources.tgz` である。
 この artifact には、CLI entrypoint、`core API` 実行に必要な `src/js` runtime、XML DOM 実装を含めている。
+`mikuproject-sources.tgz` には、再ビルド・監査・下流確認用の source / docs / tests をまとめて格納する。
 
 生成後は追加の `npm install` なしで、そのまま CLI 実行に使える。たとえば次で動く。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -189,7 +189,7 @@ npm run build:full
 - `npm run build:js`: `src/ts/` から `src/js/` を生成する
 - `npm run build:html`: `index-src.html` と `mikuproject-src.html` から `index.html` と `mikuproject.html` を生成する
 - `npm run build:web`: JavaScript 生成と HTML 生成をまとめて行う
-- `npm run build:cli-bundle`: 下流 Agent Skills に渡す単一 `MJS` CLI runtime artifact を `bundle/mikuproject.mjs` へ生成する
+- `npm run build:cli-bundle`: 下流 Agent Skills に渡す単一 `MJS` CLI runtime artifact を `bundle/mikuproject.mjs` へ生成し、再ビルド・監査用 source archive を `bundle/mikuproject-sources.tgz` へ生成する
 - `npm run build:xlsx-sample`: `local-data/` 配下へサンプル XLSX / Markdown を生成する
 - `npm run build:app`: `build:web` と `build:xlsx-sample` を順に実行する
 - `npm run build:full`: `build:web`、`build:cli-bundle`、`test:full` を順に実行する

--- a/docs/core-api-import-export-notes.md
+++ b/docs/core-api-import-export-notes.md
@@ -195,14 +195,16 @@ first cut の候補は次とする。
 
 ## Node.js CLI runtime artifact
 
-`npm run build:cli-bundle` は、下流 Agent Skills に渡す Node.js CLI runtime artifact として、単一 `MJS` ファイルを生成する。
+`npm run build:cli-bundle` は、下流 Agent Skills に渡す Node.js CLI runtime artifact として、単一 `MJS` ファイルと source archive を生成する。
 
 既定の出力先は次のとおり。
 
 ```text
 bundle/mikuproject.mjs
+bundle/mikuproject-sources.tgz
 ```
 
 この artifact は、`scripts/mikuproject-cli.mjs` 相当の CLI entrypoint、`core API` 実行に必要な `src/js` runtime、XML DOM 実装を 1 ファイルに埋め込む。生成後の実行時には、従来の `bundle/mikuproject-cli-bundle/` ディレクトリや `node_modules` を同梱しない。
+`mikuproject-sources.tgz` は実行には不要だが、受け取り側が source / docs / tests を確認し、必要に応じて再ビルドや監査を行うための補助 artifact として扱う。
 
 `mikuproject-skills` 側では、この artifact を `skills/mikuproject/runtime/mikuproject.mjs` のような skill-local runtime path に配置して呼び出す想定である。

--- a/docs/development.md
+++ b/docs/development.md
@@ -20,7 +20,7 @@ npm test
 ```
 
 - `npm run build` は日常開発向けの標準 build で、`build:web`、`build:cli-bundle`、`test:fast` を順に実行する
-- `build:cli-bundle` は、下流 Agent Skills に渡す単一 `MJS` CLI runtime artifact を `bundle/mikuproject.mjs` に生成する
+- `build:cli-bundle` は、下流 Agent Skills に渡す単一 `MJS` CLI runtime artifact を `bundle/mikuproject.mjs` に生成し、再ビルド・監査用 source archive を `bundle/mikuproject-sources.tgz` に生成する
 - `npm run build:app` は `build:web` と `build:xlsx-sample` を順に実行する
 - `npm run build:full` は `build:web`、`build:cli-bundle`、`test:full` を順に実行し、日常で見たい core UI smoke suite までを確認する
 - `build:xlsx-sample` は必要なときだけ `build:app` か `npm run build:xlsx-sample` で明示実行する

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mikuproject",
-  "version": "0.1.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mikuproject",
-      "version": "0.1.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mikuproject",
-  "version": "0.1.0",
+  "version": "0.8.0",
   "private": true,
   "description": "Local HTML tool for MS Project XML round-trip experiments.",
   "license": "Apache-2.0",

--- a/scripts/build-cli-bundle.mjs
+++ b/scripts/build-cli-bundle.mjs
@@ -1,9 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
+import zlib from "node:zlib";
 
 const ROOT = process.cwd();
 const args = parseArgs(process.argv.slice(2));
 const outFile = path.resolve(args.out || path.join(ROOT, "bundle", "mikuproject.mjs"));
+const sourcesOutFile = path.resolve(args["sources-out"] || path.join(path.dirname(outFile), "mikuproject-sources.tgz"));
 const CORE_API_MODULE_RELATIVE_PATHS = readCoreApiModuleRelativePaths();
 
 const XMLDOM_MODULE_RELATIVE_PATHS = [
@@ -15,6 +17,26 @@ const XMLDOM_MODULE_RELATIVE_PATHS = [
   "node_modules/@xmldom/xmldom/lib/index.js"
 ];
 
+const SOURCE_ARCHIVE_ROOT = "mikuproject-sources";
+const SOURCE_ARCHIVE_PATHS = [
+  "package.json",
+  "package-lock.json",
+  "README.md",
+  "LICENSE",
+  "THIRD-PARTY-NOTICES.md",
+  "CONTRIBUTING.md",
+  "CONTRIBUTORS.md",
+  "CODE_OF_CONDUCT.md",
+  "index-src.html",
+  "mikuproject-src.html",
+  "docs",
+  "lht-cmn",
+  "scripts",
+  "src",
+  "testdata",
+  "tests"
+];
+
 buildCliBundle();
 
 function buildCliBundle() {
@@ -23,6 +45,9 @@ function buildCliBundle() {
   fs.writeFileSync(outFile, buildSingleMjsRuntime(), "utf8");
   fs.chmodSync(outFile, 0o755);
   console.log(`[build:cli-bundle] generated ${path.relative(ROOT, outFile)}`);
+  fs.mkdirSync(path.dirname(sourcesOutFile), { recursive: true });
+  fs.writeFileSync(sourcesOutFile, buildSourcesTgz());
+  console.log(`[build:cli-bundle] generated ${path.relative(ROOT, sourcesOutFile)}`);
 }
 
 function parseArgs(argv) {
@@ -55,9 +80,15 @@ function assertRequiredFilesExist() {
       throw new Error(`CLI bundle に必要なファイルが見つかりません: ${relativePath}`);
     }
   }
+  for (const relativePath of SOURCE_ARCHIVE_PATHS) {
+    if (!fs.existsSync(path.resolve(ROOT, relativePath))) {
+      throw new Error(`source archive に必要なパスが見つかりません: ${relativePath}`);
+    }
+  }
 }
 
 function buildSingleMjsRuntime() {
+  const packageJson = JSON.parse(readRepoFile("package.json"));
   const cliSource = stripCliImports(readRepoFile("scripts/mikuproject-cli.mjs"));
   const coreModuleSources = Object.fromEntries(
     CORE_API_MODULE_RELATIVE_PATHS.map((relativePath) => [relativePath, readRepoFile(relativePath)])
@@ -76,6 +107,8 @@ function buildSingleMjsRuntime() {
     "import path from \"node:path\";",
     "import { fileURLToPath } from \"node:url\";",
     "import { Blob as NodeBlob, File as NodeFile } from \"node:buffer\";",
+    "",
+    `const BUNDLED_PACKAGE_VERSION = ${JSON.stringify(packageJson.version || "unknown")};`,
     "",
     "const BUNDLED_CORE_API_MODULE_RELATIVE_PATHS = Object.freeze(",
     `${JSON.stringify(CORE_API_MODULE_RELATIVE_PATHS, null, 2)});`,
@@ -264,6 +297,126 @@ function toXmldomModuleId(relativePath) {
     throw new Error(`Unexpected xmldom path: ${relativePath}`);
   }
   return `/node_modules/@xmldom/xmldom/${relativePath.slice(prefix.length)}`;
+}
+
+function buildSourcesTgz() {
+  const tarParts = [];
+  for (const sourcePath of collectSourceArchiveFiles()) {
+    const absolutePath = path.resolve(ROOT, sourcePath);
+    const archivePath = path.posix.join(SOURCE_ARCHIVE_ROOT, toPosixPath(sourcePath));
+    const data = fs.readFileSync(absolutePath);
+    tarParts.push(buildTarFileEntry(archivePath, data, getArchiveMode(absolutePath)));
+  }
+  tarParts.push(Buffer.alloc(1024));
+  return zlib.gzipSync(Buffer.concat(tarParts), { level: 9, mtime: 0 });
+}
+
+function collectSourceArchiveFiles() {
+  const files = [];
+  for (const relativePath of SOURCE_ARCHIVE_PATHS) {
+    const absolutePath = path.resolve(ROOT, relativePath);
+    const stat = fs.statSync(absolutePath);
+    if (stat.isDirectory()) {
+      collectFilesRecursive(relativePath, files);
+      continue;
+    }
+    if (stat.isFile()) {
+      files.push(relativePath);
+    }
+  }
+  return files.sort((a, b) => a.localeCompare(b));
+}
+
+function collectFilesRecursive(relativeDir, files) {
+  const absoluteDir = path.resolve(ROOT, relativeDir);
+  const entries = fs.readdirSync(absoluteDir, { withFileTypes: true })
+    .sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    const relativePath = path.join(relativeDir, entry.name);
+    if (entry.name === ".DS_Store") {
+      continue;
+    }
+    if (entry.isDirectory()) {
+      collectFilesRecursive(relativePath, files);
+      continue;
+    }
+    if (entry.isFile()) {
+      files.push(relativePath);
+    }
+  }
+}
+
+function buildTarFileEntry(name, data, mode) {
+  const header = Buffer.alloc(512);
+  const { namePart, prefixPart } = splitTarPath(name);
+  writeTarString(header, namePart, 0, 100);
+  writeTarOctal(header, mode, 100, 8);
+  writeTarOctal(header, 0, 108, 8);
+  writeTarOctal(header, 0, 116, 8);
+  writeTarOctal(header, data.length, 124, 12);
+  writeTarOctal(header, 0, 136, 12);
+  header.fill(0x20, 148, 156);
+  header[156] = "0".charCodeAt(0);
+  writeTarString(header, "ustar", 257, 6);
+  writeTarString(header, "00", 263, 2);
+  writeTarString(header, "mikuproject", 265, 32);
+  writeTarString(header, "mikuproject", 297, 32);
+  writeTarString(header, prefixPart, 345, 155);
+
+  let checksum = 0;
+  for (const byte of header) {
+    checksum += byte;
+  }
+  writeTarChecksum(header, checksum);
+
+  const paddingLength = (512 - (data.length % 512)) % 512;
+  return Buffer.concat([header, data, Buffer.alloc(paddingLength)]);
+}
+
+function splitTarPath(name) {
+  const nameBytes = Buffer.byteLength(name);
+  if (nameBytes <= 100) {
+    return { namePart: name, prefixPart: "" };
+  }
+
+  const parts = name.split("/");
+  for (let index = 1; index < parts.length; index += 1) {
+    const prefixPart = parts.slice(0, index).join("/");
+    const namePart = parts.slice(index).join("/");
+    if (Buffer.byteLength(prefixPart) <= 155 && Buffer.byteLength(namePart) <= 100) {
+      return { namePart, prefixPart };
+    }
+  }
+  throw new Error(`tar path が長すぎます: ${name}`);
+}
+
+function writeTarString(buffer, value, offset, length) {
+  const written = buffer.write(value, offset, length, "utf8");
+  if (written < length) {
+    buffer[offset + written] = 0;
+  }
+}
+
+function writeTarOctal(buffer, value, offset, length) {
+  const text = value.toString(8).padStart(length - 1, "0");
+  buffer.write(text.slice(-length + 1), offset, length - 1, "ascii");
+  buffer[offset + length - 1] = 0;
+}
+
+function writeTarChecksum(buffer, checksum) {
+  const text = checksum.toString(8).padStart(6, "0");
+  buffer.write(text.slice(-6), 148, 6, "ascii");
+  buffer[154] = 0;
+  buffer[155] = 0x20;
+}
+
+function getArchiveMode(absolutePath) {
+  const stat = fs.statSync(absolutePath);
+  return stat.mode & 0o111 ? 0o755 : 0o644;
+}
+
+function toPosixPath(relativePath) {
+  return relativePath.split(path.sep).join("/");
 }
 
 function readRepoFile(relativePath) {

--- a/scripts/mikuproject-cli.mjs
+++ b/scripts/mikuproject-cli.mjs
@@ -32,6 +32,10 @@ class CliProcessingError extends Error {
 async function main() {
   const rawArgv = process.argv.slice(2);
   const { command, options } = parseArgs(rawArgv);
+  if (options.version) {
+    process.stdout.write(`mikuproject ${getCliVersion()}\n`);
+    return;
+  }
   if (options.help || command.length === 0) {
     writeHelp(process.stdout);
     return;
@@ -70,6 +74,10 @@ function parseArgs(argv) {
       options.help = true;
       continue;
     }
+    if (key === "version") {
+      options.version = true;
+      continue;
+    }
 
     const value = argv[index + 1];
     if (value === undefined || value.startsWith("--")) {
@@ -82,6 +90,21 @@ function parseArgs(argv) {
   }
 
   return { command, options };
+}
+
+function getCliVersion() {
+  if (typeof BUNDLED_PACKAGE_VERSION === "string" && BUNDLED_PACKAGE_VERSION) {
+    return BUNDLED_PACKAGE_VERSION;
+  }
+  try {
+    const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+    if (typeof packageJson.version === "string" && packageJson.version) {
+      return packageJson.version;
+    }
+  } catch {
+    // Fall through to an explicit unknown marker when package metadata is unavailable.
+  }
+  return "unknown";
 }
 
 async function runCommand(command, options, api) {
@@ -1145,6 +1168,7 @@ function writeOutput(output, outPath) {
 function writeHelp(stream) {
   stream.write([
     "Usage:",
+    "  mikuproject --version",
     "  mikuproject ai spec",
     "  mikuproject ai export project-overview [--in workbook.json|-] [--diagnostics text|json] [--out overview.editjson|-]",
     "  mikuproject ai export task-edit [--in workbook.json|-] [--task-uid 123] [--select auto|first-task|uid] [--diagnostics text|json] [--out task.editjson|-]",

--- a/tests/mikuproject-cli.test.js
+++ b/tests/mikuproject-cli.test.js
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
+import { gunzipSync } from "node:zlib";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -15,6 +16,7 @@ const cliPath = path.resolve(repoRoot, "scripts/mikuproject-cli.mjs");
 const cliBundleBuildPath = path.resolve(repoRoot, "scripts/build-cli-bundle.mjs");
 const cliAiWorkflowExamplePath = path.resolve(repoRoot, "scripts/cli-ai-workflow-example.mjs");
 const cliAiStdioExamplePath = path.resolve(repoRoot, "scripts/cli-ai-stdio-example.mjs");
+const packageVersion = JSON.parse(readFileSync(path.resolve(repoRoot, "package.json"), "utf8")).version;
 
 const tempDirs = [];
 const disposers = [];
@@ -41,6 +43,7 @@ describe("mikuproject cli", () => {
     const result = runCli(["--help"]);
 
     expect(result.status).toBe(0);
+    expect(result.stdout).toContain("mikuproject --version");
     expect(result.stdout).toContain("mikuproject ai export project-overview");
     expect(result.stdout).toContain("mikuproject ai export task-edit");
     expect(result.stdout).toContain("mikuproject ai export phase-detail");
@@ -51,6 +54,14 @@ describe("mikuproject cli", () => {
     expect(result.stdout).toContain("mikuproject ai validate-patch");
     expect(result.stdout).toContain("mikuproject state summarize");
     expect(result.stdout).toContain("mikuproject state diff");
+  });
+
+  it("prints the cli version", () => {
+    const result = runCli(["--version"]);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe(`mikuproject ${packageVersion}\n`);
+    expect(result.stderr).toBe("");
   });
 
   it("creates workbook json from project_draft_view", () => {
@@ -889,6 +900,7 @@ describe("mikuproject cli", () => {
 
   it("builds a single-file cli runtime artifact that runs outside the repo", () => {
     const bundlePath = path.join(createTempDir("mikuproject-cli-bundle-test-"), "mikuproject.mjs");
+    const sourcesPath = path.join(path.dirname(bundlePath), "mikuproject-sources.tgz");
     const buildResult = spawnSync(process.execPath, [cliBundleBuildPath, "--out", bundlePath], {
       cwd: repoRoot,
       encoding: "utf8"
@@ -896,6 +908,18 @@ describe("mikuproject cli", () => {
 
     expect(buildResult.status).toBe(0);
     expect(existsSync(bundlePath)).toBe(true);
+    expect(existsSync(sourcesPath)).toBe(true);
+    expect(listTarGzEntries(sourcesPath)).toEqual(expect.arrayContaining([
+      "mikuproject-sources/package.json",
+      "mikuproject-sources/README.md",
+      "mikuproject-sources/scripts/build-cli-bundle.mjs",
+      "mikuproject-sources/scripts/mikuproject-cli.mjs",
+      "mikuproject-sources/scripts/lib/core-api-loader.mjs",
+      "mikuproject-sources/src/ts/core-api.ts",
+      "mikuproject-sources/src/js/core-api.js",
+      "mikuproject-sources/docs/miku-soft-40-agentskills-design-v20260425.md",
+      "mikuproject-sources/tests/mikuproject-cli.test.js"
+    ]));
 
     const workbookPath = writeTempJson("bundle-workbook.json", buildWorkbookState("Bundled CLI export xml"));
     const result = spawnSync(process.execPath, [bundlePath, "export", "xml", "--in", workbookPath], {
@@ -906,6 +930,25 @@ describe("mikuproject cli", () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("<Project");
     expect(result.stdout).toContain("<Name>Bundled CLI export xml</Name>");
+  });
+
+  it("prints the version from a single-file cli runtime artifact outside the repo", () => {
+    const bundlePath = path.join(createTempDir("mikuproject-cli-version-bundle-test-"), "mikuproject.mjs");
+    const buildResult = spawnSync(process.execPath, [cliBundleBuildPath, "--out", bundlePath], {
+      cwd: repoRoot,
+      encoding: "utf8"
+    });
+
+    expect(buildResult.status).toBe(0);
+
+    const result = spawnSync(process.execPath, [bundlePath, "--version"], {
+      cwd: path.dirname(bundlePath),
+      encoding: "utf8"
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe(`mikuproject ${packageVersion}\n`);
+    expect(result.stderr).toBe("");
   });
 
   it("provides a runnable CLI AI workflow example script", () => {
@@ -973,6 +1016,30 @@ function createTempDir(prefix) {
   const dir = mkdtempSync(path.join(os.tmpdir(), prefix));
   tempDirs.push(dir);
   return dir;
+}
+
+function listTarGzEntries(filePath) {
+  const tar = gunzipSync(readFileSync(filePath));
+  const entries = [];
+  for (let offset = 0; offset + 512 <= tar.length;) {
+    const header = tar.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) {
+      break;
+    }
+    const name = readTarString(header, 0, 100);
+    const prefix = readTarString(header, 345, 155);
+    const sizeText = readTarString(header, 124, 12).trim();
+    const size = sizeText ? Number.parseInt(sizeText, 8) : 0;
+    entries.push(prefix ? `${prefix}/${name}` : name);
+    offset += 512 + Math.ceil(size / 512) * 512;
+  }
+  return entries;
+}
+
+function readTarString(buffer, offset, length) {
+  const slice = buffer.subarray(offset, offset + length);
+  const end = slice.indexOf(0);
+  return slice.subarray(0, end === -1 ? slice.length : end).toString("utf8");
 }
 
 function buildWorkbookState(projectName) {


### PR DESCRIPTION
## 概要

CLI に `--version` を追加し、`package.json` のバージョンを出力できるようにしました。

あわせて、`build:cli-bundle` で単一 `MJS` runtime artifact に加えて、再ビルド・監査・下流確認用の `mikuproject-sources.tgz` を生成するようにしました。

## 変更内容

- `mikuproject --version` を追加
- `package.json` / `package-lock.json` のバージョンを `0.8.0` に更新
- `build:cli-bundle` で以下を生成するように変更
  - `bundle/mikuproject.mjs`
  - `bundle/mikuproject-sources.tgz`
- 単一 `MJS` runtime artifact にバージョン情報を埋め込み、リポジトリ外でも `--version` が動作するように変更
- source archive に source / docs / tests などを含める処理を追加
- CLI テストに以下を追加
  - 通常 CLI の `--version`
  - 単一 `MJS` runtime artifact の `--version`
  - `mikuproject-sources.tgz` の生成と代表的な収録ファイル確認
- README と関連 docs に `--version` と source archive 生成の説明を追加

## 確認

- `npm run test:fast -- mikuproject-cli`