### PR TITLE
miku設計文書を20260501版へ更新

### DIFF
--- a/docs/miku-soft-20-javaapp-design-v20260501.md
+++ b/docs/miku-soft-20-javaapp-design-v20260501.md
@@ -330,16 +330,16 @@ The CLI is a formal entrypoint for humans, scripts, build tools, and AI agents.
 
 CLI design emphasizes the following.
 
-- Keep options understandable and close to upstream where applicable
+- Keep command groups, subcommands, option names, and argument combinations close to upstream where applicable
 - Use explicit input and output paths
-- Use stdout for normal textual output or declared artifact output
+- Use stdout for normal textual output or explicitly declared stream-friendly output
 - Use stderr for diagnostics, usage errors, progress, and verbose logs
 - Make success and failure judgeable by exit code
 - Keep verbose output available for progress and timing when useful
-- Keep binary output file-based by default
+- Keep binary output file-based by default, and use an explicit Base64 stdout option when stream-friendly binary exchange is needed
 - Test stdout, stderr, exit code, and generated files
 
-When the upstream has a CLI, the Java CLI should respect its interface as far as practical. Differences caused by Java runtime needs should be documented.
+When the upstream has a CLI, the Java CLI should respect its interface as far as practical. This includes the command group structure, subcommand names, option names, stdin / stdout conventions, diagnostics options, and usage-error boundaries. Differences caused by Java runtime needs or Java-side automation extensions should be documented.
 
 CLI help, README usage, and tests should be synchronized closely enough that option descriptions do not drift.
 
@@ -596,7 +596,7 @@ CLI tests should check:
 - output files
 - no-overwrite or failure behavior where relevant
 
-For normal usage, output files are preferred for generated artifacts. Stdout should be used only when the command contract clearly states it.
+For normal usage, output files are preferred for generated artifacts. Stdout should be used only when the command contract clearly states it. For binary artifacts, prefer `--out <path>` and use an explicit Base64 stdout option such as `--out-base64 -` when the upstream CLI defines that stream-friendly contract.
 
 ### Maven Plugin Conventions
 
@@ -786,7 +786,6 @@ The upstream product treats `MS Project XML` as the semantic base and uses `Proj
 The Java version currently emphasizes the following execution paths.
 
 - runtime jar / CLI
-- Java-side multi-input batch commands
 - public core API facades
 - deterministic report and exchange artifact generation
 - distribution zip for runtime users
@@ -814,21 +813,23 @@ These facades are Java-side aggregation points. They should remain traceable to 
 Important design points:
 
 - preserve the upstream goal of bridging `MS Project XML`, WBS reports, workbook exchange, and AI workflows
+- keep Java CLI command groups, subcommands, option names, stdin / stdout behavior, diagnostics options, and usage-error boundaries aligned with the Node.js upstream where practical
 - keep `MS Project XML` and `ProjectModel` as the semantic center
 - treat workbook JSON, `.xlsx`, AI JSON, patch JSON, Markdown, SVG, Mermaid, and WBS XLSX as exchange, editing, report, or inspection surfaces around that center
 - keep browser Web UI behavior out of scope
 - keep AI-facing workflows artifact-based, such as project overview, phase detail, task edit, draft request, patch JSON, validate, apply, and diff-oriented outputs
 - keep report outputs such as WBS Markdown, daily / weekly / monthly SVG, Mermaid, WBS XLSX, report directory, and report bundle as derived artifacts, not canonical project state
+- keep XLSX / ZIP and other binary CLI artifacts file-based by default; when stream-friendly exchange is needed, follow the upstream `--in-base64 -` / `--out-base64 -` convention rather than writing raw binary to stdout
 - make report bundle and report directory outputs deterministic enough for byte-level comparison where practical
 - keep CLI help, README command lists, mapping documents, and focused tests synchronized
 
-#### Batch Commands in `mikuproject-java`
+#### Java-Side CLI Extensions in `mikuproject-java`
 
-`mikuproject-java` has many Java-side `*-batch` CLI commands.
+`mikuproject-java` may add Java-side CLI extensions for local automation when they have clear operational value.
 
-These commands are operational extensions for local automation. They are useful because project report and import/export workflows often need to process several XML, workbook, JSON, or patch files in one JVM invocation.
+These commands are operational extensions for local automation. They can be useful when project report and import/export workflows need to process several XML, workbook, JSON, or patch files in one JVM invocation.
 
-This batch surface should be read as a Java-side extension, not as a change to the upstream `mikuproject` single-operation product contract.
+This extension surface should be read as Java-side behavior, not as a change to the upstream `mikuproject` single-operation product contract.
 
 The current direction is:
 

--- a/docs/miku-soft-40-agentskills-design-v20260501.md
+++ b/docs/miku-soft-40-agentskills-design-v20260501.md
@@ -31,11 +31,11 @@ Use the shared design documents together as follows.
 
 - `docs/miku-soft-10-mainapp-design-v20260501.md`
   - describes the upstream product design and semantic center
-- `docs/miku-soft-20-javaapp-design-v20260426.md`
+- `docs/miku-soft-20-javaapp-design-v20260425.md`
   - describes Java runtime versions when they exist
 - `docs/miku-soft-30-straight-conversion-v20260425.md`
   - describes how Java versions are created from upstream main applications
-- `docs/miku-soft-40-agentskills-design-v20260429.md`
+- `docs/miku-soft-40-agentskills-design-v20260501.md`
   - describes how Agent Skills versions should expose miku workflows to AI agents
 
 This document separates the following levels.
@@ -214,7 +214,7 @@ The preferred order is as follows.
 
 This keeps agent behavior predictable. It also prevents the skill from accidentally using stale generated files, unrelated scripts, or partial local experiments.
 
-Runtime artifact lookup should be simple and fixed. Place the single jar and single JavaScript CLI file under the skill directory, such as `skills/<skill-name>/runtime/`, and let the skill use those declared paths.
+Runtime artifact lookup should be simple and fixed. Place the single jar and single JavaScript CLI file under the skill directory, such as `skills/<skill-name>/runtime/`, and let the skill resolve the declared versioned artifacts there.
 
 Do not create a separate skill product line only because an additional runtime path exists. When both Java CLI and Node.js CLI runtimes are available, treat them as runtime artifacts of the same normal `-skills` package. The skill name, activation rules, workflow vocabulary, artifact roles, and product boundary should remain tied to the upstream main application, not to the runtime implementation.
 
@@ -535,8 +535,8 @@ repository root
       SKILL.md
       references/
       runtime/
-        <product>.jar
-        <product>.mjs
+        <product>-<version>.jar
+        <product>-<version>.mjs
   tests/
   workplace/.gitkeep
 ```
@@ -551,11 +551,11 @@ skills/
     SKILL.md
     references/
     runtime/
-      mikuproject.jar
-      mikuproject.mjs
+      mikuproject-<version>.jar
+      mikuproject-<version>.mjs
 ```
 
-The Java jar and Node.js CLI file are peer runtime artifacts. Their presence should not change the skill name or split the workflow vocabulary into runtime-specific skill products.
+The Java jar and Node.js CLI file are peer runtime artifacts. Use versioned file names for received artifacts, and resolve the actual file under `runtime/` at execution time. Their presence should not change the skill name or split the workflow vocabulary into runtime-specific skill products.
 
 `vendor/` directories are transition-only locations for repositories that still depend on copied upstream source trees or broader runtime trees. New normal operation should not add new runtime lookup through `vendor/`. As upstream Java and Node.js CLI artifacts become available as single files, repositories should move those artifacts into `skills/<skill-name>/runtime/` and remove the vendored runtime tree.
 
@@ -671,8 +671,8 @@ Important design points:
 - declared `mikuproject` runtime artifacts are checked before broad repository exploration
 - execution backend policy defaults to `cli-preferred`, while still allowing `cli-only`, `mcp-only`, `mcp-preferred`, and `handoff-only` when the user, environment, or repository configuration requires them
 - MCP backend support should use the `mikuproject-mcp` server layer and aligned MCP tools; `mikuproject-skills` remains the Agent Skill workflow layer, not the MCP server implementation
-- the upstream Node.js CLI runtime artifact is produced by `mikuproject` as a single `bundle/mikuproject.mjs` file and should be received by `mikuproject-skills` as `skills/mikuproject/runtime/mikuproject.mjs`
-- the upstream Java CLI runtime artifact is produced by `mikuproject-java` as `target/mikuproject.jar` and should be received by `mikuproject-skills` as `skills/mikuproject/runtime/mikuproject.jar`
+- the upstream Node.js CLI runtime artifact is produced by `mikuproject` as a single `bundle/mikuproject.mjs` file and should be received by `mikuproject-skills` as `skills/mikuproject/runtime/mikuproject-<version>.mjs`
+- the upstream Java CLI runtime artifact is produced by `mikuproject-java` as `target/mikuproject.jar` and should be received by `mikuproject-skills` as `skills/mikuproject/runtime/mikuproject-<version>.jar`
 
 This skill does not aim to replace the `mikuproject` browser UI. Its center is structured AI-agent operation over the upstream product's core APIs and artifacts.
 

--- a/docs/miku-soft-50-mcp-design-v20260501.md
+++ b/docs/miku-soft-50-mcp-design-v20260501.md
@@ -1,4 +1,4 @@
-# Miku Software MCP Design v20260430
+# Miku Software MCP Design v20260501
 
 This memo organizes design characteristics commonly expected for MCP server versions in the `miku` software series.
 
@@ -23,6 +23,8 @@ What characterizes MCP server versions is not a new product separate from the up
 - Use Node.js / TypeScript as the standard MCP server implementation choice
 - Use upstream public APIs, CLI, or bundled runtime artifacts rather than duplicating product logic
 - Treat the MCP server as a thin protocol adapter
+- Prefer stateless or short-lived execution over durable server-side product state
+- Treat client-provided files and data as the source of truth unless a product-specific design explicitly says otherwise
 - Keep local and server deployments aligned around the same tool contracts
 - Preserve diagnostics, warnings, and artifact roles in structured results
 
@@ -39,9 +41,9 @@ Use the shared design documents together as follows.
 
 - `docs/miku-soft-10-mainapp-design-v20260501.md`
   - describes the upstream product design and semantic center
-- `docs/miku-soft-40-agentskills-design-v20260429.md`
+- `docs/miku-soft-40-agentskills-design-v20260501.md`
   - describes how Agent Skills versions expose miku workflows to AI agents
-- `docs/miku-soft-50-mcp-design-v20260430.md`
+- `docs/miku-soft-50-mcp-design-v20260501.md`
   - describes how MCP server versions should expose miku workflows to MCP clients
 
 This document separates the following levels.
@@ -119,16 +121,26 @@ The MCP version emphasizes the parts that fit MCP operation particularly well.
 - resource links for generated artifacts
 - diagnostics and warnings as structured results
 - repeatable file-based operation
+- request-scoped or session-scoped data processing
+- command execution on behalf of the MCP client
 - stdio local server execution
 - optional HTTP server deployment when remote access is required
 
 An MCP version should not become a generic planner, generic converter, hosted replacement application, or independent semantic implementation. Its value is that MCP clients can use the upstream miku product correctly through stable tool and resource contracts.
 
+For most miku MCP servers, the default execution model is simple: the MCP client
+provides the input files, structured data, or resource references for each
+operation; the MCP server validates the request, invokes the upstream product
+API, CLI, or bundled runtime through fixed adapter code, and returns generated
+artifacts, diagnostics, summaries, or transformed data. The MCP server should
+not become the durable owner of the product data unless that responsibility is
+explicitly designed for a specific product.
+
 ## Relationship to Main Applications
 
 MCP server versions are downstream of miku main applications.
 
-The upstream main application owns the product semantics, canonical source, core conversions, output policy, and limitations. The MCP server owns protocol exposure, tool schema, resource naming, transport handling, runtime discovery, and result formatting.
+The upstream main application owns the product semantics, canonical source, core conversions, output policy, and limitations. The MCP client or calling environment usually owns the concrete input and output files for a run. The MCP server owns protocol exposure, tool schema, resource naming, transport handling, runtime discovery, command invocation, and result formatting.
 
 The preferred relationship is as follows.
 
@@ -138,6 +150,8 @@ The preferred relationship is as follows.
 - MCP server exposes reusable state and artifacts as resources
 - MCP server may expose product-specific workflow prompts
 - MCP server returns diagnostics, warnings, hard errors, and generated artifact links in a structured form
+- MCP server treats durable product data as client-owned unless a product-specific design assigns persistence to the server
+- MCP server keeps intermediate state request-scoped or session-scoped where practical
 - MCP server does not reimplement core conversion behavior unless no upstream surface exists
 
 If an upstream capability is missing, the preferred order is to request or implement the capability on the upstream side, expose it as a stable upstream API, and then let the MCP server call it. MCP servers should not silently add upstream product capabilities on the MCP side. MCP-local workaround code should be treated as temporary or product-specific, not as the new semantic center.
@@ -178,7 +192,11 @@ An MCP server usually exposes one or more of the following.
 
 The MCP server is not primarily the browser UI, not primarily a runtime port, and not primarily an Agent Skill. For miku MCP repositories, Node.js / TypeScript is the normal MCP server implementation choice. The server can call bundled or configured runtime artifacts if that is the natural way to execute the upstream product, but the MCP layer itself should remain thin.
 
-The center of an MCP server is reliable protocol adaptation: receive a typed tool call, validate arguments, call the upstream runtime, preserve useful state, expose resulting artifacts as resources, and return diagnostics without hiding important constraints.
+The center of an MCP server is reliable protocol adaptation: receive a typed
+tool call, validate arguments, call the upstream runtime, expose resulting
+artifacts as resources, and return diagnostics without hiding important
+constraints. When state is needed, prefer explicit input and output artifacts or
+short-lived session state over implicit durable server-side product state.
 
 ## Cross-Cutting Principles
 
@@ -277,6 +295,14 @@ The local stdio server should not behave like a long-running public web service.
 
 The HTTP server is a deployment variant, not the initial semantic center.
 
+For miku MCP servers, the preferred HTTP shape is an ephemeral execution
+adapter. The client remains the owner of the canonical product files and data.
+The HTTP server receives explicit inputs, uploads, or session-scoped resource
+references, runs the configured product runtime or CLI, and returns generated
+artifacts, transformed data, and diagnostics. It should not become a durable
+product database or the source of truth for current product state unless a
+product-specific design explicitly assigns that responsibility.
+
 An HTTP MCP server must define the following before it is treated as production-ready.
 
 - authentication and authorization model
@@ -291,6 +317,61 @@ An HTTP MCP server must define the following before it is treated as production-
 - user-visible confirmation policy for destructive operations when the client supports it
 
 HTTP deployment should not expose arbitrary local filesystem paths from the host. It should prefer session-scoped resource URIs, upload identifiers, or controlled workspace-relative paths.
+
+Mutation-style tools in an HTTP deployment should prefer input-to-output
+semantics: given base data and a patch, edit request, conversion request, or
+other operation input, return the updated data, diff, summary, diagnostics, and
+generated artifacts for the client to persist. Server-side product state should
+be request-scoped or session-scoped, short-lived, and safe to discard.
+
+### HTTP MVP Implementation Guidance
+
+The first `mikuproject-mcp` Streamable HTTP implementation confirmed that a miku
+MCP HTTP MVP can stay small when it follows the stateless execution-adapter
+model.
+
+Recommended first implementation shape:
+
+- keep the stdio entrypoint unchanged
+- add HTTP as a separate entrypoint, not as a replacement for stdio
+- expose a single Streamable HTTP endpoint such as `/mcp`
+- bind to `127.0.0.1` by default
+- use stateless transport unless server-to-client requests, resumability, or
+  durable per-client state is explicitly needed
+- create or reset MCP server state per request when the product operation can be
+  handled as input-to-output processing
+- do not accept client-provided host file path arguments in HTTP `tools/call`
+  when inline content or controlled resource references can represent the input
+- prefer inline JSON/text content and Base64 content for stateless HTTP calls
+- use request-scoped temporary workspaces only for adapter-internal runtime
+  files, such as materializing one inline input when an upstream CLI accepts
+  only one stdin payload for a multi-input operation
+- remove request-scoped temporary workspaces after the response completes
+- do not issue `Mcp-Session-Id` in the stateless MVP
+- validate `Origin` and reject non-local origins unless explicitly allowlisted
+- set an HTTP request body size limit before passing input to the MCP transport
+- set an HTTP response body size limit before returning large content-mode or
+  Base64 artifacts
+- keep tool names, input schemas, resource URIs, prompt names, result shapes,
+  diagnostics, and artifact roles identical to stdio
+- verify initialize, tool listing, representative tool calls, resource reads,
+  prompt listing, invalid-origin rejection, request-size rejection,
+  response-size rejection, host-path rejection, and temporary workspace cleanup
+  through an HTTP client test
+
+If a stateless HTTP profile deletes temporary workspaces immediately after each
+response, returned server-local paths are not durable artifact handles. Hosted
+profiles that need clients to retrieve generated files should add explicit
+content-return, download, or resource-retention behavior.
+
+Invalid session behavior is not applicable to a stateless MVP that does not
+issue `Mcp-Session-Id`. If a later profile enables stateful HTTP sessions,
+invalid session behavior should be designed and tested with that session model.
+
+This shape is intentionally not a hosted multi-user design. Remote deployment
+still requires the broader HTTP server principles above: authentication,
+workspace isolation, upload lifecycle, storage policy, cleanup, audit, and
+runtime isolation.
 
 ## Tool Design Principles
 
@@ -439,7 +520,11 @@ MCP servers distinguish several kinds of data.
 
 These roles should not be collapsed only because they are all represented as JSON or files.
 
-For local stdio deployment, file paths can be a practical state boundary. For HTTP deployment, session-scoped resource URIs or upload identifiers are usually safer than arbitrary host paths.
+For local stdio deployment, file paths can be a practical state boundary. For
+HTTP deployment, inline content, Base64 content, session-scoped resource URIs,
+or upload identifiers are usually safer than arbitrary host paths. Temporary
+files created from inline HTTP inputs should be treated as adapter-internal
+runtime bridges, not as durable artifacts or public resource handles.
 
 For products such as `mikuproject`, `mikuproject_workbook_json` may be the practical MCP state handoff format, while `MS Project XML` remains the product's semantic base. The MCP server should make that distinction visible in naming, docs, and tool descriptions.
 
@@ -761,4 +846,17 @@ shapes, resources, diagnostics, and local workspace behavior.
 implementation in the current Node server documentation. If a concrete future
 requirement appears, handle that implementation design at that time.
 
-If `mikuproject-mcp` later adds an HTTP server, it should keep the same core tool names. The HTTP server should add session-scoped resources, upload handling, authentication, storage policy, and artifact lifecycle management rather than changing the product operation vocabulary.
+As of 2026-05-01, `mikuproject-mcp` includes a localhost-oriented stateless
+Streamable HTTP entrypoint. It keeps the same core tool names and follows the
+general miku MCP execution model. The HTTP entrypoint is a short-lived adapter
+for client-owned project data: it accepts explicit inline workbook/WBS/patch
+inputs or Base64 content, invokes the existing `mikuproject` runtime commands,
+and returns generated artifacts, diagnostics, diffs, summaries, or updated state
+for the client to store.
+
+The current HTTP entrypoint does not issue `Mcp-Session-Id`, rejects
+client-provided host path arguments for `tools/call`, and uses request-scoped
+temporary files only as adapter-internal runtime inputs when the upstream CLI
+requires a path. A hosted or non-localhost profile remains out of scope until
+authentication, storage policy, upload handling, artifact lifecycle management,
+audit, and runtime isolation are explicitly designed.

--- a/tests/mikuproject-cli.test.js
+++ b/tests/mikuproject-cli.test.js
@@ -987,7 +987,7 @@ describe("mikuproject cli", () => {
       "mikuproject-sources/scripts/lib/core-api-loader.mjs",
       "mikuproject-sources/src/ts/core-api.ts",
       "mikuproject-sources/src/js/core-api.js",
-      "mikuproject-sources/docs/miku-soft-40-agentskills-design-v20260429.md",
+      "mikuproject-sources/docs/miku-soft-40-agentskills-design-v20260501.md",
       "mikuproject-sources/tests/mikuproject-cli.test.js"
     ]));
 


### PR DESCRIPTION
## 概要

miku software 系列の設計文書を 20260501 版へ更新し、関連する CLI バンドルテストの期待値を新しい文書パスに合わせます。

## 変更内容

- Java Application Design 文書を `v20260426` から `v20260501` に更新
  - CLI のコマンドグループ、サブコマンド、オプション名、stdin / stdout、diagnostics、usage error 境界を upstream に合わせる方針を明確化
  - binary artifact は file-based を基本とし、stream-friendly な交換には明示的な Base64 stdout option を使う方針を追記
  - `mikuproject-java` の batch command 表現を Java-side CLI extension として整理

- Agent Skills Design 文書を `v20260429` から `v20260501` に更新
  - 関連文書参照を更新
  - runtime artifact の配置例を versioned file name に変更
  - `mikuproject-skills` が受け取る Node.js / Java runtime artifact の想定パスを versioned artifact 前提に更新

- MCP Design 文書を `v20260430` から `v20260501` に更新
  - MCP server は durable server-side product state ではなく、stateless または short-lived execution を優先する方針を追加
  - client-provided files / data を source of truth として扱う方針を追加
  - HTTP server の ephemeral execution adapter model と HTTP MVP implementation guidance を追加
  - `mikuproject-mcp` の localhost-oriented stateless Streamable HTTP entrypoint に関する記述を追加
  - HTTP `tools/call` における client-provided host path rejection、request-scoped temporary files、`Mcp-Session-Id` 非発行、hosted profile の out-of-scope 条件を明記

- CLI バンドルテストの source archive 期待値を更新
  - `miku-soft-40-agentskills-design-v20260501.md` を期待するように変更

## 確認

- `npx vitest run tests/mikuproject-cli.test.js`
- `npm run build`