### PR TITLE
Release CLI bundleのタグバージョン判定でドット付き接尾辞を許容する

### DIFF
--- a/.github/workflows/release-cli-bundle.yml
+++ b/.github/workflows/release-cli-bundle.yml
@@ -47,10 +47,13 @@ jobs:
           set -euo pipefail
           VERSION="${TAG_NAME#v}"
           PACKAGE_VERSION="$(node -p "require('./package.json').version")"
-          if [ "${VERSION}" != "${PACKAGE_VERSION}" ]; then
-            echo "Release tag version (${VERSION}) does not match package.json version (${PACKAGE_VERSION})." >&2
-            exit 1
-          fi
+          case "${VERSION}" in
+            "${PACKAGE_VERSION}"|"${PACKAGE_VERSION}".*) ;;
+            *)
+              echo "Release tag version (${VERSION}) must match package.json version (${PACKAGE_VERSION}) or add a dot suffix such as ${PACKAGE_VERSION}.2." >&2
+              exit 1
+              ;;
+          esac
 
           mkdir -p release-assets
           cp bundle/mikuproject.mjs "release-assets/mikuproject-${VERSION}.mjs"


### PR DESCRIPTION
## 概要

Release CLI bundle workflow のReleaseタグ検証を変更し、`package.json` のバージョンと完全一致するタグに加えて、同じバージョンにドット付き接尾辞を付けたタグも許容します。

## 変更内容

- `Prepare release assets` ステップのバージョン検証を `if` から `case` に変更
- `VERSION` が `PACKAGE_VERSION` と完全一致する場合を許容
- `VERSION` が `PACKAGE_VERSION.` で始まる場合を許容
- 許容されないタグの場合のエラーメッセージを更新

## 許容される形式

`package.json` の `version` が `0.8.3` の場合、次の形式が許容されます。

- `v0.8.3`
- `v0.8.3.2`

## 確認事項

- このコミット内には、workflow実行結果の記録は含まれていません。