### PR TITLE
テスト実行時のタイムゾーンをAsia/Tokyoに固定する

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -61,7 +61,11 @@ vitestArgs.push(...SUITES[requestedSuite]);
 
 const result = spawnSync(process.execPath, vitestArgs, {
   stdio: "inherit",
-  cwd: process.cwd()
+  cwd: process.cwd(),
+  env: {
+    ...process.env,
+    TZ: "Asia/Tokyo"
+  }
 });
 
 process.exit(result.status ?? 1);


### PR DESCRIPTION
## 概要

テストランナーからVitestを起動する際の環境変数に `TZ: "Asia/Tokyo"` を追加し、テスト実行時のタイムゾーンを固定します。

## 変更内容

- `scripts/run-tests.mjs` の `spawnSync` オプションに `env` を追加
- 既存の `process.env` を引き継いだうえで、`TZ` を `Asia/Tokyo` に設定
- Vitest子プロセスが固定タイムゾーンで実行されるように変更

## 確認事項

- このコミット内には、テスト実行結果の記録は含まれていません。