### PR TITLE
miku-soft Agent Skills / MCP 設計文書を更新

### DIFF
--- a/docs/miku-soft-40-agentskills-design-v20260429.md
+++ b/docs/miku-soft-40-agentskills-design-v20260429.md
@@ -31,11 +31,11 @@ Use the shared design documents together as follows.
 
 - `docs/miku-soft-10-mainapp-design-v20260425.md`
   - describes the upstream product design and semantic center
-- `docs/miku-soft-20-javaapp-design-v20260425.md`
+- `docs/miku-soft-20-javaapp-design-v20260426.md`
   - describes Java runtime versions when they exist
 - `docs/miku-soft-30-straight-conversion-v20260425.md`
   - describes how Java versions are created from upstream main applications
-- `docs/miku-soft-40-agentskills-design-v20260425.md`
+- `docs/miku-soft-40-agentskills-design-v20260429.md`
   - describes how Agent Skills versions should expose miku workflows to AI agents
 
 This document separates the following levels.
@@ -140,6 +140,7 @@ miku Agent Skills emphasize the following cross-cutting principles.
 6. Distinguish canonical source, conversation state, primary output, reports, and temporary handoff data.
 7. Use small projections, patches, validation, and diffs for AI-assisted edits where practical.
 8. Make installation, bundling, smoke testing, and upstream synchronization explainable.
+9. Keep workflow guidance separate from execution backend selection so CLI, MCP, and handoff execution can follow explicit policy.
 
 ### Basic Philosophy of Agent Skills
 
@@ -173,6 +174,7 @@ Agent Skills use the following principles as defaults.
 - Treat the Node.js CLI runtime artifact as a single JavaScript file
 - Use bundled upstream runtime artifacts when local, reproducible execution and bundling need them
 - Prefer upstream public APIs, stable global APIs, or documented CLI commands
+- Allow execution backend policy to choose CLI, MCP, or handoff behavior without changing the skill name or workflow vocabulary
 - Package distributable bundles with scripts that can be tested
 - Keep repository-level README user-facing and developer details under `docs/`
 - Use `workplace/` for local scratch data, upstream checks, generated outputs, and verification files
@@ -219,6 +221,36 @@ Do not create a separate skill product line only because an additional runtime p
 When both Java CLI and Node.js CLI runtime artifacts are bundled, the skill may prefer the Java CLI first for local execution. A single jar is easy to locate, smoke-test, and run in automation environments. If the Java CLI artifact is missing, cannot be invoked, or does not support the requested operation, the skill may fall back to the Node.js CLI runtime.
 
 This runtime preference is an execution policy, not a semantic priority. The upstream main application remains the semantic center. Runtime differences should be reported as capability or compatibility diagnostics.
+
+### Execution Backend Policy Principles
+
+Agent Skills should remain the workflow layer even when the execution backend changes.
+
+The skill owns activation rules, operation selection, artifact roles, file placement guidance, diagnostics policy, and handoff expectations. The execution backend owns how an operation is actually carried out in a particular environment.
+
+Common backend categories are:
+
+- CLI backend: run bundled or configured upstream CLI artifacts, usually through Java or Node.js commands
+- MCP backend: call a product-specific MCP server that exposes aligned tools and resources
+- handoff backend: do not execute the product operation directly; return the spec, structured JSON, prompt, or step-by-step handoff material visibly
+
+The default policy for mature miku Agent Skills should be `cli-preferred`: try the declared local CLI backend first, and fall back to MCP only when that fallback is allowed by the active environment and repository policy.
+
+Supported policy values should be interpreted as follows.
+
+- `cli-only`: use only the CLI backend; do not inspect or call MCP as an automatic fallback
+- `cli-preferred`: use CLI first; use MCP only when CLI is unavailable or unsuitable and fallback is allowed
+- `mcp-only`: use only the MCP backend; do not inspect or run CLI artifacts as an automatic fallback
+- `mcp-preferred`: use MCP first; use CLI only when MCP is unavailable or unsuitable and fallback is allowed
+- `handoff-only`: do not execute backend operations; provide visible handoff material and instructions
+
+Execution backend policy is subordinate to the user's explicit instruction and the active environment policy. If an environment disallows CLI execution, a skill must not run CLI commands merely because `cli-preferred` is the repository default. If an environment disallows MCP access, a skill must not call MCP tools merely because CLI failed.
+
+Strict policies are intentionally strict. Under `cli-only` or `mcp-only`, failure of the selected backend should be reported as a hard execution-path error instead of silently switching to another backend. Under `handoff-only`, backend execution should not occur even when CLI or MCP is available.
+
+When fallback is allowed and happens, diagnostics should state the source backend, target backend, and concise reason. For example, a result may say that CLI was unavailable and execution continued through MCP, or that MCP lacked a required tool and execution continued through CLI.
+
+An MCP backend should use the MCP server layer described by the miku MCP design documents. The Agent Skill should not become the MCP server implementation and should not redefine MCP tool names, resource roles, or protocol contracts locally. It should describe how its operation vocabulary maps to the MCP tools and resources exposed by the product-specific MCP server.
 
 ### AI-Facing Spec Retrieval Principles
 
@@ -438,6 +470,7 @@ Test coverage should include:
 - skill smoke tests
 - upstream runtime availability checks
 - runtime selection checks, including Java CLI available, Java CLI unavailable with Node.js fallback, unsupported Java CLI operation with Node.js fallback, and all runtimes missing as a hard error
+- execution backend policy checks, including strict `cli-only`, strict `mcp-only`, preferred fallback behavior, and `handoff-only` no-execution behavior when the repository supports those modes
 - representative import / export operations
 - draft / patch / validate / apply operations where applicable
 - diagnostics and hard-error behavior
@@ -636,6 +669,8 @@ Important design points:
 - report outputs such as `WBS XLSX`, `SVG`, `Markdown`, `Mermaid`, and ZIP are derived outputs
 - AI JSON spec retrieval is exposed through upstream core API functions and the `mikuproject ai spec` CLI path, so the skill should prefer those contracts over file search
 - declared `mikuproject` runtime artifacts are checked before broad repository exploration
+- execution backend policy defaults to `cli-preferred`, while still allowing `cli-only`, `mcp-only`, `mcp-preferred`, and `handoff-only` when the user, environment, or repository configuration requires them
+- MCP backend support should use the `mikuproject-mcp` server layer and aligned MCP tools; `mikuproject-skills` remains the Agent Skill workflow layer, not the MCP server implementation
 - the upstream Node.js CLI runtime artifact is produced by `mikuproject` as a single `bundle/mikuproject.mjs` file and should be received by `mikuproject-skills` as `skills/mikuproject/runtime/mikuproject.mjs`
 - the upstream Java CLI runtime artifact is produced by `mikuproject-java` as `target/mikuproject.jar` and should be received by `mikuproject-skills` as `skills/mikuproject/runtime/mikuproject.jar`
 

--- a/docs/miku-soft-50-mcp-design-v20260430.md
+++ b/docs/miku-soft-50-mcp-design-v20260430.md
@@ -1,4 +1,4 @@
-# Miku Software MCP Design v20260427
+# Miku Software MCP Design v20260430
 
 This memo organizes design characteristics commonly expected for MCP server versions in the `miku` software series.
 
@@ -39,9 +39,9 @@ Use the shared design documents together as follows.
 
 - `docs/miku-soft-10-mainapp-design-v20260425.md`
   - describes the upstream product design and semantic center
-- `docs/miku-soft-40-agentskills-design-v20260425.md`
+- `docs/miku-soft-40-agentskills-design-v20260429.md`
   - describes how Agent Skills versions expose miku workflows to AI agents
-- `docs/miku-soft-50-mcp-design-v20260427.md`
+- `docs/miku-soft-50-mcp-design-v20260430.md`
   - describes how MCP server versions should expose miku workflows to MCP clients
 
 This document separates the following levels.
@@ -226,6 +226,8 @@ MCP servers use the following principles as defaults.
 - Prefer a single Node.js / TypeScript MCP server unless a concrete product constraint justifies another server implementation
 - Prefer bundled or configured runtime artifacts when local, reproducible execution needs them
 - Prefer upstream public APIs, stable global APIs, or documented CLI commands
+- Align the MCP package version with the primary bundled Node.js CLI runtime
+  version by default
 - Keep tool schemas and result schemas under version control
 - Keep repository-level README user-facing and developer details under `docs/`
 - Use `workplace/` or a configured workspace root for local scratch data, uploaded files, generated outputs, and verification files
@@ -304,7 +306,7 @@ For products with a documented CLI, MCP tool names should preserve the CLI
 command tree. Use this form:
 
 ```text
-<product>.<cli command tokens joined by "_">
+<product>_<cli command tokens joined by "_">
 ```
 
 Omit only the runtime launcher, such as `node mikuproject.mjs` or
@@ -318,17 +320,29 @@ Skills documentation harder to compare.
 
 Examples:
 
-- `mikuproject.ai_spec`
-- `mikuproject.ai_detect_kind`
-- `mikuproject.state_from_draft`
-- `mikuproject.ai_export_project_overview`
-- `mikuproject.ai_export_task_edit`
-- `mikuproject.ai_export_phase_detail`
-- `mikuproject.ai_validate_patch`
-- `mikuproject.state_apply_patch`
-- `mikuproject.state_diff`
-- `mikuproject.export_workbook_json`
-- `mikuproject.report_mermaid`
+- `mikuproject_version`
+- `mikuproject_ai_spec`
+- `mikuproject_ai_detect_kind`
+- `mikuproject_state_from_draft`
+- `mikuproject_ai_export_project_overview`
+- `mikuproject_ai_export_bundle`
+- `mikuproject_ai_export_task_edit`
+- `mikuproject_ai_export_phase_detail`
+- `mikuproject_ai_validate_patch`
+- `mikuproject_state_apply_patch`
+- `mikuproject_state_diff`
+- `mikuproject_state_summarize`
+- `mikuproject_export_workbook_json`
+- `mikuproject_export_xml`
+- `mikuproject_export_xlsx`
+- `mikuproject_import_xlsx`
+- `mikuproject_report_wbs_xlsx`
+- `mikuproject_report_daily_svg`
+- `mikuproject_report_weekly_svg`
+- `mikuproject_report_monthly_calendar_svg`
+- `mikuproject_report_all`
+- `mikuproject_report_wbs_markdown`
+- `mikuproject_report_mermaid`
 
 Tool input should use JSON Schema. Tool results should return structured content when practical. For compatibility with clients that primarily display text, structured results may also be serialized into a text content block.
 
@@ -591,19 +605,34 @@ For a first miku MCP server, use this shape.
 
 For `mikuproject-mcp`, the MVP tools should be close to the Agent Skills MVP operation set.
 
-- `mikuproject.ai_spec`
-- `mikuproject.ai_detect_kind`
-- `mikuproject.state_from_draft`
-- `mikuproject.ai_export_project_overview`
-- `mikuproject.ai_export_task_edit`
-- `mikuproject.ai_export_phase_detail`
-- `mikuproject.ai_validate_patch`
-- `mikuproject.state_apply_patch`
-- `mikuproject.state_diff`
-- `mikuproject.state_summarize`
-- `mikuproject.export_workbook_json`
+- `mikuproject_ai_spec`
+- `mikuproject_ai_detect_kind`
+- `mikuproject_version`
+- `mikuproject_state_from_draft`
+- `mikuproject_ai_export_project_overview`
+- `mikuproject_ai_export_bundle`
+- `mikuproject_ai_export_task_edit`
+- `mikuproject_ai_export_phase_detail`
+- `mikuproject_ai_validate_patch`
+- `mikuproject_state_apply_patch`
+- `mikuproject_state_diff`
+- `mikuproject_state_summarize`
+- `mikuproject_export_workbook_json`
+- `mikuproject_export_xml`
+- `mikuproject_export_xlsx`
+- `mikuproject_import_xlsx`
+- `mikuproject_report_wbs_xlsx`
+- `mikuproject_report_daily_svg`
+- `mikuproject_report_weekly_svg`
+- `mikuproject_report_monthly_calendar_svg`
+- `mikuproject_report_all`
+- `mikuproject_report_wbs_markdown`
+- `mikuproject_report_mermaid`
 
-File import/export and report generation can be added after the core state workflow is stable.
+The current first version includes core state workflow tools plus file
+import/export and report outputs that are available in the bundled Java and
+Node runtime artifacts. Additional CLI operations such as XML import and merge
+imports can remain later capability-gated extensions.
 
 ## Out of Scope for the First Version
 
@@ -718,11 +747,11 @@ CLI correspondence.
 
 The CLI command tree is the naming source for MCP tools:
 
-- `ai spec` becomes `mikuproject.ai_spec`
-- `ai detect-kind` becomes `mikuproject.ai_detect_kind`
-- `state from-draft` becomes `mikuproject.state_from_draft`
-- `ai validate-patch` becomes `mikuproject.ai_validate_patch`
-- `state apply-patch` becomes `mikuproject.state_apply_patch`
+- `ai spec` becomes `mikuproject_ai_spec`
+- `ai detect-kind` becomes `mikuproject_ai_detect_kind`
+- `state from-draft` becomes `mikuproject_state_from_draft`
+- `ai validate-patch` becomes `mikuproject_ai_validate_patch`
+- `state apply-patch` becomes `mikuproject_state_apply_patch`
 
 For `mikuproject-mcp`, the MCP server implementation is TypeScript. The
 TypeScript version establishes the MCP contract for tools, schemas, result


### PR DESCRIPTION
## 概要

miku-soft 系の Agent Skills 設計文書と MCP 設計文書を、新しい日付版の文書へ更新します。

## 変更内容

- `miku-soft-40-agentskills-design` を `v20260425` から `v20260429` に更新
- `miku-soft-50-mcp-design` を `v20260427` から `v20260430` に更新
- Agent Skills 設計文書で、Java アプリ設計文書への参照を `v20260426` に更新
- Agent Skills 設計文書に、実行バックエンドポリシーに関する方針を追加
  - CLI backend
  - MCP backend
  - handoff backend
  - `cli-only`
  - `cli-preferred`
  - `mcp-only`
  - `mcp-preferred`
  - `handoff-only`
- MCP 設計文書で、MCP ツール名の形式をドット区切りからアンダースコア区切りに変更
- `mikuproject-mcp` の MVP ツール例を拡充
  - version
  - export bundle
  - workbook / XML / XLSX import-export
  - WBS XLSX / SVG / Markdown / Mermaid などの report 系ツール
- MCP パッケージバージョンを主要な bundled Node.js CLI runtime version と揃える方針を追加

## 補足

このコミットでは、既存の日付版 Markdown ファイルを削除し、新しい日付版 Markdown ファイルを追加しています。

## 確認事項

- 実行テストの有無: 未確認