### PR TITLE
miku software設計文書の概要とMCP設計を追加

### DIFF
--- a/docs/miku-soft-00-overview-design-v20260427.md
+++ b/docs/miku-soft-00-overview-design-v20260427.md
@@ -1,0 +1,224 @@
+# Miku Software Overview Design v20260427
+
+This memo is the entry point for the shared design documents of the `miku` software series.
+
+The initial versions of the related tools were created by `Mikuku` and Toshiki Iga.
+
+The current contents are based on the main-application design memo, Java application design memo, straight-conversion guide, Agent Skills design memo, and MCP design memo checked on 2026-04-27.
+
+## Design Summary
+
+The `miku` software series can be summarized as follows.
+
+> A family of small, local-first bridge tools that expose domain files and domain data through human-facing Web Apps, scriptable CLI runtimes, agent-facing skill packages, Java runtime artifacts, and MCP protocol adapters while preserving each product's semantic center.
+
+The series is not organized around a single UI, runtime, or protocol. It is organized around a layered product shape.
+
+- Keep each upstream product's semantic center clear
+- Provide human-facing Single-file Web Apps where useful
+- Provide Node.js CLI surfaces as normal main-application surfaces
+- Provide Java 1.8 CLI runtimes through straight conversion as a normal follow-up deliverable
+- Package Agent Skills with instructions, operation maps, references, and executable CLI runtime artifacts
+- Provide MCP servers when there is no product-specific reason to avoid them
+- Keep Java versions, Agent Skills, and MCP servers downstream of the upstream product semantics
+- Preserve artifact roles, diagnostics, local execution, and runtime traceability across layers
+
+## Role of This Document
+
+This document is not a replacement for the detailed design documents. It explains how those documents fit together and records the product-family shape that sits above them.
+
+The detailed documents define the behavior and conventions of each layer. This overview explains the order, responsibility split, and intended relationship among those layers.
+
+When a specification is unclear, read this overview as the product-family map, then use the layer-specific document for detailed decisions.
+
+## Document Set
+
+This overview is the entry point for the shared miku software design document set.
+
+The detailed documents are organized by layer and concern.
+
+- `docs/miku-soft-00-overview-design-v*.md`
+  - provides the top-level product-family overview and explains how the design documents relate to each other
+- `docs/miku-soft-10-mainapp-design-v*.md`
+  - describes the main application layer, including the Single-file Web App and Node.js CLI as normal first-class product surfaces
+- `docs/miku-soft-20-javaapp-design-v*.md`
+  - describes Java application versions, especially Java 1.8 CLI/runtime artifacts, packaging, testing, and build integration
+- `docs/miku-soft-30-straight-conversion-v*.md`
+  - describes how TypeScript / Node.js products are converted into Java while preserving upstream traceability and behavior
+- `docs/miku-soft-40-agentskills-design-v*.md`
+  - describes Agent Skills packages, including local instructions, operation maps, references, and bundled CLI runtime artifacts for AI agents
+- `docs/miku-soft-50-mcp-design-v*.md`
+  - describes MCP server versions that expose product operations to MCP clients through tools, resources, and prompts
+
+## Layered Product Shape
+
+The miku software series can be understood through three facing layers.
+
+1. Human-facing layer
+2. Agent-facing layer
+3. MCP-facing layer
+
+These are facing layers, not independent product semantics. The upstream product owns the semantic center. Downstream runtime, skill, and protocol layers should expose that product meaning without becoming replacement implementations.
+
+## Human-Facing Layer
+
+A miku main application normally has two first-class surfaces: a Single-file Web App for human users and a Node.js CLI for automation, agents, and repeatable local workflows.
+
+The Single-file Web App is the human-facing surface when a product benefits from interactive loading, preview, diagnostics, and download. It is usually created in Node.js / TypeScript, has a Web UI, and runs locally in a browser without requiring server setup.
+
+The Node.js CLI is also a normal main-application surface. It exposes the same product core for scripts, repeatable local workflows, downstream Agent Skills, and later runtime adapters.
+
+Some main applications may be CLI-only when that is the natural product shape. In that case, the product is still a main application if it stands as the primary upstream product, accepts real local input, and produces verifiable artifacts.
+
+The human-facing layer should keep the following properties.
+
+- local-first execution
+- no server requirement for core functionality
+- clear canonical source or semantic base
+- structured outputs that scripts and AI agents can reuse
+- human-reviewable outputs such as HTML, Markdown, SVG, XLSX, XML, or ZIP when useful
+- shared core behavior behind UI, CLI, tests, and downstream adapters where practical
+
+## Java Runtime Layer
+
+A Java 1.8 CLI runtime is treated as a normal follow-up deliverable for miku products, implemented through straight conversion from the TypeScript / Node.js product unless there is a clear reason not to.
+
+The Java runtime should not be a Java-first redesign. Its first responsibility is to preserve upstream semantics, vocabulary, file-boundary traceability, CLI behavior, diagnostics, and artifact roles while making the product easier to run in Java-centered local and build environments.
+
+The Java runtime layer usually emphasizes:
+
+- Java 1.8 source and binary compatibility
+- CLI runtime jar
+- batch execution where it has clear operational value
+- Maven and build-tool integration when useful
+- deterministic artifact generation
+- public core APIs callable from CLI, tests, Maven plugins, and automation
+- distribution artifacts such as executable jars, sources jars, and distribution zips
+
+The TypeScript / Node.js CLI and Java CLI are peer runtime surfaces when both exist. Differences caused by runtime constraints should be documented rather than hidden.
+
+## Straight Conversion Layer
+
+Straight conversion is the bridge from the TypeScript / Node.js upstream product to the Java runtime.
+
+It is not a separate user-facing product layer. It is the reproducible method used to create and maintain Java versions without losing the ability to follow upstream changes.
+
+Straight conversion fixes the following direction.
+
+- Do not start from Java-first redesign
+- Keep upstream file boundaries and vocabulary traceable
+- Keep upstream tests and Java tests mapped
+- Keep the Node.js CLI contract close where a CLI exists
+- Treat Java-side extensions as separate contracts
+- Keep the Web UI out of the Java runtime unless explicitly required
+
+The output of straight conversion is a Java application version that remains understandable as a downstream runtime of the upstream product.
+
+## Agent-Facing Layer
+
+The agent-facing layer packages the product for AI agents.
+
+Agent Skills are not only instruction documents. They are agent-facing packages that combine local instructions, constraints, operation maps, references, and executable CLI runtime artifacts.
+
+The normal first runtime is the TypeScript / Node.js CLI artifact produced by the main application. A Java CLI runtime is also a normal runtime path when the Java version exists. As the target shape, miku Agent Skills should receive runtime artifacts as simple files under the skill package.
+
+Typical runtime artifacts are:
+
+- a single JavaScript CLI file for the Node.js runtime path
+- a single jar for the Java CLI runtime path
+
+Both runtime paths belong to the same skill product. Their presence should not split the skill name, activation rules, workflow vocabulary, artifact roles, or product boundary.
+
+Agent Skills should use upstream public APIs, documented CLI commands, stable global APIs, or bundled runtime artifacts before writing skill-local product logic. If the upstream product does not expose a needed capability, the preferred direction is to add or stabilize that capability upstream, then let the skill call it.
+
+The agent-facing layer should especially preserve:
+
+- explicit activation boundaries
+- product-specific operation maps
+- distinction between canonical source, state, draft, patch, projection, report, and diagnostics artifacts
+- local file workflow discipline
+- hard-error and soft-warning reporting
+- runtime lookup through declared skill-local artifacts before broad repository search
+
+## MCP-Facing Layer
+
+The MCP-facing layer is a normal extension target, not a replacement for Agent Skills.
+
+When there is no product-specific reason to avoid it, a miku product should provide an MCP server for MCP clients.
+
+The MCP server exposes product operations through tools, resources, and prompts. It should remain a protocol adapter over the product runtime, not a replacement implementation.
+
+The MCP server may use the TypeScript / Node.js runtime, the Java runtime, or both. When both runtime artifacts are available, the MCP server should treat runtime choice as an execution policy, not as a change in product semantics.
+
+The MCP-facing layer should keep the following properties.
+
+- product-prefixed tools with structured input schemas
+- structured tool results and diagnostics
+- resources for reusable state, specifications, reports, generated files, and diagnostics
+- small product-specific prompts when useful
+- local stdio transport as the first implementation target
+- HTTP transport as an additional deployment form with explicit session, storage, authentication, and isolation boundaries
+- shared tool names and result shapes across local and server variants
+
+MCP servers and Agent Skills should stay aligned around upstream product vocabulary, operation maps, artifact roles, and runtime contracts. Neither layer should become the semantic owner of the product.
+
+## Normal Product Flow
+
+The usual product flow for the miku software series is as follows.
+
+1. Create or maintain the TypeScript / Node.js main application.
+2. Provide the Single-file Web App when human-facing UI is useful.
+3. Provide the Node.js CLI as a normal product surface.
+4. Produce a single-file Node.js CLI runtime artifact for downstream use.
+5. Create the Java 1.8 CLI runtime through straight conversion unless there is a clear reason not to.
+6. Package Agent Skills with instructions, operation maps, references, and bundled runtime artifacts.
+7. Provide an MCP server when there is no product-specific reason to avoid it.
+
+This flow is a default direction, not a reason to blur responsibilities. Each layer must keep the upstream product boundary visible.
+
+## Responsibility Split
+
+The preferred responsibility split is as follows.
+
+- Main application
+  - owns product semantics, canonical source or semantic base, primary conversions, core APIs, Web UI when present, and Node.js CLI
+- Java application
+  - owns Java runtime packaging, Java CLI, Java-side batch or build integration, and Java-side tests while preserving upstream behavior
+- Straight conversion guide
+  - owns the method for creating and maintaining Java versions from TypeScript / Node.js upstreams
+- Agent Skills package
+  - owns agent-facing instructions, activation rules, workflow maps, local file discipline, runtime lookup, and bundled runtime artifact wiring
+- MCP server
+  - owns MCP tools, resources, prompts, transport handling, session or workspace policy, and protocol result formatting
+
+The semantic center should remain with the upstream main application. Runtime, skill, and protocol layers should expose or adapt that center rather than redefining it.
+
+## Shared Artifact Discipline
+
+Across all layers, miku products distinguish artifact roles.
+
+Common roles include:
+
+- canonical source or semantic base
+- internal product state
+- AI-facing projection
+- draft or patch returned by AI
+- primary exchange output
+- human-facing report
+- generated bundle
+- diagnostics and warnings
+- temporary scratch output
+
+These roles should not be collapsed only because the artifacts share a file extension or can all be represented as JSON or files.
+
+For example, a structural workbook `XLSX`, a human-facing `WBS XLSX`, a workbook JSON state file, and a Patch JSON document may all participate in one product workflow, but they are not the same contract.
+
+Keeping artifact roles visible makes UI, CLI, Java runtime, Agent Skills, and MCP server behavior easier to align.
+
+## Summary
+
+The miku software series starts from small local products, usually implemented in TypeScript / Node.js, and then exposes the same product meaning through multiple surfaces.
+
+The main application provides the upstream semantic center and normally exposes both a Single-file Web App and a Node.js CLI. Java versions provide Java 1.8 CLI runtimes through straight conversion. Agent Skills package instructions and executable runtime artifacts for AI agents. MCP servers expose product operations through a standard protocol for MCP clients.
+
+The important point is not to multiply implementations. It is to keep one product meaning usable from human UI, local CLI, Java runtime, agent package, and MCP protocol without losing traceability, diagnostics, or artifact discipline.

--- a/docs/miku-soft-20-javaapp-design-v20260426.md
+++ b/docs/miku-soft-20-javaapp-design-v20260426.md
@@ -1,4 +1,4 @@
-# Miku Software Java Application Design v20260425
+# Miku Software Java Application Design v20260426
 
 This memo organizes design characteristics commonly expected for Java application versions in the `miku` software series.
 
@@ -302,9 +302,12 @@ Java applications package local runtime use explicitly.
 
 The default runtime artifact is a single executable fat jar.
 
+The normal Maven package should also attach a sources jar, such as `<artifactId>-<version>-sources.jar`. The sources jar is a traceability and publication artifact, not the executable runtime artifact.
+
 When a distribution zip is useful, it should contain the minimal runtime-user-facing items such as:
 
 - runtime jar
+- sources jar when publishing or downstream traceability needs it
 - `README.md`
 - `LICENSE`
 - CLI or runtime docs where useful
@@ -316,6 +319,7 @@ The basic naming direction is:
 - Maven `groupId`: `jp.igapyon`
 - Maven `artifactId`: product-derived artifact name
 - jar name: `<artifactId>-<version>.jar`
+- sources jar name: `<artifactId>-<version>-sources.jar`
 - distribution zip name: `<artifactId>-dist-<version>.zip` or a similarly traceable form
 
 Runtime artifacts should not depend on source-tree-relative paths. If runtime markdown, prompt specs, or templates are needed inside the jar, copy them to classpath resources and read them through `getResourceAsStream` or an equivalent jar-safe mechanism.
@@ -842,9 +846,10 @@ The repository currently uses a single Maven project.
 The expected runtime artifacts are:
 
 - `target/mikuproject.jar`
+- `target/mikuproject-sources.jar`
 - `target/mikuproject-dist.zip`
 
-The distribution zip contains the runtime jar and minimal runtime-facing documentation such as `README.md`, `LICENSE`, and CLI documentation.
+The distribution zip contains the runtime jar, sources jar, and minimal runtime-facing documentation such as `README.md`, `LICENSE`, and CLI documentation.
 
 This single-module shape should remain acceptable while there is no Maven plugin deliverable. If a Maven plugin is added later, the repository should be reconsidered as a multi-module Maven reactor so that plugin code remains a thin adapter over the runtime / core API rather than a second implementation.
 

--- a/docs/miku-soft-40-agentskills-design-v20260425.md
+++ b/docs/miku-soft-40-agentskills-design-v20260425.md
@@ -637,6 +637,7 @@ Important design points:
 - AI JSON spec retrieval is exposed through upstream core API functions and the `mikuproject ai spec` CLI path, so the skill should prefer those contracts over file search
 - declared `mikuproject` runtime artifacts are checked before broad repository exploration
 - the upstream Node.js CLI runtime artifact is produced by `mikuproject` as a single `bundle/mikuproject.mjs` file and should be received by `mikuproject-skills` as `skills/mikuproject/runtime/mikuproject.mjs`
+- the upstream Java CLI runtime artifact is produced by `mikuproject-java` as `target/mikuproject.jar` and should be received by `mikuproject-skills` as `skills/mikuproject/runtime/mikuproject.jar`
 
 This skill does not aim to replace the `mikuproject` browser UI. Its center is structured AI-agent operation over the upstream product's core APIs and artifacts.
 

--- a/docs/miku-soft-50-mcp-design-v20260426.md
+++ b/docs/miku-soft-50-mcp-design-v20260426.md
@@ -1,0 +1,575 @@
+# Miku Software MCP Design v20260426
+
+This memo organizes design characteristics commonly expected for MCP server versions in the `miku` software series.
+
+The initial versions of the related tools were created by `Mikuku` and Toshiki Iga.
+
+The current contents are based on the miku main-application design memo, Java application design memo, straight-conversion guide, Agent Skills design memo, and the MCP concepts checked on 2026-04-26.
+
+## Design Summary
+
+The MCP server versions in the `miku` software series can be summarized as follows.
+
+> Protocol adapters that expose miku product operations to MCP clients as tools, resources, and prompts, while preserving upstream semantics, local-first workflows, structured artifacts, diagnostics, and runtime traceability.
+
+What characterizes MCP server versions is not a new product separate from the upstream application. It is a repeated set of constraints.
+
+- Keep the semantic center of the upstream main application
+- Expose product operations through stable MCP tools
+- Expose reusable state, specifications, reports, and generated files through MCP resources
+- Expose a small number of product-specific prompts when useful
+- Keep local stdio execution as the first implementation target
+- Allow HTTP server deployment as a later transport and hosting variant
+- Use upstream public APIs, CLI, or bundled runtime artifacts rather than duplicating product logic
+- Treat the MCP server as a thin protocol adapter
+- Keep local and server deployments aligned around the same tool contracts
+- Preserve diagnostics, warnings, and artifact roles in structured results
+
+## Role of This Document
+
+This document is not a detailed specification for one MCP repository. Repository-specific behavior should be checked in each MCP server README, package metadata, tool schema, and product-specific documents.
+
+Use the shared design documents together as follows.
+
+- `docs/miku-soft-10-mainapp-design-v20260425.md`
+  - describes the upstream product design and semantic center
+- `docs/miku-soft-20-javaapp-design-v20260425.md`
+  - describes Java runtime versions when they exist
+- `docs/miku-soft-30-straight-conversion-v20260425.md`
+  - describes how Java versions are created from upstream main applications
+- `docs/miku-soft-40-agentskills-design-v20260425.md`
+  - describes how Agent Skills versions expose miku workflows to AI agents
+- `docs/miku-soft-50-mcp-design-v20260426.md`
+  - describes how MCP server versions should expose miku workflows to MCP clients
+
+This document separates the following levels.
+
+- **Cross-cutting principles**: design policies that should generally be kept for MCP server versions.
+- **Recommended conventions**: transport, tool, resource, state, runtime, and packaging shapes that make maintenance easier.
+- **Observed tendencies**: design habits visible in current miku repositories and MCP usage.
+- **Product-specific notes**: design decisions for specific MCP products, recorded as concrete examples.
+
+When a specification is unclear, first check whether the decision preserves upstream meaning and keeps the MCP surface stable for clients. MCP convenience is important, but it should not hide unsupported behavior, discard diagnostics, or make local and server deployments drift into different products.
+
+## Scope
+
+The series whose names start with `miku` includes several related product types.
+
+Main applications:
+
+- `miku-abc-player`
+- `miku-docx2md`
+- `miku-indexgen`
+- `miku-unicode-guard`
+- `miku-xlsx2md`
+- `mikuproject`
+- `mikuscore`
+
+Java application versions:
+
+- `miku-indexgen-java`
+- `mikuproject-java`
+- `miku-xlsx2md-java`
+
+Agent Skills versions:
+
+- `mikuproject-skills`
+- `mikuscore-skills`
+
+MCP server versions:
+
+- `mikuproject-mcp`
+
+Projects with the `-mcp` suffix are positioned as MCP server adapters for original suffixless tools or their runtime artifacts.
+
+This document focuses on MCP server versions. It does not define the Web UI conventions for upstream main applications, Java packaging conventions for Java application versions, or skill packaging conventions for Agent Skills repositories.
+
+## Shared Direction
+
+MCP server versions continue the shared direction of the miku series: small local bridge tools that convert, extract, inspect, normalize, or export domain files and domain data.
+
+The MCP version emphasizes the parts that fit MCP operation particularly well.
+
+- model-callable tools
+- application-readable resources
+- user-selectable prompts where useful
+- structured JSON input and output schemas
+- local import / validate / export operations
+- resource links for generated artifacts
+- diagnostics and warnings as structured results
+- repeatable file-based operation
+- stdio local server execution
+- optional HTTP server deployment when remote access is required
+
+An MCP version should not become a generic planner, generic converter, hosted replacement application, or independent semantic implementation. Its value is that MCP clients can use the upstream miku product correctly through stable tool and resource contracts.
+
+## Relationship to Main Applications
+
+MCP server versions are downstream of miku main applications.
+
+The upstream main application owns the product semantics, canonical source, core conversions, output policy, and limitations. The MCP server owns protocol exposure, tool schema, resource naming, transport handling, runtime discovery, and result formatting.
+
+The preferred relationship is as follows.
+
+- upstream main application provides core APIs, CLI, bundled runtime, or stable artifacts
+- MCP server calls those upstream surfaces
+- MCP server exposes product operations as tools
+- MCP server exposes reusable state and artifacts as resources
+- MCP server may expose product-specific workflow prompts
+- MCP server returns diagnostics, warnings, hard errors, and generated artifact links in a structured form
+- MCP server does not reimplement core conversion behavior unless no upstream surface exists
+
+If an upstream capability is missing, the preferred order is to request or implement the capability on the upstream side, expose it as a stable upstream API, and then let the MCP server call it. MCP servers should not silently add upstream product capabilities on the MCP side. MCP-local workaround code should be treated as temporary or product-specific, not as the new semantic center.
+
+## Relationship to Agent Skills
+
+Agent Skills and MCP servers are closely related, but they are not the same layer.
+
+Agent Skills are instruction and workflow packages for agents. They explain when to activate a product-specific workflow, which runtime artifacts to use, how to manage intermediate files, and how to avoid confusing artifact roles.
+
+MCP servers are protocol adapters. They expose callable tools, readable resources, and optional prompts to MCP clients.
+
+The preferred relationship is as follows.
+
+- Agent Skills may continue to guide agents that can read `SKILL.md` and run local commands directly
+- MCP servers should serve clients that prefer a standard tool/resource/prompt protocol
+- both should call the same upstream runtime artifacts or public APIs when possible
+- both should use the same product vocabulary and artifact roles
+- neither should become the semantic owner of the product
+
+For a product such as `mikuproject`, an Agent Skills repository may include a local MCP server, or a separate `mikuproject-mcp` repository may provide one. In either case, the MCP contract should stay aligned with the Agent Skills operation map and upstream CLI contracts.
+
+## Role of MCP Servers
+
+In this document, an MCP server means a `miku` repository or package with an MCP server entrypoint that provides product operations through MCP.
+
+An MCP server usually exposes one or more of the following.
+
+- stdio server entrypoint for local MCP clients
+- HTTP server entrypoint for hosted or remote MCP clients
+- tool definitions with JSON input schemas
+- structured tool results and optional output schemas
+- resource definitions for state, specifications, reports, and generated files
+- resource templates for session or workspace-scoped artifacts
+- prompt definitions for product-specific workflows
+- runtime adapters for Java CLI, Node.js CLI, or public APIs
+- smoke tests for protocol startup and core tool calls
+
+The MCP server is not primarily the browser UI, not primarily a Java port, and not primarily an Agent Skill. It can use Node.js, Java, or another runtime if that is the natural way to call the upstream product, but the MCP layer itself should remain thin.
+
+The center of an MCP server is reliable protocol adaptation: receive a typed tool call, validate arguments, call the upstream runtime, preserve useful state, expose resulting artifacts as resources, and return diagnostics without hiding important constraints.
+
+## Cross-Cutting Principles
+
+miku MCP servers emphasize the following cross-cutting principles.
+
+1. Preserve the semantic center and product boundary of the upstream main application.
+2. Treat MCP as a protocol adapter, not as a replacement implementation.
+3. Keep MCP tool contracts stable across local stdio and HTTP server deployments.
+4. Prefer local stdio execution as the first implementation target.
+5. Add HTTP server deployment only with explicit session, storage, authentication, and isolation boundaries.
+6. Use structured input schemas, structured results, diagnostics, and resource links instead of loose prose.
+7. Distinguish canonical source, conversation state, MCP resources, primary output, reports, and temporary files.
+8. Make runtime selection, artifact storage, smoke testing, and upstream synchronization explainable.
+
+### Basic Philosophy of MCP Servers
+
+MCP server versions emphasize the following philosophy.
+
+- Run product operations locally when practical
+- Keep the upstream product meaning recognizable
+- Use upstream API or CLI before writing MCP-local conversion logic
+- Expose only product-specific operations that are useful to MCP clients
+- Keep tool names stable, explicit, and product-prefixed
+- Keep intermediate JSON internal when direct tool composition is possible
+- Return generated files as resources or resource links when practical
+- Preserve diagnostics and warnings as part of the result
+- Keep state and generated files easy to save, compare, and rerun
+- Keep local and hosted deployments aligned around the same tool contracts
+
+The value of an MCP server version is not that it can answer a domain question conversationally in a generic way. It is that MCP clients can safely call specific miku workflows through structured operations that are faithful to the upstream product.
+
+### Common Principles for MCP Servers
+
+MCP servers use the following principles as defaults.
+
+- Use a `-mcp` suffix when the MCP server is a separate repository or package
+- Keep the product name in tool names, such as `mikuproject.apply_patch`
+- Use stdio transport as the first local implementation
+- Treat HTTP transport as an additional deployment form, not a separate product contract
+- Use Node.js or TypeScript when that is the simplest way to implement the MCP server
+- Prefer bundled Java CLI and Node.js CLI runtime artifacts when local, reproducible execution needs them
+- Treat the Java CLI runtime artifact as a single jar
+- Treat the Node.js CLI runtime artifact as a single JavaScript file
+- Prefer upstream public APIs, stable global APIs, or documented CLI commands
+- Keep tool schemas and result schemas under version control
+- Keep repository-level README user-facing and developer details under `docs/`
+- Use `workplace/` or a configured workspace root for local scratch data, uploaded files, generated outputs, and verification files
+
+These are defaults for the miku MCP series. Individual products may add product-specific conventions, but should not change these foundations casually.
+
+## Transport Principles
+
+MCP is a protocol, not a synonym for an HTTP server.
+
+The first transport for miku MCP servers should usually be local stdio.
+
+Local stdio is appropriate when:
+
+- the user runs an MCP client on the same machine
+- the product reads and writes local files
+- the upstream runtime is available as a local jar, JavaScript file, or CLI command
+- the workflow benefits from local-first processing and simple installation
+
+HTTP transport is appropriate when:
+
+- multiple clients need remote access
+- the server owns session storage
+- files are uploaded to a controlled workspace
+- authentication, quota, and audit requirements are explicit
+- the deployment environment can isolate user workspaces safely
+
+Local stdio and HTTP deployments should share the same tool names and core input/output contracts. Differences should be limited to transport, file reference handling, session identity, storage, and authentication.
+
+## Local Stdio Server Principles
+
+The local stdio server is the preferred MVP shape.
+
+It should:
+
+- start as a local process launched by the MCP client
+- communicate over standard input and standard output
+- avoid requiring a network listener
+- discover bundled or configured runtime artifacts
+- call upstream CLI or APIs with explicit file paths
+- confine file reads and writes to declared workspace roots where practical
+- return generated file references as resources or resource links
+
+The local stdio server should not behave like a long-running public web service. It is a local adapter process whose authority comes from the user and the MCP client configuration.
+
+## HTTP Server Principles
+
+The HTTP server is a deployment variant, not the initial semantic center.
+
+An HTTP MCP server must define the following before it is treated as production-ready.
+
+- authentication and authorization model
+- session identity
+- workspace isolation
+- uploaded file lifecycle
+- generated artifact lifecycle
+- maximum input and output sizes
+- cleanup policy
+- audit or trace policy when needed
+- runtime sandboxing or equivalent execution boundary
+- user-visible confirmation policy for destructive operations when the client supports it
+
+HTTP deployment should not expose arbitrary local filesystem paths from the host. It should prefer session-scoped resource URIs, upload identifiers, or controlled workspace-relative paths.
+
+## Tool Design Principles
+
+MCP tools are the main execution surface.
+
+Tool names should be product-prefixed and stable.
+
+Examples:
+
+- `mikuproject.ai_spec`
+- `mikuproject.detect_kind`
+- `mikuproject.state_from_draft`
+- `mikuproject.project_overview`
+- `mikuproject.task_edit`
+- `mikuproject.phase_detail`
+- `mikuproject.validate_patch`
+- `mikuproject.apply_patch`
+- `mikuproject.state_diff`
+- `mikuproject.export_workbook_json`
+- `mikuproject.report_mermaid`
+
+Tool input should use JSON Schema. Tool results should return structured content when practical. For compatibility with clients that primarily display text, structured results may also be serialized into a text content block.
+
+Tools should prefer explicit argument names over positional behavior. Large input and output should be passed by file path, resource URI, upload ID, or resource link instead of being forced into chat-visible text.
+
+## Resource Design Principles
+
+MCP resources should expose reusable state and artifacts.
+
+Typical resources include:
+
+- AI-facing specifications
+- current workbook state
+- saved workbook states
+- imported canonical source files
+- generated report files
+- diagnostics logs
+- operation summaries
+
+Resource URIs should distinguish artifact roles.
+
+Examples:
+
+- `mikuproject://spec/ai-json`
+- `mikuproject://state/current`
+- `mikuproject://state/{name}`
+- `mikuproject://report/{name}`
+- `mikuproject://diagnostics/{operationId}`
+
+When a resource maps to a real local file, the server may return a `file://` resource link only when the client is expected to access that file directly. Otherwise, a product-specific URI should be preferred so that the server remains the controlled access point.
+
+## Prompt Design Principles
+
+MCP prompts should be small and product-specific.
+
+Prompts are useful when a client wants user-selectable workflow templates. They should not become the primary location for product semantics.
+
+Typical prompts include:
+
+- create a new product-specific draft from user requirements
+- revise an existing state using a small projection and patch
+- review a product artifact using documented diagnostics
+
+For products that already expose AI-facing specifications through upstream APIs or CLI commands, the MCP server should expose that specification as a tool or resource. Prompt text can reference the specification, but should not duplicate a large schema if the upstream product already provides a stable retrieval path.
+
+## Runtime Principles
+
+MCP servers should use declared runtime artifacts before broad repository exploration.
+
+The preferred order is as follows.
+
+1. Check the MCP server configuration
+2. Check bundled runtime artifacts declared by the package
+3. Use upstream public APIs, stable globals, or documented CLI/runtime flows
+4. Use MCP-local helpers only when they are the intended adapter layer
+5. Search broadly for alternatives only when the declared runtime path is missing or unusable
+
+For products with both Java and Node.js runtime artifacts, the MCP server may prefer the Java CLI first for local execution. A single jar is easy to locate, smoke-test, and run in automation environments. If the Java CLI artifact is missing, cannot be invoked, or does not support the requested operation, the MCP server may fall back to the Node.js CLI runtime.
+
+This runtime preference is an execution policy, not a semantic priority. The upstream main application remains the semantic center. Runtime differences should be reported as capability or compatibility diagnostics.
+
+## State and Artifact Principles
+
+MCP servers distinguish several kinds of data.
+
+- canonical source or semantic base owned by the upstream product
+- MCP server session state
+- AI-facing projection or draft document
+- patch or edit document returned by AI
+- primary product output
+- report or presentation output
+- diagnostics and warnings
+- temporary files and local scratch outputs
+
+These roles should not be collapsed only because they are all represented as JSON or files.
+
+For local stdio deployment, file paths can be a practical state boundary. For HTTP deployment, session-scoped resource URIs or upload identifiers are usually safer than arbitrary host paths.
+
+For products such as `mikuproject`, `mikuproject_workbook_json` may be the practical MCP state handoff format, while `MS Project XML` remains the product's semantic base. The MCP server should make that distinction visible in naming, docs, and tool descriptions.
+
+## Local and Server Variant Principles
+
+A separate MCP product may support both local and server deployments.
+
+The recommended split is:
+
+- core tool definitions
+- core input and result schemas
+- runtime adapter interface
+- local stdio entrypoint
+- HTTP entrypoint
+- storage adapter
+- session adapter
+
+Local and server variants should not create different operation vocabularies. They should share the same core tool names and result shapes.
+
+Variant-specific differences should be limited to:
+
+- transport
+- file reference representation
+- workspace and session scope
+- authentication
+- storage persistence
+- artifact lifetime
+- runtime isolation
+
+If a capability is not safe or practical in one deployment form, the server should report an explicit capability or policy error rather than silently changing behavior.
+
+## Error Handling Principles
+
+MCP servers should separate the following.
+
+- invalid tool arguments
+- unsupported document kind
+- missing base state
+- upstream runtime failure
+- upstream validation error
+- upstream warning
+- file access or storage policy error
+- transport or session error
+
+Hard errors should make the tool call fail in a way the MCP client can surface clearly.
+
+Soft errors and upstream warnings should be returned in structured results when the operation can still produce a meaningful artifact. They should not be discarded only because the requested output file was generated.
+
+## Security and Trust Principles
+
+MCP servers expose executable operations to AI clients, so security boundaries must be explicit.
+
+Local stdio servers should:
+
+- avoid reading arbitrary files unless the user or client provides them explicitly
+- avoid writing outside configured workspace or output roots when practical
+- avoid accepting shell fragments or raw command lines from tool arguments
+- call upstream runtimes through fixed argument arrays, not string-built shell commands
+- report generated paths clearly
+
+HTTP servers should additionally:
+
+- authenticate clients or users
+- isolate sessions
+- restrict file access to controlled storage
+- enforce upload and output size limits
+- clean up temporary artifacts
+- prevent cross-user resource access
+- treat uploaded files as untrusted input
+
+MCP tool descriptions and annotations are not a substitute for server-side validation.
+
+## Product Boundary Principles
+
+MCP servers must preserve the product boundary of the upstream miku tool.
+
+Examples:
+
+- `mikuproject-mcp` exposes WBS import, draft, patch, state, and report operations; it is not a full project-management server.
+- `mikuscore-mcp` would expose score conversion, inspection, and handoff operations; it would not become a full notation editor.
+- `miku-xlsx2md-mcp` would expose workbook-to-Markdown extraction and diagnostics; it would not become a general spreadsheet automation server.
+
+If the MCP server starts needing broad domain features that the upstream application does not own, treat that as a product design issue rather than hiding it in MCP tool code.
+
+## Recommended MVP Shape
+
+For a first miku MCP server, use this shape.
+
+- local stdio transport
+- product-prefixed tools
+- JSON Schema input definitions
+- structured tool results
+- resource links for generated artifacts
+- bundled or configured runtime artifact lookup
+- smoke test for server startup
+- smoke test for one read-only tool
+- smoke test for one state-changing tool with temporary files
+
+For `mikuproject-mcp`, the MVP tools should be close to the Agent Skills MVP operation set.
+
+- `mikuproject.ai_spec`
+- `mikuproject.detect_kind`
+- `mikuproject.state_from_draft`
+- `mikuproject.project_overview`
+- `mikuproject.task_edit`
+- `mikuproject.phase_detail`
+- `mikuproject.validate_patch`
+- `mikuproject.apply_patch`
+- `mikuproject.state_diff`
+- `mikuproject.state_summarize`
+- `mikuproject.export_workbook_json`
+
+File import/export and report generation can be added after the core state workflow is stable.
+
+## Out of Scope for the First Version
+
+The first version should not include:
+
+- broad hosted multi-tenant operation
+- custom user management
+- external AI model invocation
+- API key management for model providers
+- a browser UI replacement
+- full domain editing outside upstream-supported operations
+- automatic workflow planning beyond exposed tools and prompts
+- broad filesystem browsing
+- parallel implementation of upstream conversion logic
+
+These may become useful later, but they should not be allowed to blur the initial MCP contract.
+
+## Product-Specific Note: mikuproject-mcp
+
+`mikuproject-mcp` should expose `mikuproject` operations to MCP clients.
+
+The semantic center remains upstream `mikuproject`. The practical MCP state handoff format may be `mikuproject_workbook_json`. `MS Project XML` remains the semantic base and compatibility format for the product.
+
+`mikuproject-mcp` may be developed as an independent repository and product, rather than as a subdirectory of `mikuproject-skills`.
+
+This independence means that `mikuproject-mcp` owns its MCP-specific entrypoints, schemas, transport handling, and adapter code. It does not mean that `mikuproject-mcp` owns the product semantics of `mikuproject`.
+
+The preferred repository relationship is as follows.
+
+- `mikuproject`
+  - owns the upstream product semantics
+  - owns the canonical domain behavior, conversion policy, report policy, and AI-facing product contracts
+- `mikuproject-java`
+  - provides the Java runtime and jar-based execution path when used
+  - keeps Java CLI behavior aligned with the upstream product
+- `mikuproject-skills`
+  - provides the Agent Skills workflow design reference
+  - records operation maps, state-handling rules, file workflow rules, and agent-facing boundaries
+- `mikuproject-mcp`
+  - owns the MCP server entrypoints
+  - owns tool, resource, and prompt definitions
+  - owns MCP input and output schemas
+  - owns local stdio transport and optional HTTP transport
+  - owns session, workspace, storage, and runtime adapter policy for MCP deployments
+
+For development, `mikuproject-mcp` may use local upstream checkouts under `workplace/upstream/`.
+
+Recommended layout:
+
+```text
+mikuproject-mcp/
+  workplace/
+    upstream/
+      mikuproject/
+      mikuproject-java/
+      mikuproject-skills/
+```
+
+These checkouts are reference material and local development inputs. They should normally remain outside Git tracking except for placeholder files needed to keep the workspace directory shape.
+
+The upstream checkouts should be used to inspect and synchronize the following.
+
+- upstream `mikuproject` CLI contracts and AI-facing specifications
+- upstream `mikuproject` product behavior and artifact roles
+- `mikuproject-java` jar behavior and Java CLI parity
+- `mikuproject-skills` operation map and workflow boundary rules
+- runtime artifact generation and smoke-test expectations
+
+The MCP repository may copy, bundle, or download runtime artifacts according to its own packaging policy, but it should not treat `workplace/upstream/` itself as the installed runtime surface.
+
+The clean responsibility split is:
+
+```text
+mikuproject
+  -> upstream semantic owner
+
+mikuproject-java
+  -> Java runtime / jar provider
+
+mikuproject-skills
+  -> Agent Skills workflow design reference
+
+mikuproject-mcp
+  -> MCP protocol adapter
+```
+
+The first implementation should borrow heavily from `mikuproject-skills` design material, especially:
+
+- operation names and operation grouping
+- `mikuproject_workbook_json` as the practical state boundary
+- Java runtime preference with Node.js runtime fallback
+- distinction between structural workbook `XLSX` and `WBS XLSX` report output
+- distinction between draft, patch, projection, workbook, report, and diagnostics artifacts
+- default local output discipline for state, report, and temporary files
+
+The first implementation should prefer local stdio transport. It should call `mikuproject.jar` or `mikuproject.mjs` through fixed runtime adapter code. It should keep the tool names aligned with the existing `mikuproject-skills` operation map and the Java / Node.js CLI correspondence.
+
+If `mikuproject-mcp` later adds an HTTP server, it should keep the same core tool names. The HTTP server should add session-scoped resources, upload handling, authentication, storage policy, and artifact lifecycle management rather than changing the product operation vocabulary.


### PR DESCRIPTION
## 概要

miku softwareシリーズの設計文書群を束ねる overview 文書を追加し、MCP server版の設計方針を追加しました。

あわせて、Java application設計文書を v20260426 に更新し、Agent Skills設計文書に Java CLI runtime artifact の受け取り方針を追記しました。

## 変更内容

- `miku-soft-00-overview-design-v20260427.md` を追加
  - `miku-soft-10` から `miku-soft-50` までの文書セットの位置づけを整理
  - Human-facing layer / Agent-facing layer / MCP-facing layer の関係を整理
  - Single-file Web App、Node.js CLI、Java CLI runtime、Agent Skills、MCP server の責務分担を整理
- `miku-soft-50-mcp-design-v20260426.md` を追加
  - MCP server版の設計方針を整理
  - MCP tools / resources / prompts、stdio / HTTP transport、runtime、state / artifact、error handling、security、`mikuproject-mcp` の位置づけを記述
- Java application設計文書を `v20260425` から `v20260426` へ更新
  - sources jar の扱いを追加
  - `mikuproject-java` の想定成果物に sources jar を追加
  - distribution zip に runtime jar と sources jar を含める方針を追記
- Agent Skills設計文書を更新
  - `mikuproject-java` が生成する Java CLI runtime artifact を `mikuproject-skills` 側で受け取る方針を追記

## テスト

未確認です。変更対象は設計文書のみです。