### PR TITLE
バージョン番号を 0.8.3 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mikuproject",
-  "version": "0.8.0",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mikuproject",
-      "version": "0.8.0",
+      "version": "0.8.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@xmldom/xmldom": "^0.8.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mikuproject",
-  "version": "0.8.0",
+  "version": "0.8.3",
   "private": true,
   "description": "Local HTML tool for MS Project XML round-trip experiments.",
   "license": "Apache-2.0",


### PR DESCRIPTION
## 概要

`package.json` と `package-lock.json` のプロジェクトバージョンを `0.8.0` から `0.8.3` に更新します。

## 変更内容

- `package.json` の `version` を `0.8.3` に更新
- `package-lock.json` のルート `version` を `0.8.3` に更新
- `package-lock.json` 内のパッケージ定義の `version` を `0.8.3` に更新

## 確認

- `npm run build:full` が成功
- 15 test files / 221 tests passed